### PR TITLE
Add delete operation support for scimMe

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1815,8 +1815,12 @@ public class SCIMUserManager implements UserManager {
     @Override
     public void deleteMe(String userName) throws NotFoundException, CharonException, NotImplementedException {
 
-        String error = "Self delete is not supported";
-        throw new NotImplementedException(error);
+        try {
+            String userId = carbonUM.getUserIDFromUserName(userName);
+            deleteUser(userId);
+        } catch (UserStoreException e) {
+            throw new CharonException("Error occurred while getting id for user : " + userName, e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8466

To support this, we need to modify the permission for delete operation. Currently the permission is 

```
<Permissions>/permission/admin/manage/identity/usermgt/delete</Permissions>
<Scopes>internal_user_mgt_delete</Scopes>
```

The user need to have these permission and scope. Else we can modify it via the config