### PR TITLE
Add enterprise user schema impl to SCIMUserManager

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -98,8 +98,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
@@ -3795,6 +3797,39 @@ public class SCIMUserManager implements UserManager {
     }
 
     /**
+     * Returns the schema of the enterprise user extension in SCIM 2.0.
+     *
+     * @return List of attributes of enterprise user extension
+     * @throws CharonException
+     */
+    @Override
+    public List<Attribute> getEnterpriseUserSchema() throws CharonException {
+
+        List<Attribute> enterpriseUserSchemaAttributesList = null;
+
+        if (SCIMCommonUtils.isEnterpriseUserExtensionEnabled()) {
+            Map<ExternalClaim, LocalClaim> scimClaimToLocalClaimMap =
+                    getMappedLocalClaimsForDialect(SCIMCommonConstants.SCIM_ENTERPRISE_USER_CLAIM_DIALECT, tenantDomain);
+
+            Map<String, Attribute> filteredAttributeMap =
+                    getFilteredEnterpriseUserSchemaAttributes(scimClaimToLocalClaimMap);
+            Map<String, Attribute> hierarchicalAttributeMap =
+                    buildHierarchicalAttributeMap(filteredAttributeMap);
+
+            enterpriseUserSchemaAttributesList = new ArrayList(hierarchicalAttributeMap.values());
+
+            if (log.isDebugEnabled()) {
+               logSchemaAttributes(enterpriseUserSchemaAttributesList);
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Enterprise user schema support disabled.");
+            }
+        }
+        return enterpriseUserSchemaAttributesList;
+    }
+
+    /**
      * Get mapped local claims for the claims in specified external claim dialect.
      *
      * @param externalClaimDialect
@@ -3871,6 +3906,15 @@ public class SCIMUserManager implements UserManager {
         return filteredFlatAttributeMap;
     }
 
+    private Map<String, Attribute> getFilteredEnterpriseUserSchemaAttributes(Map<ExternalClaim, LocalClaim>
+                                                                                     scimClaimToLocalClaimMap) {
+
+        return scimClaimToLocalClaimMap.entrySet().stream()
+                .filter(entry -> isSupportedByDefault(entry.getValue()))
+                .map(e -> getSchemaAttributes(e.getKey(), e.getValue()))
+                .collect(Collectors.toMap(attr -> attr.getName(), Function.identity()));
+    }
+
     private boolean isSupportedByDefault(LocalClaim mappedLocalClaim) {
 
         String supportedByDefault = mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY);
@@ -3911,6 +3955,7 @@ public class SCIMUserManager implements UserManager {
     private boolean isComplexAttribute(String name) {
 
         switch(name) {
+            case "manager":
             case "name" :
             case "emails" :
             case "phoneNumbers" :

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -36,6 +36,8 @@ public class SCIMCommonConstants {
 
     public static final String SCIM_CORE_CLAIM_DIALECT = "urn:ietf:params:scim:schemas:core:2.0";
     public static final String SCIM_USER_CLAIM_DIALECT = "urn:ietf:params:scim:schemas:core:2.0:User";
+    public static final String SCIM_ENTERPRISE_USER_CLAIM_DIALECT =
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
 
     public static final String EQ = "eq";
     public static final String CO = "co";
@@ -64,6 +66,7 @@ public class SCIMCommonConstants {
     public static final String BULK_MAX_OPERATIONS = "bulk-maxOperations";
     public static final String BULK_MAX_PAYLOAD_SIZE = "bulk-maxPayloadSize";
     public static final String FILTER_MAX_RESULTS = "filter-maxResults";
+    public static final String ENTERPRISE_USER_EXTENSION_ENABLED = "user-schema-extension-enabled";
 
     public static final java.lang.String ASK_PASSWORD_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword";
     public static final java.lang.String VERIFY_EMAIL_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -405,4 +405,15 @@ public class SCIMCommonUtils {
                         CarbonConstants.DOMAIN_SEPARATOR).toLowerCase());
     }
 
+    /**
+     * Check if SCIM enterprise user extension has been enabled.
+     *
+     * @return True if enterprise user extension enabled
+     */
+    public static boolean isEnterpriseUserExtensionEnabled() {
+
+        return Boolean.parseBoolean(SCIMConfigProcessor.getInstance()
+                .getProperty(SCIMCommonConstants.ENTERPRISE_USER_EXTENSION_ENABLED));
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -298,8 +298,8 @@
         <identity.framework.version>5.15.55</identity.framework.version>
         <junit.version>4.11</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
-        <charon.version>3.3.15</charon.version>
         <identity.governance.version>1.3.11</identity.governance.version>
+        <charon.version>3.3.16</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
## Purpose
Implement enterprise user schema retrieval for SCIMUserManager for new method definition in UserManager interface(https://github.com/wso2/charon/pull/279).
Related to issue: https://github.com/wso2/product-is/issues/5284

### Depends on PR
https://github.com/wso2/charon/pull/279