### PR TITLE
change EnterpriseUser scim property to match its schema URN.  resolves product-is 3487

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -166,7 +166,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
-"attributeName":"EnterpriseUser",
+"attributeName":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "dataType":"complex",
 "multiValued":"false",
 "description":"Enterprise User",


### PR DESCRIPTION
from [product-is 3487](https://github.com/wso2/product-is/issues/3487):

Currently, the `EnterpriseUser` key is used in SCIM user creation to specify the properties of a user specified in `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`.

Per [RFC 7643 section 3.3](https://tools.ietf.org/html/rfc7643#section-3.3), "Except for the base object schema, the schema extension URI SHALL be used as a JSON container to distinguish attributes belonging to the extension namespace from base schema attributes.".  See also the example User JSON in [section 8.3](https://tools.ietf.org/html/rfc7643#section-8.3).

I've set this pull request against master (2.x) because it is a breaking change from the current implementation