### PR TITLE
Correct totalResult in pagination when secondary userstore is JDBC and primary userstore is LDAP

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -519,24 +519,17 @@ public class SCIMUserManager implements UserManager {
     private long getTotalUsers(String domainName) throws CharonException {
 
         long totalUsers = 0;
-        if (carbonUM instanceof JDBCUserStoreManager) {
-            try {
-                AbstractUserStoreManager secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
-                        .getSecondaryUserStoreManager(domainName);
+        AbstractUserStoreManager secondaryUserStoreManager = null;
+        if (StringUtils.isNotBlank(domainName)) {
+            secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
+                    .getSecondaryUserStoreManager(domainName);
+        }
+        try {
+            if (secondaryUserStoreManager instanceof JDBCUserStoreManager) {
                 totalUsers = secondaryUserStoreManager.countUsersWithClaims(USERNAME_CLAIM, "*");
-            } catch (org.wso2.carbon.user.core.UserStoreException e) {
-                throw new CharonException("Error while getting total user count in domain: " + domainName);
             }
-        } else if (StringUtils.isNotBlank(domainName)) {
-            try {
-                AbstractUserStoreManager secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
-                        .getSecondaryUserStoreManager(domainName);
-                if (secondaryUserStoreManager instanceof JDBCUserStoreManager) {
-                    totalUsers = secondaryUserStoreManager.countUsersWithClaims(USERNAME_CLAIM, "*");
-                }
-            } catch (org.wso2.carbon.user.core.UserStoreException e) {
-                throw new CharonException("Error while getting total user count in domain: " + domainName);
-            }
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            throw new CharonException("Error while getting total user count in domain: " + domainName);
         }
         return totalUsers;
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -132,6 +132,7 @@ public class SCIMUserManager implements UserManager {
     private static final String LOCATION_CLAIM = "http://wso2.org/claims/location";
     private static final String LAST_MODIFIED_CLAIM = "http://wso2.org/claims/modified";
     private static final String RESOURCE_TYPE_CLAIM = "http://wso2.org/claims/resourceType";
+    private static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
 
     @Deprecated
     public SCIMUserManager(UserStoreManager carbonUserStoreManager, ClaimManager claimManager) {
@@ -522,16 +523,16 @@ public class SCIMUserManager implements UserManager {
             try {
                 AbstractUserStoreManager secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
                         .getSecondaryUserStoreManager(domainName);
-                totalUsers = secondaryUserStoreManager.countUsersWithClaims("http://wso2.org/claims/username", "*");
+                totalUsers = secondaryUserStoreManager.countUsersWithClaims(USERNAME_CLAIM, "*");
             } catch (org.wso2.carbon.user.core.UserStoreException e) {
                 throw new CharonException("Error while getting total user count in domain: " + domainName);
             }
-        } else if (domainName != null) {
+        } else if (StringUtils.isNotBlank(domainName)) {
             try {
                 AbstractUserStoreManager secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
                         .getSecondaryUserStoreManager(domainName);
                 if (secondaryUserStoreManager instanceof JDBCUserStoreManager) {
-                    totalUsers = secondaryUserStoreManager.countUsersWithClaims("http://wso2.org/claims/username", "*");
+                    totalUsers = secondaryUserStoreManager.countUsersWithClaims(USERNAME_CLAIM, "*");
                 }
             } catch (org.wso2.carbon.user.core.UserStoreException e) {
                 throw new CharonException("Error while getting total user count in domain: " + domainName);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -526,6 +526,16 @@ public class SCIMUserManager implements UserManager {
             } catch (org.wso2.carbon.user.core.UserStoreException e) {
                 throw new CharonException("Error while getting total user count in domain: " + domainName);
             }
+        } else if (domainName != null) {
+            try {
+                AbstractUserStoreManager secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
+                        .getSecondaryUserStoreManager(domainName);
+                if (secondaryUserStoreManager instanceof JDBCUserStoreManager) {
+                    totalUsers = secondaryUserStoreManager.countUsersWithClaims("http://wso2.org/claims/username", "*");
+                }
+            } catch (org.wso2.carbon.user.core.UserStoreException e) {
+                throw new CharonException("Error while getting total user count in domain: " + domainName);
+            }
         }
         return totalUsers;
     }


### PR DESCRIPTION
**Description**

https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/243/ resolves https://github.com/wso2/product-is/issues/7320 partially. 

Eventhough the secondary userstorre is a JDBC one, the fix https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/243/  provides the correct totalResult for the following CURL command:

`curl -v -k --user admin:admin 'https://localhost:9443/scim2/Users?startIndex=1&count=2&domain=<secondary user store domain>'`
only if the primary userstore is a JDBC. 

The fix in this PR is able to provide the correct totalResult in pagination if the specified domain is a JDBC userstore domain.