### PR TITLE
Introducing 'AND' logical operators for multi attribute user filtering with pagination

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -509,9 +509,8 @@ public class SCIMUserManager implements UserManager {
 
         } else if (node instanceof OperationNode) {
             // Support multi attribute filtering.
-            List<Object> xx = getMultiAttributeFilteredUsers(node, requiredAttributes, offset, limit, sortBy, sortOrder,
+            return getMultiAttributeFilteredUsers(node, requiredAttributes, offset, limit, sortBy, sortOrder,
                     domainName, filteredUsers);
-            return xx;
         } else {
             throw new CharonException("Unsupported Operation");
         }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -621,7 +621,8 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
-    private List<Object> getFilteredUserDetails(String[] userNames, Map<String, Boolean> requiredAttributes) throws CharonException {
+    private List<Object> getFilteredUserDetails(String[] userNames, Map<String, Boolean> requiredAttributes)
+            throws CharonException {
 
         List<Object> filteredUsers = new ArrayList<>();
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -294,7 +294,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockIdentityUtil.extractDomainFromName(anyString())).thenReturn("value");
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
         List<Object> roleList = scimUserManager.listGroupsWithGET(node, 1, 1, null, null,
-                requiredAttributes);
+                null, requiredAttributes);
 
         assertEquals(roleList.size(), 2);
 

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
@@ -186,6 +186,7 @@ public class GroupResource extends AbstractResource {
         requestAttributes.put(SCIMProviderConstants.COUNT, count);
         requestAttributes.put(SCIMProviderConstants.SORT_BY, sortBy);
         requestAttributes.put(SCIMProviderConstants.SORT_ORDER, sortOrder);
+        requestAttributes.put(SCIMProviderConstants.DOMAIN, domainName);
         requestAttributes.put(SCIMProviderConstants.SEARCH, "0");
         return processRequest(requestAttributes);
     }
@@ -338,9 +339,10 @@ public class GroupResource extends AbstractResource {
 
                 String sortBy = requestAttributes.get(SCIMProviderConstants.SORT_BY);
                 String sortOrder = requestAttributes.get(SCIMProviderConstants.SORT_ORDER);
+                String domainName = requestAttributes.get(SCIMProviderConstants.DOMAIN);
 
                 scimResponse = groupResourceManager.listWithGET(userManager, filter, startIndex,
-                        count, sortBy, sortOrder, attributes, excludedAttributes);
+                        count, sortBy, sortOrder, domainName, attributes, excludedAttributes);
 
             } else if (GET.class.getSimpleName().equals(httpVerb)) {
                 scimResponse = groupResourceManager.get(id, userManager, attributes, excludedAttributes);

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
@@ -163,7 +163,8 @@ public class GroupResource extends AbstractResource {
                              @QueryParam(SCIMProviderConstants.START_INDEX) String startIndex,
                              @QueryParam(SCIMProviderConstants.COUNT) String count,
                              @QueryParam(SCIMProviderConstants.SORT_BY) String sortBy,
-                             @QueryParam(SCIMProviderConstants.SORT_ORDER) String sortOrder) {
+                             @QueryParam(SCIMProviderConstants.SORT_ORDER) String sortOrder,
+                             @QueryParam(SCIMProviderConstants.DOMAIN) String domainName) {
 
         String userName = SupportUtils.getAuthenticatedUsername();
         try {

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -205,7 +205,7 @@ public class UserResource extends AbstractResource {
             SCIMResponse scimResponse = null;
 
             scimResponse = userResourceManager.listWithGET(userManager, filter, startIndex, count,
-                    sortBy, sortOrder, attribute, excludedAttributes);
+                    sortBy, sortOrder, domainName, attribute, excludedAttributes);
 
             return SupportUtils.buildResponse(scimResponse);
         } catch (CharonException e) {

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -178,7 +178,8 @@ public class UserResource extends AbstractResource {
                             @QueryParam (SCIMProviderConstants.START_INDEX) int startIndex,
                             @QueryParam (SCIMProviderConstants.COUNT) int count,
                             @QueryParam (SCIMProviderConstants.SORT_BY) String sortBy,
-                            @QueryParam (SCIMProviderConstants.SORT_ORDER) String sortOrder) {
+                            @QueryParam (SCIMProviderConstants.SORT_ORDER) String sortOrder,
+                            @QueryParam (SCIMProviderConstants.DOMAIN) String domainName) {
 
         JSONEncoder encoder = null;
         try {

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/util/SCIMProviderConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/util/SCIMProviderConstants.java
@@ -33,6 +33,7 @@ public class SCIMProviderConstants {
     public static final String APPLICATION__JSON = "application/json";
     public static final String ACCEPT_HEADER = "Accept";
     public static final String ID = "id";
+    public static final String DOMAIN = "domain";
 
     public static final String RESOURCE_STRING = "RESOURCE_STRING";
     public static final String HTTP_VERB = "HTTP_VERB";

--- a/pom.xml
+++ b/pom.xml
@@ -277,11 +277,11 @@
         <cxf-bundle.wso2.version>2.7.16.wso2v1</cxf-bundle.wso2.version>
         <inbound.auth.oauth.version>5.2.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.4.31</carbon.kernel.version>
+        <carbon.kernel.version>4.4.34</carbon.kernel.version>
         <identity.framework.version>5.6.15</identity.framework.version>
         <junit.version>4.11</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
-        <charon.version>3.0.17</charon.version>
+        <charon.version>3.0.25</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
Introducing logical operators for SCIM2 filters with pagination. Here we going to support 'AND' logical operator for following SCIM2 filters such as eq, sw, ew, co. The user can query user details using multi-attribute search filters.
Also, support pagination within a particular user store, where the end user can specify which user store he/she wants to perform the paginated search. Otherwise, perform the paginated search on PRIMARY user store.
If the end user didn't specify pagination, then perform filtering on all available user stores and retrieve.
For further details,
[https://docs.google.com/document/d/1rsJgQ7g8dAJL0pW1biLe6iRXHbZKmJsTCEJncVHJ5hQ/edit?usp=sharing](url)