### PR TITLE
Improve group patch to return 200 OK always if attributes are requested

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
@@ -518,7 +518,7 @@ public class GroupResource extends AbstractResource {
                             excludedAttributes));
                 }
             } else if (PATCH.class.getSimpleName().equals(httpVerb)) {
-                if (isGroupReturnedInPatchResponse()) {
+                if (isGroupReturnedInPatchResponse() || isAttributesRequested(attributes)) {
                     scimResponse = groupResourceManager
                             .updateWithPATCH(id, resourceString, userManager, attributes, excludedAttributes);
                 } else {
@@ -544,6 +544,11 @@ public class GroupResource extends AbstractResource {
 
         String property = IdentityUtil.getProperty(SCIMCommonConstants.SCIM_RETURN_UPDATED_GROUP_IN_PATCH_RESPONSE);
         return property == null || Boolean.parseBoolean(property);
+    }
+
+    private boolean isAttributesRequested(String attributes) {
+
+        return StringUtils.isNotBlank(attributes);
     }
 
     /**


### PR DESCRIPTION
With changes done for https://github.com/wso2/product-is/issues/6918 we can enable a config that would return a 204 response for Group PATCH requests.

However, if attributes are requested then we need to always send a 200 OK response