### PR TITLE
FIX user specifying count zero

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -175,8 +175,8 @@ public class UserResource extends AbstractResource {
                             @QueryParam (SCIMProviderConstants.ATTRIBUTES) String attribute,
                             @QueryParam (SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String excludedAttributes,
                             @QueryParam (SCIMProviderConstants.FILTER) String filter,
-                            @QueryParam (SCIMProviderConstants.START_INDEX) int startIndex,
-                            @QueryParam (SCIMProviderConstants.COUNT) int count,
+                            @QueryParam (SCIMProviderConstants.START_INDEX) Integer startIndex,
+                            @QueryParam (SCIMProviderConstants.COUNT) Integer count,
                             @QueryParam (SCIMProviderConstants.SORT_BY) String sortBy,
                             @QueryParam (SCIMProviderConstants.SORT_ORDER) String sortOrder,
                             @QueryParam (SCIMProviderConstants.DOMAIN) String domainName) {
@@ -202,7 +202,7 @@ public class UserResource extends AbstractResource {
             // create charon-SCIM user resource manager and hand-over the request.
             UserResourceManager userResourceManager = new UserResourceManager();
 
-            SCIMResponse scimResponse = null;
+            SCIMResponse scimResponse;
 
             scimResponse = userResourceManager.listWithGET(userManager, filter, startIndex, count,
                     sortBy, sortOrder, domainName, attribute, excludedAttributes);

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <identity.framework.version>5.6.15</identity.framework.version>
         <junit.version>4.11</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
-        <charon.version>3.1.20</charon.version>
+        <charon.version>3.1.21</charon.version>
         <identity.governance.version>1.1.37</identity.governance.version>
 
         <!--Maven Plugin Version-->


### PR DESCRIPTION
- FIX [wso2_product_is#5106](https://github.com/wso2/product-is/issues/5106)
- Previously int variables were used to hold values for count and startIndex. Therefore, variables could not hold Null state values.
 - In the fix Count and startIndex variables were set as Integer objects so that they can hold Null state values.
- A new method was declared to process the count and startIndex params in the groups endpoint.