### PR TITLE
Introducing 'AND' Logical Operator for SCIM2 Filters in WSO2 Identity Server

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -38,6 +38,12 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.model.Condition;
+import org.wso2.carbon.user.core.model.ExpressionAttribute;
+import org.wso2.carbon.user.core.model.ExpressionCondition;
+import org.wso2.carbon.user.core.model.ExpressionOperation;
+import org.wso2.carbon.user.core.model.OperationalCondition;
+import org.wso2.carbon.user.core.model.OperationalOperation;
 import org.wso2.carbon.user.core.model.UserClaimSearchEntry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.charon3.core.attributes.Attribute;
@@ -60,6 +66,7 @@ import org.wso2.charon3.core.utils.AttributeUtil;
 import org.wso2.charon3.core.utils.ResourceManagerUtil;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.Node;
+import org.wso2.charon3.core.utils.codeutils.OperationNode;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 
 import java.util.ArrayList;
@@ -265,7 +272,7 @@ public class SCIMUserManager implements UserManager {
         if(sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported");
         } else if(rootNode != null) {
-            return filterUsers(rootNode, requiredAttributes, startIndex, count);
+            return filterUsers(rootNode, requiredAttributes, startIndex, count, sortBy, sortOrder);
         } else {
             return listUsers(requiredAttributes);
         }
@@ -446,22 +453,10 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
-    private List<Object> filterUsers(Node node, Map<String, Boolean> requiredAttributes, int offset, int limit)
+    private List<Object> filterUsers(Node node, Map<String, Boolean> requiredAttributes, int offset, int limit,
+                                     String sortBy, String sortOrder)
             throws NotImplementedException, CharonException {
 
-        if(node.getLeftNode() != null || node.getRightNode() != null){
-            String error = "Complex filters are not supported yet";
-            throw new NotImplementedException(error);
-        }
-
-        String attributeName = ((ExpressionNode)node).getAttributeValue();
-        String filterOperation = ((ExpressionNode)node).getOperation();
-        String attributeValue = ((ExpressionNode)node).getValue();
-
-        if (log.isDebugEnabled()) {
-            log.debug("Listing users by filter: " + attributeName + filterOperation +
-                    attributeValue);
-        }
         List<Object> filteredUsers = new ArrayList<>();
         //0th index is to store total number of results
         filteredUsers.add(0);
@@ -469,86 +464,88 @@ public class SCIMUserManager implements UserManager {
         ClaimMapping[] coreClaims;
         ClaimMapping[] extensionClaims = null;
 
-        User scimUser;
-        int totalUserCount;
+        int totalUserCount = 0;
         try {
             String[] userNames = null;
-            if (!SCIMConstants.UserSchemaConstants.GROUP_URI.equals(attributeName)) {
+            while (carbonUM != null) {
+                // If carbonUM is not an instance of Abstract User Store Manger we can't get the domain name.
+                if (carbonUM instanceof PaginatedUserStoreManager && carbonUM instanceof AbstractUserStoreManager) {
 
-                if (!filterOperation.equalsIgnoreCase(SCIMCommonConstants.EQ)) {
-                    String error = "Filter operator "+ filterOperation +" is not implemented non group filtering";
-                    throw new NotImplementedException(error);
+                    String domainName = carbonUM.getRealmConfiguration().getUserStoreProperty("DomainName");
+                    coreClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_CORE_CLAIM_DIALECT);
+                    userClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT);
+                    if (SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema() != null) {
+                        extensionClaims = carbonClaimManager.getAllClaimMappings(
+                                SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema().getURI());
+                    }
+                    Map<String, String> attributes = new HashMap<>();
+                    for (ClaimMapping claim : coreClaims) {
+                        attributes.put(claim.getClaim().getClaimUri(), claim.getMappedAttribute(domainName));
+                    }
+                    for (ClaimMapping claim : userClaims) {
+                        attributes.put(claim.getClaim().getClaimUri(), claim.getMappedAttribute(domainName));
+                    }
+                    if (extensionClaims != null) {
+                        for (ClaimMapping claim : extensionClaims) {
+                            attributes.put(claim.getClaim().getClaimUri(), claim.getMappedAttribute(domainName));
+                        }
+                    }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Invoking the do get user list for domain: " + domainName);
+                    }
+                    userNames = ((PaginatedUserStoreManager) carbonUM).
+                            getUserList(getCondition(node, attributes), domainName, UserCoreConstants.DEFAULT_PROFILE,
+                                    limit, offset, sortBy, sortOrder);
                 }
-                //get the user name of the user with this id
-                userNames = carbonUM.getUserList(attributeName, attributeValue, UserCoreConstants.DEFAULT_PROFILE);
-            } else {
-                if (isNotGroupFilteringSupported(filterOperation)) {
-                    String error = "Filter operator " + filterOperation + " is not implemented for group filtering";
-                    throw new NotImplementedException(error);
-                }
-
-                if (filterOperation.equalsIgnoreCase(SCIMCommonConstants.EQ)) {
-                    userNames = carbonUM.getUserListOfRole(attributeValue);
-                } else if (carbonUM instanceof AbstractUserStoreManager) {
-                    String[] roleNames = getRoleNames(filterOperation, attributeValue);
-                    userNames = getUserListOfRoles(roleNames);
+                if (userNames == null || userNames.length == 0) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Users does not exits for given multi attributes filter in the system.");
+                    }
+                    return filteredUsers;
                 } else {
-                    String error = "Filter operator " + filterOperation + " is not supported by the user store.";
-                    throw new NotImplementedException(error);
-                }
-            }
+                    totalUserCount += userNames.length;
+//                userNames = paginateUsers(userNames, limit, offset);
+                    //get claims related to SCIM claim dialect
+                    coreClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_CORE_CLAIM_DIALECT);
+                    userClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT);
+                    if (SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema() != null) {
+                        extensionClaims = carbonClaimManager.getAllClaimMappings(
+                                SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema().getURI());
+                    }
 
-            if (userNames == null || userNames.length == 0) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Users with filter: " + attributeName + filterOperation +
-                            attributeValue + " does not exist in the system.");
-                }
-                return filteredUsers;
-            } else {
-                totalUserCount = userNames.length;
-                userNames = paginateUsers(userNames, limit, offset);
-
-                //get claims related to SCIM claim dialect
-                coreClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_CORE_CLAIM_DIALECT);
-                userClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT);
-                if (SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema() != null){
-                    extensionClaims = carbonClaimManager.getAllClaimMappings(
-                            SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema().getURI());
-                }
-
-                List<String> claimURIList = new ArrayList<>();
-                for (ClaimMapping claim : coreClaims) {
-                    claimURIList.add(claim.getClaim().getClaimUri());
-                }
-                for (ClaimMapping claim : userClaims) {
-                    claimURIList.add(claim.getClaim().getClaimUri());
-                }
-                if(extensionClaims != null) {
-                    for (ClaimMapping claim : extensionClaims) {
+                    List<String> claimURIList = new ArrayList<>();
+                    for (ClaimMapping claim : coreClaims) {
                         claimURIList.add(claim.getClaim().getClaimUri());
                     }
-                }
-                List<String> requiredClaims = getOnlyRequiredClaims(claimURIList, requiredAttributes);
+                    for (ClaimMapping claim : userClaims) {
+                        claimURIList.add(claim.getClaim().getClaimUri());
+                    }
+                    if (extensionClaims != null) {
+                        for (ClaimMapping claim : extensionClaims) {
+                            claimURIList.add(claim.getClaim().getClaimUri());
+                        }
+                    }
+                    List<String> requiredClaims = getOnlyRequiredClaims(claimURIList, requiredAttributes);
 
-                User[] scimUsers;
-                if (isPaginatedUserStoreAvailable()) {
-                    if (carbonUM instanceof PaginatedUserStoreManager) {
-                        scimUsers = this.getSCIMUsers(userNames, requiredClaims);
-                        filteredUsers.addAll(Arrays.asList(scimUsers));
+                    User[] scimUsers;
+                    if (isPaginatedUserStoreAvailable()) {
+                        if (carbonUM instanceof PaginatedUserStoreManager) {
+                            scimUsers = this.getSCIMUsers(userNames, requiredClaims);
+                            filteredUsers.addAll(Arrays.asList(scimUsers));
+                        } else {
+                            addSCIMUsers(filteredUsers, userNames, requiredClaims);
+                        }
                     } else {
                         addSCIMUsers(filteredUsers, userNames, requiredClaims);
                     }
-                } else {
-                    addSCIMUsers(filteredUsers, userNames, requiredClaims);
+                    log.info("Users filtered through SCIM for the multi attributes filter. ");
                 }
-                log.info("Users filtered through SCIM for the filter: " + attributeName + filterOperation +
-                        attributeValue);
+                carbonUM = carbonUM.getSecondaryUserStoreManager();
             }
             //set the total results
             filteredUsers.set(0, totalUserCount);
         } catch (UserStoreException | CharonException e) {
-            throw new CharonException("Error in filtering users by attribute name : " + attributeName + ", " +
-                    "attribute value : " + attributeValue + " and filter operation " + filterOperation, e);
+            throw new CharonException("Error in filtering users by multi attributes ", e);
         }
         return filteredUsers;
     }
@@ -568,6 +565,52 @@ public class SCIMUserManager implements UserManager {
                 continue;
             }
             filteredUsers.add(scimUser);
+        }
+    }
+
+    private Condition getCondition(Node node, Map<String, String> attributes) throws CharonException {
+
+        if (node instanceof ExpressionNode) {
+            String operation = ((ExpressionNode) node).getOperation();
+            String attributeName = ((ExpressionNode) node).getAttributeValue();
+            String attributeValue = ((ExpressionNode) node).getValue();
+
+            String conditionOperation;
+            String conditionAttributeName;
+
+            if (SCIMCommonConstants.EQ.equals(operation)) {
+                conditionOperation = ExpressionOperation.EQ.toString();
+            } else if (SCIMCommonConstants.SW.equals(operation)) {
+                conditionOperation = ExpressionOperation.SW.toString();
+            } else if (SCIMCommonConstants.EW.equals(operation)) {
+                conditionOperation = ExpressionOperation.EW.toString();
+            } else if (SCIMCommonConstants.CO.equals(operation)) {
+                conditionOperation = ExpressionOperation.CO.toString();
+            } else {
+                conditionOperation = operation;
+            }
+
+            if (SCIMConstants.UserSchemaConstants.GROUP_URI.equals(attributeName)) {
+                conditionAttributeName = ExpressionAttribute.ROLE.toString();
+            } else if (SCIMConstants.UserSchemaConstants.USER_NAME_URI.equals(attributeName)) {
+                conditionAttributeName = ExpressionAttribute.USERNAME.toString();
+            } else if (attributes.get(attributeName) != null) {
+                conditionAttributeName = attributes.get(attributeName);
+            } else {
+                throw new CharonException("Unsupported attribute: " + attributeName);
+            }
+            return new ExpressionCondition(conditionOperation, conditionAttributeName, attributeValue);
+        } else if (node instanceof OperationNode) {
+            Condition leftCondition = getCondition(node.getLeftNode(), attributes);
+            Condition rightCondition = getCondition(node.getRightNode(), attributes);
+            String operation = ((OperationNode) node).getOperation();
+            if (OperationalOperation.AND.toString().equalsIgnoreCase(operation)) {
+                return new OperationalCondition(OperationalOperation.AND.toString(), leftCondition, rightCondition);
+            } else {
+                throw new CharonException("Unsupported Operation: " + operation);
+            }
+        } else {
+            throw new CharonException("Unsupported Operation");
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -463,8 +463,8 @@ public class SCIMUserManager implements UserManager {
         ClaimMapping[] userClaims;
         ClaimMapping[] coreClaims;
         ClaimMapping[] extensionClaims = null;
-
         int totalUserCount = 0;
+
         try {
             String[] userNames = null;
             while (carbonUM != null) {
@@ -497,6 +497,7 @@ public class SCIMUserManager implements UserManager {
                             getUserList(getCondition(node, attributes), domainName, UserCoreConstants.DEFAULT_PROFILE,
                                     limit, offset, sortBy, sortOrder);
                 }
+
                 if (userNames == null || userNames.length == 0) {
                     if (log.isDebugEnabled()) {
                         log.debug("Users does not exits for given multi attributes filter in the system.");
@@ -505,6 +506,7 @@ public class SCIMUserManager implements UserManager {
                 } else {
                     totalUserCount += userNames.length;
 //                userNames = paginateUsers(userNames, limit, offset);
+
                     //get claims related to SCIM claim dialect
                     coreClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_CORE_CLAIM_DIALECT);
                     userClaims = carbonClaimManager.getAllClaimMappings(SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT);
@@ -538,7 +540,6 @@ public class SCIMUserManager implements UserManager {
                     } else {
                         addSCIMUsers(filteredUsers, userNames, requiredClaims);
                     }
-                    log.info("Users filtered through SCIM for the multi attributes filter. ");
                 }
                 carbonUM = carbonUM.getSecondaryUserStoreManager();
             }


### PR DESCRIPTION
Introducing logical operators for SCIM2 filters in WSO2 Identity Server. Here we going to support 'AND' logical operator for following SCIM2 filters such as eq, sw, ew, co. The user can query user details using multi-attribute search filters. 
For further details,
[https://docs.google.com/document/d/1rsJgQ7g8dAJL0pW1biLe6iRXHbZKmJsTCEJncVHJ5hQ/edit?usp=sharing](url)