### PR TITLE
Not throwing an error when iterating though the userstores

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1361,9 +1361,13 @@ public class SCIMUserManager implements UserManager {
             }
 
             // Filter users for given condition and domain.
-            Set<org.wso2.carbon.user.core.common.User> coreUsers =
-                    filterUsernames(condition, offset, limit, sortBy, sortOrder, userStoreDomainName);
-
+            Set<org.wso2.carbon.user.core.common.User> coreUsers;
+            try {
+                coreUsers = filterUsernames(condition, offset, limit, sortBy, sortOrder, userStoreDomainName);
+            } catch (CharonException e) {
+                log.error("Error occurred while getting the users list for domain: " + userStoreDomainName, e);
+                continue;
+            }
             // Calculating new offset and limit parameters.
             int numberOfFilteredUsers = coreUsers.size();
             if (numberOfFilteredUsers <= 0 && offset > 1) {


### PR DESCRIPTION
Resolve https://github.com/wso2/product-is/issues/9907

### Approach
Not throwing an error when iterating through the user stores. Therefore when an error occurred in one user store, the user search of other user stores will not get affected due to this.