### PR TITLE
Support hybrid role listing & filtering with domain parameter for SCIM

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1890,9 +1890,16 @@ public class SCIMUserManager implements UserManager {
             // If the domain is specified create a attribute value with the domain name.
             String searchValue = domainName + CarbonConstants.DOMAIN_SEPARATOR + SCIMCommonConstants.ANY;
 
-            // Retrieve roles using the above attribute value.
-            List<String> roleList = Arrays.asList(((AbstractUserStoreManager) carbonUM)
-                    .getRoleNames(searchValue, MAX_ITEM_LIMIT_UNLIMITED, true, true, true));
+            List<String> roleList;
+            // Retrieve roles using the above search value.
+            if (isInternalOrApplicationGroup(domainName)) {
+                // Support for hybrid roles listing with domain parameter. ex: domain=Application.
+                roleList = Arrays.asList(filterHybridRoles(domainName, searchValue));
+            } else {
+                // Retrieve roles using the above attribute value.
+                roleList = Arrays.asList(((AbstractUserStoreManager) carbonUM)
+                        .getRoleNames(searchValue, MAX_ITEM_LIMIT_UNLIMITED, true, true, true));
+            }
             Set<String> roleNames = new HashSet<>(roleList);
             return roleNames;
         }
@@ -2076,7 +2083,12 @@ public class SCIMUserManager implements UserManager {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Attribute value: %s is embedded with a domain.", attributeValue));
                 }
-                extractedDomain = contentInAttributeValue[0].toUpperCase();
+                String domainInAttributeValue = contentInAttributeValue[0];
+                if (isInternalOrApplicationGroup(domainInAttributeValue)) {
+                    extractedDomain = domainInAttributeValue;
+                } else {
+                    extractedDomain = domainInAttributeValue.toUpperCase();
+                }
 
                 // Check whether the domain name is equal to the extracted domain name from attribute value.
                 if (StringUtils.isNotEmpty(domainName) && StringUtils.isNotEmpty(extractedDomain) && !extractedDomain
@@ -2937,8 +2949,18 @@ public class SCIMUserManager implements UserManager {
         if (log.isDebugEnabled()) {
             log.debug(String.format("Filtering roleNames from search attribute: %s", searchAttribute));
         }
-        return ((AbstractUserStoreManager) carbonUM)
-                .getRoleNames(searchAttribute, MAX_ITEM_LIMIT_UNLIMITED, true, true, true);
+        String domain = SCIMCommonUtils.extractDomain(attributeValue);
+        // Extract domain from attribute value.
+        if (isInternalOrApplicationGroup(domain)) {
+            return filterHybridRoles(domain, searchAttribute);
+        } else if (StringUtils.isEmpty(domain)) {
+            // When domain is empty filter through all the domains.
+            return ((AbstractUserStoreManager) carbonUM)
+                    .getRoleNames(searchAttribute, MAX_ITEM_LIMIT_UNLIMITED, false, true, true);
+        } else {
+            return ((AbstractUserStoreManager) carbonUM)
+                    .getRoleNames(searchAttribute, MAX_ITEM_LIMIT_UNLIMITED, true, true, true);
+        }
     }
 
     /**
@@ -3154,5 +3176,33 @@ public class SCIMUserManager implements UserManager {
         // Update user claims.
         userClaimsToBeModified.putAll(userClaimsToBeAdded);
         carbonUM.setUserClaimValues(user.getUserName(), userClaimsToBeModified, null);
+    }
+
+    /**
+     * Method to filter hybrid roles (Application & Internal) from a search value.
+     *
+     * @param domainInAttributeValue domain of the hybrid role
+     * @param searchAttribute        search value
+     * @return Array of filtered hybrid roles.
+     * @throws org.wso2.carbon.user.core.UserStoreException
+     */
+    private String[] filterHybridRoles(String domainInAttributeValue, String searchAttribute)
+            throws org.wso2.carbon.user.core.UserStoreException {
+
+        List<String> roleList = new ArrayList<>();
+        // Get filtered hybrid roles by passing noInternalRoles=false.
+        String[] hybridRoles = ((AbstractUserStoreManager) carbonUM)
+                .getRoleNames(searchAttribute, MAX_ITEM_LIMIT_UNLIMITED, false, true, true);
+        // Iterate through received hybrid roles and filter out specific hybrid role domain(Application or Internal) values
+        for (String hybridRole : hybridRoles) {
+            if (domainInAttributeValue != null && !hybridRole.startsWith(domainInAttributeValue)) {
+                continue;
+            }
+            if (hybridRole.toLowerCase().startsWith(SCIMCommonConstants.INTERNAL_DOMAIN.toLowerCase()) || hybridRole
+                    .toLowerCase().startsWith(SCIMCommonConstants.APPLICATION_DOMAIN.toLowerCase())) {
+                roleList.add(hybridRole);
+            }
+        }
+        return roleList.toArray(new String[roleList.size()]);
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -369,4 +369,20 @@ public class SCIMCommonUtils {
             return UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME + CarbonConstants.DOMAIN_SEPARATOR + value;
         }
     }
+
+    /**
+     * Method to extract domain name from the input value passed in to this method.
+     *
+     * @param nameWithDomain string which contains domain name
+     * @return extracted domain value or empty string if no domain.
+     */
+    public static String extractDomain(String nameWithDomain) {
+
+        if (nameWithDomain != null && nameWithDomain.indexOf("/") > 0) {
+            String domain = nameWithDomain.substring(0, nameWithDomain.indexOf("/"));
+            return domain;
+        } else {
+            return null;
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -378,8 +378,8 @@ public class SCIMCommonUtils {
      */
     public static String extractDomain(String nameWithDomain) {
 
-        if (nameWithDomain != null && nameWithDomain.indexOf("/") > 0) {
-            String domain = nameWithDomain.substring(0, nameWithDomain.indexOf("/"));
+        if (nameWithDomain != null && nameWithDomain.indexOf(CarbonConstants.DOMAIN_SEPARATOR) > 0) {
+            String domain = nameWithDomain.substring(0, nameWithDomain.indexOf(CarbonConstants.DOMAIN_SEPARATOR));
             return domain;
         } else {
             return null;


### PR DESCRIPTION
Resolves wso2/product-is#5954

In this PR it supports hybrid roles (Application &Internal) listing and filtering.
Listing can be done using a new 'domain' query param.
Filtering can be done in 2 ways.
1.using 'domain' query param
2.using '{domain}/' prefix

Example listing request:
curl -v -k --user admin:admin 'https://localhost:9443/scim2/Groups?domain=Application'

Example filtering request with domain parameter:
curl -v -k --user admin:admin 'https://localhost:9443/scim2/Groups?filter=displayName+eq+Apple&domain=Internal'

Example filtering request with domain prefix:
curl -v -k --user admin:admin 'https://localhost:9443/scim2/Groups?filter=displayName+sw+Application/App'