### PR TITLE
Fix for Remove Duplicate Members From the Patched Group

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2238,9 +2238,16 @@ public class SCIMUserManager implements UserManager {
 
             if (updated) {
                 log.info("Group: " + oldGroup.getDisplayName() + " is updated through SCIM.");
+                // In case the duplicate existing in the newGroup, query the corresponding group
+                // again and return it.
+                Group newUpdatedGroup = getGroup(newGroup.getId(), requiredAttributes);
+                return newUpdatedGroup;
             } else {
                 log.warn("There is no updated field in the group: " + oldGroup.getDisplayName() +
                         ". Therefore ignoring the provisioning.");
+                // Hence no changes were done, return original group. There are some cases, new group can have
+                // duplicated members.
+                return oldGroup;
             }
 
         } catch (UserStoreException | IdentitySCIMException e) {
@@ -2251,8 +2258,6 @@ public class SCIMUserManager implements UserManager {
             throw new CharonException("Error in updating the group", e);
 
         }
-
-        return newGroup;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2238,8 +2238,7 @@ public class SCIMUserManager implements UserManager {
 
             if (updated) {
                 log.info("Group: " + oldGroup.getDisplayName() + " is updated through SCIM.");
-                // In case the duplicate existing in the newGroup, query the corresponding group
-                // again and return it.
+                // Duplicate may exist in newGroup, to make sure, query the corresponding group again and return it.
                 Group newUpdatedGroup = getGroup(newGroup.getId(), requiredAttributes);
                 return newUpdatedGroup;
             } else {


### PR DESCRIPTION
Fix: wso2/product-is#5333
Approach

- The UpdateGroup method, validates whether there has been an update or not and populate variable `updated`.
- When we try to add duplicate member to an existing group, in the previous case `newGroup` was returned. The issue is, in newGroup there can be duplicate entries even though `updated` param is set to `false`.
- This `update` var will be `True` only if there is a change. Therefore the value will be `false` for duplicate entries.
- In this approach, if the updated param is `false`, `oldGroup` is returned because there are no duplicate entries and vise versa.
- In this approach, if the updated param is `true`, we'll query again and return the updated group.