### PR TITLE
Introduce a new claim to check user's mutability

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -75,6 +75,9 @@ public class SCIMCommonConstants {
     // Identity recovery claims
     public static final String ASK_PASSWORD_CLAIM = "http://wso2.org/claims/identity/askPassword";
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
+
+    public static final String READ_ONLY_USER_CLAIM = "http://wso2.org/claims/identity/isReadOnlyUser";
+
     public static final String SCIM_COMPLEX_MULTIVALUED_ATTRIBUTE_SUPPORT_ENABLED = "SCIM2" +
             ".ComplexMultiValuedAttributeSupportEnabled";
     public static final String SCIM_ENABLE_FILTERING_ENHANCEMENTS = "SCIM2.EnableFilteringEnhancements";

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -540,6 +540,21 @@
 "referenceTypes":[]
 },
 {
+"attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isReadOnlyUser",
+"attributeName":"isReadOnlyUser",
+"dataType":"boolean",
+"multiValued":"false",
+"description":"States whether the user is in a read only user store or not",
+"required":"false",
+"caseExact":"false",
+"mutability":"readOnly",
+"returned":"request",
+"uniqueness":"none",
+"subAttributes":"null",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "attributeName":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "dataType":"complex",
@@ -550,7 +565,8 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth",
+"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager
+pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/6101

**Requirement**
The user portal should be able to disable updating the user claims if the user is in a read-only user store. Therefore there should be a way to get the detail of whether the user-store is read-only or not when retrieving the user details by calling the SCIM GET API.

**Approach**
1. We have introduced a new claim as `http://wso2.org/claims/identity/isReadOnlyUser` to the WSO2 claim dialect and it is mapped with the `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isReadOnlyUser` of the WSO2 enterprise user dialect. ( https://github.com/wso2/carbon-identity-framework/pull/3033)
2. The SCIM attribute is defined such that it will be returned only when it is requested.
3. Therefore when calling the SCIM endpoint this attribute can be defined in the query param for requested claims. `https://localhost:9443/scim2/Users/<user_id>?attributes=username,urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.isReadOnlyUser`
4. The `doPostGetUserClaimValues` of **SCIMUserOperationListener** will be called upon retrieving the user claim. This method will check whether the `http://wso2.org/claims/identity/isReadOnlyUser` is in the requested list of claims. If it is requested, its value is set depending on the mutability of the userstore and added to the returned set of claims. If the userstore is read-only the value of the claim is set to _True_