### PR TITLE
Use the local mapped claim of the lastModified

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -172,8 +172,9 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         }
 
         String lastModifiedDate = AttributeUtil.formatDateTime(Instant.now());
-        claims.put(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI, lastModifiedDate);
-
+        Map<String, String> scimToLocalMappings = SCIMCommonUtils.getSCIMtoLocalMappings();
+        String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI);
+        claims.put(modifiedLocalClaimUri, lastModifiedDate);
         return true;
     }
 


### PR DESCRIPTION
During the add user event, we add the mapped local claim in the listener
https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/blob/c695cb6ac05376678f10367d36faa5bf5c866227/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java#L410

But in the doPreSetUserClaimValues, we have added the 'lastModified' SCIM claim, which causes the https://github.com/wso2/product-is/issues/6003 during updating the user profile when the 'lastModified' is mapped to an identity claim

(fix https://github.com/wso2/product-is/issues/6003)