### PR TITLE
Updating travis build JDK to fix build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_install:
 - export PATH=$M2_HOME/bin:$PATH
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 install: /bin/true
 script: mvn clean install


### PR DESCRIPTION
 As per https://github.com/travis-ci/travis-ci/issues/7884 oraclejdk7 is no longer supported.