### PR TITLE
Add scim user schema endpoint impl

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -159,8 +159,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
@@ -112,12 +112,9 @@ public class IdentitySCIMManager {
                 int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
                 //get tenant's user realm
                 UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
-                ClaimManager claimManager;
                 if (userRealm != null) {
-                    //get claim manager for manipulating attributes
-                    claimManager = (ClaimManager) userRealm.getClaimManager();
                     scimUserManager = new SCIMUserManager((UserStoreManager) userRealm.getUserStoreManager(),
-                            claimManager);
+                            SCIMCommonComponentHolder.getClaimManagementService(), tenantDomain);
                 }
             } else {
                 String error = "Can not obtain carbon realm service..";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
@@ -57,7 +58,9 @@ import org.wso2.carbon.user.core.model.OperationalOperation;
 import org.wso2.carbon.user.core.model.UserClaimSearchEntry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.RolePermissionException;
+import org.wso2.charon3.core.attributes.AbstractAttribute;
 import org.wso2.charon3.core.attributes.Attribute;
+import org.wso2.charon3.core.attributes.ComplexAttribute;
 import org.wso2.charon3.core.attributes.MultiValuedAttribute;
 import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.config.SCIMUserSchemaExtensionBuilder;
@@ -71,6 +74,7 @@ import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.SCIMConstants;
+import org.wso2.charon3.core.schema.SCIMDefinitions;
 import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 import org.wso2.charon3.core.utils.AttributeUtil;
@@ -111,6 +115,11 @@ public class SCIMUserManager implements UserManager {
     private ClaimMetadataManagementService claimMetadataManagementService = null;
     private static final int MAX_ITEM_LIMIT_UNLIMITED = -1;
     private static final String ENABLE_PAGINATED_USER_STORE = "SCIM.EnablePaginatedUserStore";
+
+    // Additional wso2 user schema properties.
+    private static final String DISPLAY_NAME_PROPERTY = "displayName";
+    private static final String DISPLAY_ORDER_PROPERTY = "displayOrder";
+    private static final String REGULAR_EXPRESSION_PROPERTY = "regEx";
 
     @Deprecated
     public SCIMUserManager(UserStoreManager carbonUserStoreManager, ClaimManager claimManager) {
@@ -3424,4 +3433,282 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
+    @Override
+    public List<Attribute> getUserSchema() throws CharonException {
+
+        Map<ExternalClaim, LocalClaim> scimClaimToLocalClaimMap =
+                getMappedLocalClaimsForDialect(SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT, tenantDomain);
+
+        Map<String, Attribute> filteredFlatAttributeMap = getFilteredUserSchemaAttributes(scimClaimToLocalClaimMap);
+        Map<String, Attribute> hierarchicalAttributeMap = buildHierarchicalAttributeMap(filteredFlatAttributeMap);
+
+        List<Attribute> userSchemaAttributesList = new ArrayList(hierarchicalAttributeMap.values());
+        if (log.isDebugEnabled()) {
+            logSchemaAttributes(userSchemaAttributesList);
+        }
+
+        return userSchemaAttributesList;
+    }
+
+    /**
+     * Get mapped local claims for the claims in specified external claim dialect.
+     *
+     * @param externalClaimDialect
+     * @param tenantDomain
+     * @return
+     * @throws ClaimMetadataException
+     */
+    private Map<ExternalClaim, LocalClaim> getMappedLocalClaimsForDialect(String externalClaimDialect,
+                                                                          String tenantDomain) throws CharonException {
+
+        try {
+            Map<ExternalClaim, LocalClaim> externalClaimLocalClaimMap = new HashMap<>();
+            List<ExternalClaim> externalClaimList =
+                    this.claimMetadataManagementService.getExternalClaims(externalClaimDialect, tenantDomain);
+            List<LocalClaim> localClaimList = this.claimMetadataManagementService.getLocalClaims(tenantDomain);
+
+            if (externalClaimList != null && localClaimList != null) {
+
+                for (ExternalClaim externalClaim : externalClaimList) {
+                    LocalClaim mappedLocalClaim = getMappedLocalClaim(externalClaim, localClaimList);
+                    externalClaimLocalClaimMap.put(externalClaim, mappedLocalClaim);
+                }
+            }
+            return externalClaimLocalClaimMap;
+
+        } catch (ClaimMetadataException e) {
+            throw new CharonException("Error while retrieving schema attribute details.", e);
+        }
+    }
+
+    /**
+     * Get mapped local claim for specified external claim.
+     *
+     * @param externalClaim
+     * @param localClaimList
+     * @return
+     */
+    private LocalClaim getMappedLocalClaim(ExternalClaim externalClaim, List<LocalClaim> localClaimList) {
+
+        LocalClaim mappedLocalClaim = null;
+        if (localClaimList != null) {
+            for (LocalClaim localClaim : localClaimList) {
+                if (localClaim.getClaimURI().equals(externalClaim.getMappedLocalClaim())) {
+                    mappedLocalClaim = localClaim;
+                    break;
+                }
+            }
+        }
+        return mappedLocalClaim;
+    }
+
+    /**
+     * Get filtered claims that can be used in the schema attributes.
+     * This will allow only the username claim or the claims with supported-by-default value true.
+     *
+     * @param scimClaimToLocalClaimMap
+     * @return
+     */
+    private Map<String, Attribute> getFilteredUserSchemaAttributes(Map<ExternalClaim, LocalClaim>
+                                                                           scimClaimToLocalClaimMap) {
+
+        Map<String, Attribute> filteredFlatAttributeMap = new HashMap<>();
+
+        for (Map.Entry<ExternalClaim, LocalClaim> entry: scimClaimToLocalClaimMap.entrySet()) {
+
+            ExternalClaim scimClaim = entry.getKey();
+            LocalClaim mappedLocalClaim = entry.getValue();
+
+            if (isSupportedByDefault(mappedLocalClaim) || isUsernameClaim(scimClaim)) {
+                // Return only the schema of supported-by-default claims and the username claim.
+                Attribute schemaAttribute = getSchemaAttributes(scimClaim, mappedLocalClaim);
+                filteredFlatAttributeMap.put(schemaAttribute.getName(), schemaAttribute);
+            }
+        }
+
+        return filteredFlatAttributeMap;
+    }
+
+    private boolean isSupportedByDefault(LocalClaim mappedLocalClaim) {
+
+        String supportedByDefault = mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY);
+        return Boolean.parseBoolean(supportedByDefault);
+    }
+
+    private boolean isUsernameClaim(ExternalClaim scimClaim) {
+
+        return SCIMConstants.UserSchemaConstants.USER_NAME_URI.equals(scimClaim.getClaimURI());
+    }
+
+    /**
+     * Build and return the Charon Attribute representation using the claim metadata.
+     *
+     * @param scimClaim
+     * @param mappedLocalClaim
+     * @return
+     */
+    private Attribute getSchemaAttributes(ExternalClaim scimClaim, LocalClaim mappedLocalClaim) {
+
+        String name = scimClaim.getClaimURI();
+        if (name.startsWith(scimClaim.getClaimDialectURI())) {
+            name = name.substring(scimClaim.getClaimDialectURI().length() + 1);
+        }
+
+        AbstractAttribute attribute;
+        if (isComplexAttribute(name)) {
+            attribute = new ComplexAttribute(name);
+        } else {
+            attribute = new SimpleAttribute(name, null);
+        }
+
+        pupulateBasicAttributes(mappedLocalClaim, attribute);
+
+        return attribute;
+    }
+
+    private boolean isComplexAttribute(String name) {
+
+        switch(name) {
+            case "name" :
+            case "emails" :
+            case "phoneNumbers" :
+            case "ims" :
+            case "photos" :
+            case "addresses" :
+            case "groups" :
+            case "entitlements" :
+            case "roles" :
+            case "x509Certificates" :
+                return true;
+            default :
+                return false;
+        }
+    }
+
+    /**
+     * Populates basic Charon Attributes details using the claim metadata.
+     *
+     * @param mappedLocalClaim
+     * @param attribute
+     */
+    private void pupulateBasicAttributes(LocalClaim mappedLocalClaim, AbstractAttribute attribute) {
+
+        if (mappedLocalClaim != null) {
+            attribute.setDescription(mappedLocalClaim.getClaimProperty(ClaimConstants.DESCRIPTION_PROPERTY));
+
+            attribute.setRequired(Boolean.parseBoolean(mappedLocalClaim.
+                    getClaimProperty(ClaimConstants.REQUIRED_PROPERTY)));
+
+            String readOnlyProperty = mappedLocalClaim.getClaimProperty(ClaimConstants.READ_ONLY_PROPERTY);
+            if (Boolean.parseBoolean(readOnlyProperty)) {
+                attribute.setMutability(SCIMDefinitions.Mutability.READ_ONLY);
+            } else {
+                attribute.setMutability(SCIMDefinitions.Mutability.READ_WRITE);
+
+            }
+        }
+
+        // Fixed schema attributes
+        attribute.setCaseExact(false);
+        attribute.setType(SCIMDefinitions.DataType.STRING);
+        attribute.setMultiValued(false);
+        attribute.setReturned(SCIMDefinitions.Returned.DEFAULT);
+        attribute.setUniqueness(SCIMDefinitions.Uniqueness.NONE);
+
+        if (mappedLocalClaim != null) {
+            // Additional schema attributes
+            attribute.addAttributeProperty(DISPLAY_NAME_PROPERTY,
+                    mappedLocalClaim.getClaimProperty(ClaimConstants.DISPLAY_NAME_PROPERTY));
+            attribute.addAttributeProperty(DISPLAY_ORDER_PROPERTY,
+                    mappedLocalClaim.getClaimProperty(ClaimConstants.DISPLAY_ORDER_PROPERTY));
+            attribute.addAttributeProperty(REGULAR_EXPRESSION_PROPERTY,
+                    mappedLocalClaim.getClaimProperty(ClaimConstants.REGULAR_EXPRESSION_PROPERTY));
+        }
+    }
+
+    /**
+     * Builds complex attribute schema with correct sub attributes using the flat attribute map.
+     *
+     * @param filteredFlatAttributeMap
+     * @return
+     */
+    private Map<String, Attribute> buildHierarchicalAttributeMap(Map<String, Attribute> filteredFlatAttributeMap)
+            throws CharonException {
+
+        Map<String, Attribute> simpleAttributeMap = new HashMap<>();
+
+        Map<String, ComplexAttribute> complexAttributeMap = new HashMap<>();
+        for (Map.Entry<String, Attribute> userAttribute: filteredFlatAttributeMap.entrySet()) {
+            String attributeName = userAttribute.getKey();
+            Attribute attribute = userAttribute.getValue();
+
+            if (attributeName.contains(".")) {
+                ComplexAttribute parentAttribute = handleSubAttribute(attribute, filteredFlatAttributeMap,
+                        complexAttributeMap);
+                complexAttributeMap.put(parentAttribute.getName(), parentAttribute);
+            } else {
+                simpleAttributeMap.put(attributeName, attribute);
+            }
+        }
+        simpleAttributeMap.putAll(complexAttributeMap);
+
+        return simpleAttributeMap;
+    }
+
+    /**
+     * Set sub attribute to the correct parent attribute and return complex parent attribute.
+     *
+     * @param attribute
+     * @param flatAttributeMap
+     * @param complexAttributeMap
+     * @return
+     */
+    private ComplexAttribute handleSubAttribute(Attribute attribute, Map<String, Attribute> flatAttributeMap,
+                                                Map<String, ComplexAttribute> complexAttributeMap)
+            throws CharonException {
+
+        String attributeName = attribute.getName();
+        String parentAttributeName = attributeName.substring(0, attributeName.indexOf("."));
+        String subAttributeName = attributeName.substring(attributeName.indexOf(".") + 1);
+
+        ComplexAttribute parentAttribute = (ComplexAttribute) flatAttributeMap.get(parentAttributeName);
+
+        if (parentAttribute == null) {
+            parentAttribute = complexAttributeMap.get(parentAttributeName);
+        }
+
+        if (parentAttribute == null) {
+            parentAttribute = new ComplexAttribute(parentAttributeName);
+            pupulateBasicAttributes(null, parentAttribute);
+            complexAttributeMap.put(parentAttributeName, parentAttribute);
+        }
+
+        if (attribute instanceof AbstractAttribute) {
+            ((AbstractAttribute) attribute).setName(subAttributeName);
+        } else {
+            throw new CharonException("Unsupported attribute type");
+        }
+        parentAttribute.setSubAttribute(attribute);
+
+        return parentAttribute;
+    }
+
+    private void logSchemaAttributes(List<Attribute> userSchemaAttributesList) {
+
+        StringBuffer sb = new StringBuffer();
+        sb.append("Final user schema attribute list calculated as: [");
+        boolean isFirst = true;
+        for (Attribute userSchemaAttribute: userSchemaAttributesList) {
+
+            if (!isFirst) {
+                sb.append(", ");
+            }
+
+            sb.append("{");
+            sb.append(userSchemaAttribute.getName());
+            sb.append("}");
+        }
+        sb.append("]");
+        log.debug(sb);
+    }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim2.common.listener.SCIMTenantMgtListener;
@@ -176,6 +177,37 @@ public class SCIMCommonComponent {
         }
         SCIMCommonComponentHolder.setRolePermissionManagementService(null);
     }
+
+    /**
+     * Set claim metadata management service implementation.
+     *
+     * @param claimManagementService ClaimManagementService
+     */
+    @Reference(
+            name = "claimManagementService",
+            service = org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService .class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetadataManagementService")
+    protected void setClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("claimManagementService set in SCIMCommonComponent bundle");
+        }
+        SCIMCommonComponentHolder.setClaimManagementService(claimManagementService);
+    }
+
+    /**
+     * Unset claim metadata management service implementation.
+     */
+    protected void unsetClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("claimManagementService unset in SCIMCommonComponent bundle");
+        }
+        SCIMCommonComponentHolder.setClaimManagementService(null);
+    }
+
     @Deactivate
     protected void deactivate(ComponentContext context) {
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.scim2.common.internal;
 
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 
@@ -28,6 +29,7 @@ import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 public class SCIMCommonComponentHolder {
 
     private static RealmService realmService;
+    private static ClaimMetadataManagementService claimManagementService;
     private static RolePermissionManagementService rolePermissionManagementService;
 
     /**
@@ -69,5 +71,24 @@ public class SCIMCommonComponentHolder {
                                                                   rolePermissionManagementService) {
 
         SCIMCommonComponentHolder.rolePermissionManagementService = rolePermissionManagementService;
+    }
+
+    /**
+     * Get claim metadata management service.
+     * @return
+     */
+    public static ClaimMetadataManagementService getClaimManagementService() {
+
+        return claimManagementService;
+    }
+
+    /**
+     * Set claim metadata management service.
+     *
+     * @param claimManagementService
+     */
+    public static void setClaimManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        SCIMCommonComponentHolder.claimManagementService = claimManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/pom.xml
@@ -81,8 +81,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
                 <version>2.3.2</version>
             </plugin>
@@ -97,8 +97,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
@@ -50,8 +50,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
@@ -47,8 +47,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <identity.framework.version>5.14.85</identity.framework.version>
         <junit.version>4.11</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
-        <charon.version>3.3.0</charon.version>
+        <charon.version>3.3.2</charon.version>
         <identity.governance.version>1.3.11</identity.governance.version>
 
         <!--Maven Plugin Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -390,8 +390,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Refer: wso2/product-is#5284 for the context.

This PR implement necessary new methods introduced in SCIM User Manager (introduced with https://github.com/wso2/charon/pull/260) to populate user schema details dynamically to match with claim metadata.