### PR TITLE
Exception handling for IdentityEventException

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/IdentityEventExceptionSettings.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/IdentityEventExceptionSettings.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * this class is the blue print of IdentityEventException settings used in SCIMUserManager.
+ */
+public class IdentityEventExceptionSettings {
+    private boolean exposeErrorCodeInMessage;
+    private List<String> badRequestErrorCodes = new ArrayList<>();
+
+	public boolean isExposeErrorCodeInMessage() {
+		return exposeErrorCodeInMessage;
+	}
+
+	public void setExposeErrorCodeInMessage(boolean exposeErrorCodeInMessage) {
+		this.exposeErrorCodeInMessage = exposeErrorCodeInMessage;
+	}
+
+	public List<String> getBadRequestErrorCodes() {
+		return badRequestErrorCodes;
+	}
+
+	public void setBadRequestErrorCodes(List<String> badRequestErrorCodes) {
+		this.badRequestErrorCodes = badRequestErrorCodes;
+	}
+}
+
+

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -52,7 +52,11 @@ public class SCIMCommonConstants {
 
     //config constants
     public static final String CHARON_CONFIG_NAME = "charon-config.xml";
-    public static final String ELEMENT_NAME_AUTHENTICATION_SCHEMES = "authenticationSchemes";;
+    public static final String ELEMENT_NAME_AUTHENTICATION_SCHEMES = "authenticationSchemes";
+    public static final String ELEMENT_NAME_IEE_SETTINGS = "identityEventExceptionSettings";
+    public static final String ELEMENT_NAME_IEE_SETTINGS_EXPOSE_ERROR_CODE_IN_MESSAGE = "exposeErrorCodeInMessage";
+    public static final String ELEMENT_NAME_IEE_SETTINGS_BAD_REQUEST_ERROR_CODES = "badRequestErrorCodes";
+    public static final String ELEMENT_NAME_IEE_SETTINGS_BAD_REQUEST_ERROR_CODE = "badRequestErrorCode";
     public static final String ELEMENT_NAME_PROPERTY = "Property";
     public static final String ELEMENT_NAME_SCHEMA = "schema";
     public static final String ATTRIBUTE_NAME_NAME = "name";

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/charon-config-test.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/charon-config-test.xml
@@ -47,4 +47,13 @@
             <Property name="primary">false</Property>
         </schema>
     </authenticationSchemes>
+    <identityEventExceptionSettings>
+		<Property name="exposeErrorCodeInMessage">false</Property>
+		<badRequestErrorCodes>
+			<badRequestErrorCode>
+				<!-- ERROR_CODE_PASSWORD_HISTORY_VIOLATION -->
+				22001
+			</badRequestErrorCode>
+		</badRequestErrorCodes>
+    </identityEventExceptionSettings>
 </provisioning-config>


### PR DESCRIPTION
Follow up of #271, this PR introduces a new settings category: IdentityEventExceptionSettings which contains 2 parameters:
    - exposeErrorCodeInMessage: whether or not we should expose the internal IdentityEventExceptionSettings error code
    - badRequestErrorCodes: list of error code that should trigger a BadRequestException

In current codebase, an IdentityEventException in SCIMUserManager is transformed into a BadRequestException if the error code is "2201" (which will trigger a 400 error code). If not, it is wrapped in a CharonException (which will trigger a 500 error code).

In some use cases, we might need other error code to be transformed to bad request: this is what *badRequestErrorCodes* is for.
Also in some cases, we might need some additional context to personalized message in the UI. Without any help, we are doomed to an error message coming from the Java exception itself. Having access to the error code in the message is a good enough solution: this is what *exposeErrorCodeInMessage* is for.

I also add some unit test:
- first to cover the existing use case which was not tested
- then to cover the changes in the settings loading and in the SCIMUserManager updated exception handler.

What do you thing about this approach ?

(there is still some polish to do in the SCIMUserManager class as there are elements which are not used (dead code): ROLE_CLAIM, doUserValidation, addDomainToUserMembers, getMappedClaimList and now ERROR_CODE_PASSWORD_HISTORY_VIOLATION).
