### PR TITLE
Fix inconsistency in SCIM2 group's displayName attribute format when filtering via different endpoints

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -464,6 +464,16 @@ public class SCIMUserManager implements UserManager {
                 throw new NotImplementedException(error);
             }
 
+            if (SCIMCommonUtils.isFilteringEnhancementsEnabled()) {
+                if (SCIMCommonConstants.EQ.equalsIgnoreCase(filterOperation)) {
+                    if (StringUtils.equals(attributeName, SCIMConstants.UserSchemaConstants.USER_NAME_URI) &&
+                            !StringUtils.contains(attributeValue, CarbonConstants.DOMAIN_SEPARATOR)) {
+                        attributeValue = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME +
+                                CarbonConstants.DOMAIN_SEPARATOR + attributeValue;
+                    }
+                }
+            }
+
             if (!SCIMConstants.UserSchemaConstants.GROUP_URI.equals(attributeName)) {
                 //get the user name of the user with this id
                 userNames = getUserNames(attributeName, filterOperation, attributeValue);
@@ -863,6 +873,16 @@ public class SCIMUserManager implements UserManager {
             throw new NotImplementedException(error);
         }
 
+        if (SCIMCommonUtils.isFilteringEnhancementsEnabled()) {
+            if (SCIMCommonConstants.EQ.equalsIgnoreCase(filterOperation)) {
+                if (StringUtils.equals(attributeName, SCIMConstants.GroupSchemaConstants.DISPLAY_NAME_URI) &&
+                        !StringUtils.contains(attributeValue, CarbonConstants.DOMAIN_SEPARATOR)) {
+                    attributeValue = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME +
+                            CarbonConstants.DOMAIN_SEPARATOR + attributeValue;
+                }
+            }
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("Listing groups with filter: " + attributeName + filterOperation +
                     attributeValue);
@@ -1152,7 +1172,6 @@ public class SCIMUserManager implements UserManager {
             //add groups of user:
             for (String role : roles) {
                 if (UserCoreUtil.isEveryoneRole(role, carbonUM.getRealmConfiguration())
-                        || UserCoreUtil.isPrimaryAdminRole(role, carbonUM.getRealmConfiguration())
                         || CarbonConstants.REGISTRY_ANONNYMOUS_ROLE_NAME.equalsIgnoreCase(role)
                         || role.toLowerCase().startsWith((UserCoreConstants.INTERNAL_DOMAIN +
                         CarbonConstants.DOMAIN_SEPARATOR).toLowerCase())) {
@@ -1160,6 +1179,12 @@ public class SCIMUserManager implements UserManager {
                     // skipping them.
                     // skip intenal roles
                     continue;
+                }
+
+                if (SCIMCommonUtils.isFilteringEnhancementsEnabled()) {
+                    if (!StringUtils.contains(role, CarbonConstants.DOMAIN_SEPARATOR)) {
+                        role = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME + CarbonConstants.DOMAIN_SEPARATOR + role;
+                    }
                 }
 
                 Group group = groupMetaAttributesCache.get(role);
@@ -1249,7 +1274,6 @@ public class SCIMUserManager implements UserManager {
                 //add groups of user
                 for (String role : roles) {
                     if (UserCoreUtil.isEveryoneRole(role, carbonUM.getRealmConfiguration())
-                            || UserCoreUtil.isPrimaryAdminRole(role, carbonUM.getRealmConfiguration())
                             || CarbonConstants.REGISTRY_ANONNYMOUS_ROLE_NAME.equalsIgnoreCase(role)
                             || role.toLowerCase().startsWith((UserCoreConstants.INTERNAL_DOMAIN +
                             CarbonConstants.DOMAIN_SEPARATOR).toLowerCase())) {
@@ -1257,6 +1281,12 @@ public class SCIMUserManager implements UserManager {
                         // skipping them.
                         // skip internal roles
                         continue;
+                    }
+
+                    if (SCIMCommonUtils.isFilteringEnhancementsEnabled()) {
+                        if (!StringUtils.contains(role, CarbonConstants.DOMAIN_SEPARATOR)) {
+                            role = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME + CarbonConstants.DOMAIN_SEPARATOR + role;
+                        }
                     }
 
                     Group group = groupMetaAttributesCache.get(role);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -69,6 +69,7 @@ public class SCIMCommonConstants {
     // Identity recovery claims
     public static final String ASK_PASSWORD_CLAIM = "http://wso2.org/claims/identity/askPassword";
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
+    public static final String SCIM_ENABLE_FILTERING_ENHANCEMENTS = "SCIM2.EnableFilteringEnhancements";
 
 }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -291,4 +291,17 @@ public class SCIMCommonUtils {
         }
         return tenantDomain;
     }
+
+    /**
+     * Checks whether the identity.xml config is available for applying filtering enhancements. This makes sure that Eq
+     * should strictly check for the String match (in this case cross user store search should not be performed).
+     * This config also enforces consistency on the filtered attribute formats in the response.
+     *
+     * @return whether 'EnableFilteringEnhancements' property is enabled in identity.xml.
+     */
+    public static boolean isFilteringEnhancementsEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty
+                (SCIMCommonConstants.SCIM_ENABLE_FILTERING_ENHANCEMENTS));
+    }
 }


### PR DESCRIPTION
This PR addresses the following issues.

* https://github.com/wso2/product-is/issues/4175: Inconsistency in SCIM2 group's displayName attribute format when filtering via different endpoints
* https://github.com/wso2/product-is/issues/3973: Eq should strictly check for the String match (in this case cross user store search should not be performed)

In order to maintain the backward compatibility, this functionality is enabled with following configuration.
`	<EnableFilteringEnhancements>true</EnableFilteringEnhancements> `
