### PR TITLE
fix regression to manage schema extensions

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
@@ -596,7 +596,7 @@ public class AttributeMapper {
         String subAttributeURI = attributeEntry.getKey().replace("." + attributeNames[2],"");
         AttributeSchema subAttributeSchema = getAttributeSchema(subAttributeURI, scimObjectType);
 
-        String parentAttributeURI = subAttributeURI.replace("."+ attributeNames[1],"");
+        String parentAttributeURI = subAttributeURI.replace(":"+ attributeNames[1],"");
         AttributeSchema attributeSchema = getAttributeSchema(parentAttributeURI, scimObjectType);
 
                 /*differentiate between sub attribute of Complex attribute and a Multivalued attribute


### PR DESCRIPTION
## Purpose
A change has been done in WSO2 IS 5.8.0 to be compliant with SCIM 2 specification regarding urn:ietf:params:scim:schemas:extension:enterprise:2.0:User. 

attributeName "EnterpriseUser" has been renamed to "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"

But the underlying code is not compatible with this change. AttributeName is not split well. A regression has been introduced in commit b29a2b8e5b2f98aa7d03396c4ab519123d9c7e32 for GET operations.

## Goals
This fix change the parsing code of AttributeName to manage this use case.

## Approach
Revert the change

## User stories
N/A

## Release note
Fix AttributeName splitting when performing GET on a user with  urn:ietf:params:scim:schemas:extension:enterprise:2.0:User attributes.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
`curl -v -k --user admin:admin https://localhost:9443/scim2/Users/673b0308-1473-4590-b1cd-dbfce642caa3
`
response before the fix (see manager):
`{meta":{"created":"2019-07-18T14:34:52Z","lastModified":"2019-07-19T07:27:08.495Z"},"schemas":["urn:ietf:params:scim:schemas:core:2.0:User","urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],"roles":[{"type":"default","value":"Internal/everyone,admin"}],"manager":{"manager":{"name":"test"}},"groups":[{"display":"admin","value":"9d718f3e-fbea-4cf4-b638-95623424ed0e"}],"id":"673b0308-1473-4590-b1cd-dbfce642caa3","userName":"admin"}`

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0, WSO2 IS 5.8.0
 
## Learning
N/A