### PR TITLE
Add verificationPendingEmail attribute to scim2 schema extension.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
@@ -649,14 +649,19 @@ public class AttributeMapper {
                     attributeNames[2]);
             AttributeSchema typeAttributeSchema = getAttributeSchema(subAttributeSchema.getURI()
                     + ".type", scimObjectType);
-            DefaultAttributeFactory.createAttribute(typeAttributeSchema, typeSimpleAttribute);
+            if (typeAttributeSchema != null) {
+                DefaultAttributeFactory.createAttribute(typeAttributeSchema, typeSimpleAttribute);
+            }
 
             AttributeSchema valueAttributeSchema = getAttributeSchema(subAttributeSchema.getURI()
                     + ".value", scimObjectType);
-            SimpleAttribute valueSimpleAttribute = new SimpleAttribute(SCIMConstants.CommonSchemaConstants.VALUE,
-                    AttributeUtil.getAttributeValueFromString(attributeEntry.getValue(),
-                            valueAttributeSchema.getType()));
-            DefaultAttributeFactory.createAttribute(valueAttributeSchema, valueSimpleAttribute);
+            SimpleAttribute valueSimpleAttribute = null;
+            if (valueAttributeSchema != null) {
+                valueSimpleAttribute = new SimpleAttribute(SCIMConstants.CommonSchemaConstants.VALUE,
+                        AttributeUtil.getAttributeValueFromString(attributeEntry.getValue(),
+                                valueAttributeSchema.getType()));
+                DefaultAttributeFactory.createAttribute(valueAttributeSchema, valueSimpleAttribute);
+            }
 
             //need to set a complex type value for multivalued attribute
             Object type = SCIMCommonConstants.DEFAULT;
@@ -665,13 +670,17 @@ public class AttributeMapper {
             if (typeSimpleAttribute.getValue() != null) {
                 type = typeSimpleAttribute.getValue();
             }
-            if (valueSimpleAttribute.getValue() != null) {
+            if (valueSimpleAttribute != null && valueSimpleAttribute.getValue()!= null) {
                 value = valueSimpleAttribute.getValue();
             }
             String complexName = immediateParentAttributeName + "_" + value + "_" + type;
             ComplexAttribute complexAttribute = new ComplexAttribute(complexName);
-            complexAttribute.setSubAttribute(typeSimpleAttribute);
-            complexAttribute.setSubAttribute(valueSimpleAttribute);
+            if (typeAttributeSchema != null) {
+                complexAttribute.setSubAttribute(typeSimpleAttribute);
+            }
+            if (valueSimpleAttribute != null) {
+                complexAttribute.setSubAttribute(valueSimpleAttribute);
+            }
             DefaultAttributeFactory.createAttribute(subAttributeSchema, complexAttribute);
 
             ComplexAttribute extensionComplexAttribute = null;

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -19,7 +19,7 @@
 "attributeName":"$ref",
 "dataType":"reference",
 "multiValued":"false",
-"description":"he URI of the SCIM resource representing the User's manager.",
+"description":"The URI of the SCIM resource representing the User's manager.",
 "required":"false",
 "caseExact":"false",
 "mutability":"readwrite",
@@ -49,7 +49,7 @@
 "attributeName":"manager",
 "dataType":"complex",
 "multiValued":"false",
-"description":"The User's manager.A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User.",
+"description":"The User's manager. A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User.",
 "required":"false",
 "caseExact":"false",
 "mutability":"readwrite",
@@ -165,6 +165,36 @@
 "referenceTypes":[]
 },
 {
+"attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value",
+"attributeName":"value",
+"dataType":"string",
+"multiValued":"false",
+"description":"Store email to be updated as a temporary claim till email verification happens.",
+"required":"false",
+"caseExact":"false",
+"mutability":"readOnly",
+"returned":"default",
+"uniqueness":"none",
+"subAttributes":"null",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
+"attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails",
+"attributeName":"pendingEmails",
+"dataType":"complex",
+"multiValued":"true",
+"description":"The User's email addresses. A complex type that represents verification pending email addresses of the user.",
+"required":"false",
+"caseExact":"false",
+"mutability":"readOnly",
+"returned":"default",
+"uniqueness":"none",
+"subAttributes":"value",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "attributeName":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "dataType":"complex",
@@ -175,7 +205,7 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager",
+"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- Introduces new attribute to Enterprise User Extension to represent verification pending emails.
- Fixes NPE in constructSCIMObjectFromAttributesOfLevelThree method when there is no type property in the attribute. (https://github.com/wso2/product-is/issues/7512)

This PR is related to feature: https://github.com/wso2/product-is/issues/7183

### When should this PR be merged

This PR should be merged after https://github.com/wso2-extensions/identity-userstore-ldap/pull/34

