### PR TITLE
Pagination count config value read from charon-config.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
@@ -191,6 +191,8 @@ public class IdentitySCIMManager {
             charonConfiguration.setFilterSupport
                     (Boolean.parseBoolean(scimConfigProcessor.getProperty(SCIMCommonConstants.FILTER_SUPPORTED)),
                             Integer.parseInt(scimConfigProcessor.getProperty(SCIMCommonConstants.FILTER_MAX_RESULTS)));
+            charonConfiguration.setCountValueForPagination
+                    (Integer.parseInt(scimConfigProcessor.getProperty(SCIMCommonConstants.PAGINATION_DEFAULT_COUNT)));
 
             ArrayList<Object[]> schemaList = new ArrayList<>();
             for (AuthenticationSchema authenticationSchema : scimConfigProcessor.getAuthenticationSchemas()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -68,6 +68,7 @@ public class SCIMCommonConstants {
     public static final String BULK_MAX_PAYLOAD_SIZE = "bulk-maxPayloadSize";
     public static final String FILTER_MAX_RESULTS = "filter-maxResults";
     public static final String ENTERPRISE_USER_EXTENSION_ENABLED = "user-schema-extension-enabled";
+    public static final String PAGINATION_DEFAULT_COUNT = "pagination-default-count";
 
     public static final java.lang.String ASK_PASSWORD_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword";
     public static final java.lang.String VERIFY_EMAIL_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail";


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9859

## Approach
> The SCIM2 `.search` request fails for all (Users, Groups, Roles) endpoints when no count attribute is declared in the request body. Ideally, when the count attribute is not specified, the default pagination value must be used when returning results. The `pagination-default-count` was not being read properly from the `charon-config.xml` file. This PR adds the relevant constants needed and adds the value to the config object.

## Related PRs
> Merge with https://github.com/wso2/charon/pull/294