### PR TITLE
Fixed the issue Filter user by email address returns duplicate results 4181

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -530,6 +530,9 @@ public class SCIMUserManager implements UserManager {
             }
 
             userNames = paginateUsers(userNames, limit, offset);
+            //remove duplicated username entries
+            HashSet<String> userNamesSet = new HashSet<String>(Arrays.asList(userNames));
+            userNames = userNamesSet.toArray(new String[userNamesSet.size()]);
             filteredUsers.set(0, userNames.length);
             filteredUsers.addAll(getFilteredUserDetails(userNames, requiredAttributes));
             return filteredUsers;


### PR DESCRIPTION
**Description**
SCIMUserManager has the userNames array. Removed the duplicated username in the method filterUsers using a if condition

Product IS uses the identity-inbound-provisioning-scim2 v1.2.12

Resolved the issue [4181](https://github.com/wso2/product-is/issues/4181)