### PR TITLE
remove unused encoder from AbstractResource.handleCharonException

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/AbstractResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/AbstractResource.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
 import org.wso2.charon3.core.protocol.endpoints.AbstractResourceManager;
@@ -32,7 +31,6 @@ import javax.ws.rs.core.Response;
 
 public class AbstractResource {
     private static final Log logger = LogFactory.getLog(AbstractResource.class);
-    private JSONEncoder defaultEncoder = new JSONEncoder();
 
     //identify the output format
     public boolean isValidOutputFormat(String format) {
@@ -97,14 +95,13 @@ public class AbstractResource {
     }
 
     /**
-     * Build an error message for a Charon exception. We go with the
-     * JSON encoder as default if not specified.
+     * Build an error message for a Charon exception.
      *
      * @param e CharonException
      * @param encoder
      * @return
      */
-    protected Response handleCharonException(CharonException e, JSONEncoder encoder) {
+    protected Response handleCharonException(CharonException e) {
         if (logger.isDebugEnabled()) {
             logger.debug(e.getMessage(), e);
         }
@@ -114,18 +111,11 @@ public class AbstractResource {
             logger.error("Server error while handling the request.", e);
         }
 
-        // if the encoder is null we go with the JSON encoder as the default encoder.
-        if (encoder == null) {
-            logger.error("No encoder found. Sending error response using default JSON encoder");
-            encoder = defaultEncoder;
-        }
-
         return SupportUtils.buildResponse(AbstractResourceManager.encodeSCIMException(e));
     }
 
     /**
-     * Build the error response if the requested input or output format is not supported. We go with JSON encoder as
-     * the encoder for the error response.
+     * Build the error response if the requested input or output format is not supported.
      * @param e
      * @return
      */

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/BulkResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/BulkResource.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.identity.scim2.provider.resources;
 import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
 import org.wso2.charon3.core.extensions.RoleManager;
@@ -41,8 +40,6 @@ public class BulkResource extends AbstractResource {
                                @HeaderParam(SCIMProviderConstants.CONTENT_TYPE) String inputFormat,
                                @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat,
                                String resourceString) {
-
-        JSONEncoder encoder = null;
         try {
 
             // content-type header is compulsory in post request.
@@ -61,10 +58,6 @@ public class BulkResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -80,7 +73,7 @@ public class BulkResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e,encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/GroupResource.java
@@ -35,7 +35,6 @@ import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.mgt.RolePermissionException;
 import org.wso2.charon3.core.encoder.JSONDecoder;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
@@ -435,16 +434,11 @@ public class GroupResource extends AbstractResource {
         String attributes = requestAttributes.get(SCIMProviderConstants.ATTRIBUTES);
         String excludedAttributes = requestAttributes.get(SCIMProviderConstants.EXCLUDE_ATTRIBUTES);
         String search = requestAttributes.get(SCIMProviderConstants.SEARCH);
-        JSONEncoder encoder = null;
         JSONArray outputPermissions;
         Gson gson = new Gson();
         HashMap<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("Content-Type", SCIMProviderConstants.APPLICATION_SCIM_JSON);
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-            // Obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
-
             // Obtain the user store manager
             SCIMUserManager userManager = (SCIMUserManager) IdentitySCIMManager.getInstance().getUserManager();
 
@@ -533,10 +527,10 @@ public class GroupResource extends AbstractResource {
             return SupportUtils.buildResponse(new SCIMResponse(ResponseCodeConstants.CODE_BAD_REQUEST,
                     "The Patch request is invalid.", responseHeaders));
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (UserStoreException | RolePermissionException e) {
             return handleCharonException(new CharonException("Error occurred when getting the permissions from server",
-                    e), encoder);
+                    e));
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/MeResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/MeResource.java
@@ -18,14 +18,10 @@
 package org.wso2.carbon.identity.scim2.provider.resources;
 
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.jaxrs.designator.PATCH;
 import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
 import org.wso2.charon3.core.extensions.UserManager;
@@ -37,8 +33,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 public class MeResource extends AbstractResource {
-    private static final Log logger = LogFactory.getLog(UserResource.class);
-
     @GET
     @Produces({MediaType.APPLICATION_JSON, SCIMProviderConstants.APPLICATION_SCIM_JSON})
     public Response getUser(@HeaderParam(SCIMProviderConstants.AUTHORIZATION) String authorizationHeader,
@@ -47,16 +41,11 @@ public class MeResource extends AbstractResource {
                             @QueryParam(SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String  excludedAttributes) {
 
         String userName = SupportUtils.getAuthenticatedUsername();
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             if(!isValidOutputFormat(outputFormat)){
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -70,7 +59,7 @@ public class MeResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e,encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -84,11 +73,7 @@ public class MeResource extends AbstractResource {
                                @QueryParam(SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String  excludedAttributes,
                                String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            // obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE
@@ -105,8 +90,6 @@ public class MeResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // create charon-SCIM user endpoint and hand-over the request.
             MeResourceManager meResourceManager = new MeResourceManager();
@@ -120,7 +103,7 @@ public class MeResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -132,10 +115,7 @@ public class MeResource extends AbstractResource {
                                @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String format) {
 
         String userName = SupportUtils.getAuthenticatedUsername();
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // defaults to application/scim+json.
             if (format == null) {
                 format = SCIMProviderConstants.APPLICATION_SCIM_JSON;
@@ -144,8 +124,6 @@ public class MeResource extends AbstractResource {
                 String error = format + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -159,7 +137,7 @@ public class MeResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -174,11 +152,7 @@ public class MeResource extends AbstractResource {
                                String resourceString) {
 
         String userName = SupportUtils.getAuthenticatedUsername();
-        JSONEncoder encoder = null;
         try {
-            // obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE + " not present in the request header";
@@ -194,8 +168,6 @@ public class MeResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -209,7 +181,7 @@ public class MeResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -224,11 +196,7 @@ public class MeResource extends AbstractResource {
                               String resourceString) {
 
         String userName = SupportUtils.getAuthenticatedUsername();
-        JSONEncoder encoder = null;
         try {
-            // obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE + " not present in the request header";
@@ -244,8 +212,6 @@ public class MeResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -259,7 +225,7 @@ public class MeResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/ResourceTypesResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/ResourceTypesResource.java
@@ -18,13 +18,8 @@
 
 package org.wso2.carbon.identity.scim2.provider.resources;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
-import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.protocol.endpoints.ResourceTypeResourceManager;
 
@@ -36,29 +31,15 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 public class ResourceTypesResource extends AbstractResource {
-    private static final Log logger = LogFactory.getLog(ResourceTypesResource.class);
-
     @GET
     @Produces({MediaType.APPLICATION_JSON, SCIMProviderConstants.APPLICATION_SCIM_JSON})
     public Response getUser() {
+        // create charon-SCIM service provider config endpoint and hand-over the request.
+        ResourceTypeResourceManager resourceTypeResourceManager = new ResourceTypeResourceManager();
 
-        JSONEncoder encoder = null;
-        try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
-
-            // create charon-SCIM service provider config endpoint and hand-over the request.
-            ResourceTypeResourceManager resourceTypeResourceManager = new ResourceTypeResourceManager();
-
-            SCIMResponse scimResponse = resourceTypeResourceManager.get(null, null, null, null);
-            // needs to check the code of the response and return 200 0k or other error codes
-            // appropriately.
-            return SupportUtils.buildResponse(scimResponse);
-
-        } catch (CharonException e) {
-            return handleCharonException(e,encoder);
-        }
+        SCIMResponse scimResponse = resourceTypeResourceManager.get(null, null, null, null);
+        // needs to check the code of the response and return 200 0k or other error codes
+        // appropriately.
+        return SupportUtils.buildResponse(scimResponse);
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/RoleResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/RoleResource.java
@@ -18,19 +18,15 @@
 
 package org.wso2.carbon.identity.scim2.provider.resources;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.jaxrs.designator.PATCH;
 import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
 import org.wso2.charon3.core.extensions.RoleManager;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.protocol.endpoints.RoleResourceManager;
-import org.wso2.charon3.core.protocol.endpoints.UserResourceManager;
 import org.wso2.charon3.core.schema.SCIMConstants;
 
 import javax.ws.rs.DELETE;
@@ -48,8 +44,6 @@ import javax.ws.rs.core.Response;
 @Path("/")
 public class RoleResource extends AbstractResource {
 
-    private static final Log logger = LogFactory.getLog(RoleResource.class);
-
     @GET
     @Path("{id}")
     @Produces({ MediaType.APPLICATION_JSON, SCIMProviderConstants.APPLICATION_SCIM_JSON })
@@ -59,16 +53,11 @@ public class RoleResource extends AbstractResource {
             @QueryParam(SCIMProviderConstants.ATTRIBUTES) String attribute,
             @QueryParam(SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String excludedAttributes) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             if (!isValidOutputFormat(outputFormat)) {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // Obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -82,7 +71,7 @@ public class RoleResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -95,10 +84,7 @@ public class RoleResource extends AbstractResource {
             @HeaderParam(SCIMProviderConstants.CONTENT_TYPE) String inputFormat,
             @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat, String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE + " not present in the request header";
@@ -114,8 +100,6 @@ public class RoleResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -128,7 +112,7 @@ public class RoleResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -139,11 +123,7 @@ public class RoleResource extends AbstractResource {
             @HeaderParam(SCIMProviderConstants.CONTENT_TYPE) String inputFormat,
             @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat, String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            // Obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE + " not present in the request header";
@@ -159,8 +139,6 @@ public class RoleResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // Obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -173,7 +151,7 @@ public class RoleResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -188,10 +166,7 @@ public class RoleResource extends AbstractResource {
             @QueryParam(SCIMProviderConstants.SORT_BY) String sortBy,
             @QueryParam(SCIMProviderConstants.SORT_ORDER) String sortOrder) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // Defaults to application/scim+json.
             if (outputFormat == null) {
                 outputFormat = SCIMProviderConstants.APPLICATION_SCIM_JSON;
@@ -200,8 +175,6 @@ public class RoleResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -214,7 +187,7 @@ public class RoleResource extends AbstractResource {
 
             return SupportUtils.buildResponse(scimResponse);
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -225,11 +198,7 @@ public class RoleResource extends AbstractResource {
     public Response deleteRole(@PathParam(SCIMConstants.CommonSchemaConstants.ID) String id,
             @HeaderParam(SCIMProviderConstants.AUTHORIZATION) String authorizationHeader,
             @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat) {
-
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // defaults to application/scim+json.
             if (outputFormat == null) {
                 outputFormat = SCIMProviderConstants.APPLICATION_SCIM_JSON;
@@ -238,8 +207,6 @@ public class RoleResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // Obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -253,7 +220,7 @@ public class RoleResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -266,11 +233,7 @@ public class RoleResource extends AbstractResource {
             @HeaderParam(SCIMConstants.CONTENT_TYPE_HEADER) String inputFormat,
             @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat, String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            // Obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE + " not present in the request header";
@@ -286,8 +249,6 @@ public class RoleResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // Obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -300,7 +261,7 @@ public class RoleResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -313,11 +274,7 @@ public class RoleResource extends AbstractResource {
             @HeaderParam(SCIMConstants.CONTENT_TYPE_HEADER) String inputFormat,
             @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat, String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            // Obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE + " not present in the request header";
@@ -333,8 +290,6 @@ public class RoleResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw new FormatNotSupportedException(error);
             }
-            // Obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // Obtain the role manager.
             RoleManager roleManager = IdentitySCIMManager.getInstance().getRoleManager();
@@ -347,7 +302,7 @@ public class RoleResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/SchemaResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/SchemaResource.java
@@ -18,11 +18,8 @@
 
 package org.wso2.carbon.identity.scim2.provider.resources;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.protocol.SCIMResponse;
@@ -36,20 +33,11 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 public class SchemaResource extends AbstractResource {
-    private static Log logger = LogFactory.getLog(SchemaResource.class);
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getSchemas() {
 
-        JSONEncoder encoder = null;
         try {
-
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
-
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
 
             // create charon-SCIM schemas endpoint and hand-over the request.
@@ -59,7 +47,7 @@ public class SchemaResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e,encoder);
+            return handleCharonException(e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/ServiceProviderConfigResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/ServiceProviderConfigResource.java
@@ -19,14 +19,7 @@
 
 package org.wso2.carbon.identity.scim2.provider.resources;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
-import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
-import org.wso2.charon3.core.exceptions.CharonException;
-import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.protocol.SCIMResponse;
 import org.wso2.charon3.core.protocol.endpoints.ServiceProviderConfigResourceManager;
 
@@ -36,33 +29,16 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 public class ServiceProviderConfigResource extends AbstractResource {
-    private static final Log logger = LogFactory.getLog(ServiceProviderConfigResource.class);
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getUser() {
+        // create charon-SCIM service provider config endpoint and hand-over the request.
+        ServiceProviderConfigResourceManager serviceProviderConfigResourceManager =
+                new ServiceProviderConfigResourceManager();
 
-        JSONEncoder encoder = null;
-        try {
-
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
-
-            // obtain the user store manager
-
-            // create charon-SCIM service provider config endpoint and hand-over the request.
-            ServiceProviderConfigResourceManager serviceProviderConfigResourceManager =
-                    new ServiceProviderConfigResourceManager();
-
-            SCIMResponse scimResponse = serviceProviderConfigResourceManager.get(null, null, null, null);
-            // needs to check the code of the response and return 200 0k or other error codes
-            // appropriately.
-            return SupportUtils.buildResponse(scimResponse);
-
-        } catch (CharonException e) {
-            return handleCharonException(e,encoder);
-        }
+        SCIMResponse scimResponse = serviceProviderConfigResourceManager.get(null, null, null, null);
+        // needs to check the code of the response and return 200 0k or other error codes
+        // appropriately.
+        return SupportUtils.buildResponse(scimResponse);
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -18,13 +18,10 @@
 
 package org.wso2.carbon.identity.scim2.provider.resources;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.jaxrs.designator.PATCH;
 import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
-import org.wso2.charon3.core.encoder.JSONEncoder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.FormatNotSupportedException;
 import org.wso2.charon3.core.extensions.UserManager;
@@ -38,7 +35,6 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 public class UserResource extends AbstractResource {
-    private static final Log logger = LogFactory.getLog(UserResource.class);
 
     @GET
     @Path("{id}")
@@ -49,16 +45,11 @@ public class UserResource extends AbstractResource {
                             @QueryParam(SCIMProviderConstants.ATTRIBUTES) String attribute,
                             @QueryParam(SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String  excludedAttributes) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             if(!isValidOutputFormat(outputFormat)){
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -72,7 +63,7 @@ public class UserResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e,encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -86,12 +77,7 @@ public class UserResource extends AbstractResource {
                                @QueryParam(SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String  excludedAttributes,
                                String resourceString) {
 
-
-        JSONEncoder encoder = null;
         try {
-            // obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE
@@ -108,8 +94,6 @@ public class UserResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -123,7 +107,7 @@ public class UserResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -135,10 +119,7 @@ public class UserResource extends AbstractResource {
                                @HeaderParam(SCIMProviderConstants.AUTHORIZATION) String authorizationHeader,
                                @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String format) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // defaults to application/scim+json.
             if (format == null) {
                 format = SCIMProviderConstants.APPLICATION_SCIM_JSON;
@@ -147,8 +128,6 @@ public class UserResource extends AbstractResource {
                 String error = format + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -162,7 +141,7 @@ public class UserResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -181,10 +160,7 @@ public class UserResource extends AbstractResource {
                             @QueryParam (SCIMProviderConstants.SORT_ORDER) String sortOrder,
                             @QueryParam (SCIMProviderConstants.DOMAIN) String domainName) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // defaults to application/scim+json.
             if (format == null) {
                 format = SCIMProviderConstants.APPLICATION_SCIM_JSON;
@@ -193,8 +169,6 @@ public class UserResource extends AbstractResource {
                 String error = format + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -209,7 +183,7 @@ public class UserResource extends AbstractResource {
 
             return SupportUtils.buildResponse(scimResponse);
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -223,10 +197,7 @@ public class UserResource extends AbstractResource {
                                    @HeaderParam(SCIMProviderConstants.ACCEPT_HEADER) String outputFormat,
                                    String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE
@@ -243,8 +214,6 @@ public class UserResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -259,7 +228,7 @@ public class UserResource extends AbstractResource {
             return SupportUtils.buildResponse(scimResponse);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -275,11 +244,7 @@ public class UserResource extends AbstractResource {
                                @QueryParam (SCIMProviderConstants.EXCLUDE_ATTRIBUTES) String excludedAttributes,
                                String resourceString) {
 
-        JSONEncoder encoder = null;
         try {
-            // obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE
@@ -296,8 +261,6 @@ public class UserResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -311,7 +274,7 @@ public class UserResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }
@@ -328,11 +291,7 @@ public class UserResource extends AbstractResource {
                               String resourceString) {
 
 
-        JSONEncoder encoder = null;
         try {
-            // obtain default charon manager
-            IdentitySCIMManager identitySCIMManager = IdentitySCIMManager.getInstance();
-
             // content-type header is compulsory in post request.
             if (inputFormat == null) {
                 String error = SCIMProviderConstants.CONTENT_TYPE
@@ -349,8 +308,6 @@ public class UserResource extends AbstractResource {
                 String error = outputFormat + " is not supported.";
                 throw  new FormatNotSupportedException(error);
             }
-            // obtain the encoder at this layer in case exceptions needs to be encoded.
-            encoder = identitySCIMManager.getEncoder();
 
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
@@ -364,7 +321,7 @@ public class UserResource extends AbstractResource {
             return SupportUtils.buildResponse(response);
 
         } catch (CharonException e) {
-            return handleCharonException(e, encoder);
+            return handleCharonException(e);
         } catch (FormatNotSupportedException e) {
             return handleFormatNotSupportedException(e);
         }


### PR DESCRIPTION
In the AbstractResource.handleCharonException method, decoder is a parameter that is never used. It is overwrite by a default value but not use nonetheless. It seems to be dead code.
If you remove this parameter and update all child resources, this makes some other variables unused in cascade (usually JSONEncoder and IdentitySCIMManager) and make some catch block unreachable (due to IdentitySCIMManager.getInstance removal).