### PR TITLE
Add claim to store verification pending mobile number

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -555,6 +555,21 @@
 "referenceTypes":[]
 },
 {
+"attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingMobileNumber",
+"attributeName":"pendingMobileNumber",
+"dataType":"string",
+"multiValued":"false",
+"description":"Store user's mobile number to be updated as a temporary claim until mobile number verification happens.",
+"required":"false",
+"caseExact":"false",
+"mutability":"readWrite",
+"returned":"default",
+"uniqueness":"none",
+"subAttributes":"null",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "attributeName":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "dataType":"complex",
@@ -565,7 +580,7 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser",
+"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Adds a new attribute to the Enterprise User Extension to represent verification pending mobile number.

Related to issue - https://github.com/wso2/product-is/issues/9045