### PR TITLE
Fix #5088:SCIM2 user listing with an offset for a secondary user store is not working properly

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -360,8 +360,9 @@ public class SCIMUserManager implements UserManager {
                 log.debug(message);
             }
         } else {
-            users.set(0, userNames.length); // Set total number of results to 0th index.
-            users.addAll(getUserDetails(userNames, requiredAttributes)); // Set user details from index 1.
+            List<Object> scimUsers = getUserDetails(userNames, requiredAttributes);
+            users.set(0, scimUsers.size()); // Set total number of results to 0th index.
+            users.addAll(scimUsers); // Set user details from index 1.
         }
         return users;
     }
@@ -2055,6 +2056,10 @@ public class SCIMUserManager implements UserManager {
             Map<String, String> attributes = SCIMCommonUtils.convertLocalToSCIMDialect(userClaimValues,
                     scimToLocalClaimsMap);
 
+            if (!attributes.containsKey(SCIMConstants.CommonSchemaConstants.ID_URI)) {
+                return scimUser;
+            }
+
             //skip simple type addresses claim because it is complex with sub types in the schema
             if (attributes.containsKey(SCIMConstants.UserSchemaConstants.ADDRESSES_URI)) {
                 attributes.remove(SCIMConstants.UserSchemaConstants.ADDRESSES_URI);
@@ -2153,6 +2158,9 @@ public class SCIMUserManager implements UserManager {
                 }
 
                 try {
+                    if (!attributes.containsKey(SCIMConstants.CommonSchemaConstants.ID_URI)) {
+                        continue;
+                    }
                     //skip simple type addresses claim because it is complex with sub types in the schema
                     if (attributes.containsKey(SCIMConstants.UserSchemaConstants.ADDRESSES_URI)) {
                         attributes.remove(SCIMConstants.UserSchemaConstants.ADDRESSES_URI);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -190,6 +190,10 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.extractDomainFromName(anyString())).thenReturn("testPrimaryDomain");
 
+        mockStatic(SCIMCommonUtils.class);
+        when(SCIMCommonUtils.convertLocalToSCIMDialect(anyMap(), anyMap())).thenReturn(new HashMap<String, String>() {{
+            put(SCIMConstants.CommonSchemaConstants.ID_URI, "1f70378a-69bb-49cf-aa51-a0493c09110c"); }});
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
         when(mockedUserStoreManager.getRoleListOfUser(anyString())).thenReturn(userRoles);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -59,7 +59,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyMap;
@@ -324,6 +323,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         mockStatic(SCIMCommonUtils.class);
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimMap);
+        when(SCIMCommonUtils.convertLocalToSCIMDialect(anyMap(), anyMap())).thenReturn(new HashMap<String, String>() {{
+            put(SCIMConstants.CommonSchemaConstants.ID_URI, "1f70378a-69bb-49cf-aa51-a0493c09110c"); }});
 
         when(mockedUserStoreManager.getUserList("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getRoleListOfUser(anyString())).thenReturn(new String[0]);
@@ -341,7 +342,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         requiredClaimsMap.put("urn:ietf:params:scim:schemas:core:2.0:User:userName", false);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
         List<Object> result = scimUserManager.listUsersWithGET(null, 1, 0, null, null, requiredClaimsMap);
-        assertTrue(result.size() == expectedResultCount);
+        assertEquals(result.size(), expectedResultCount);
     }
 
     @DataProvider(name = "listUser")


### PR DESCRIPTION
- Fix wso2/product-is#5088
The issue was caused by non-scim users user being added to the result set. Since they don't have a scim id it returns "invalidValue","detail":"Required attribute id is missing in the SCIM Object." response.