### PR TITLE
Improve scim2 response messages

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -88,6 +88,7 @@ public class SCIMCommonConstants {
     public static final String SCIM_ENABLE_MANDATE_DOMAIN_FOR_USERNAMES_AND_GROUPNAMES_IN_RESPONSE =
             "SCIM2.MandateDomainForUsernamesAndGroupNamesInResponse";
     public static final String SCIM_RETURN_UPDATED_GROUP_IN_PATCH_RESPONSE = "SCIM2.ReturnUpdatedGroupInPatchResponse";
+    public static final String SCIM_NOTIFY_USERSTORE_STATUS = "SCIM2.NotifyUserstoreStatus";
 
     public static final String URL_SEPERATOR = "/";
     public static final String TENANT_URL_SEPERATOR = "/t/";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -469,4 +469,14 @@ public class SCIMCommonUtils {
                 .getProperty(SCIMCommonConstants.ENTERPRISE_USER_EXTENSION_ENABLED));
     }
 
+    /**
+     * Checks whether the identity.xml config is available to notify userstore availability.
+     *
+     * @return whether 'NotifyUserstoreStatus' property is enabled in the identity.xml.
+     */
+    public static boolean isNotifyUserstoreStatusEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(SCIMCommonConstants.SCIM_NOTIFY_USERSTORE_STATUS));
+    }
+
 }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9124

With this improvement SCIM2 user endpoints return the user core errors in the SCIM2 response. To enable it we have to add below configuration in the deployment.toml file.

```
[scim2]
notify_userstore_status = true
```