### PR TITLE
Refactor Exception Message

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2801,7 +2801,8 @@ public class SCIMUserManager implements UserManager {
             }
         } catch (UserStoreException | CharonException | NotFoundException | IdentitySCIMException |
                 BadRequestException e) {
-            throw new CharonException("Error in getting user information for user: " + scimUser.getUserName(), e);
+            throw new CharonException("Error in getting user information for user: " +
+                    coreUser.getDomainQualifiedUsername(), e);
         }
 
         return scimUser;


### PR DESCRIPTION
### Issues
https://github.com/wso2/product-is/issues/8309
https://github.com/wso2/product-is/issues/8294

### Cause
If  Exception occurred in the try method catch throw Charon Exception with scimUser.getUserName() in the message body. This may cause null point exception because scimUser defined as null before try method.

### Fix
Instead of scimUser, we can use core user to get UserName