### PR TITLE
[public]Handle username validation with case sensitivity of the userstores

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -828,8 +828,14 @@ public class SCIMUserManager implements UserManager {
                             .addDomainToName(UserCoreUtil.removeDomainFromName(user.getUserName()),
                                     getUserStoreDomainFromSP()));
                 }
+                String username = user.getUsername();
+                String oldUsername = oldUser.getUsername();
+                if (!IdentityUtil.isUserStoreInUsernameCaseSensitive(oldUser.getUsername())) {
+                    username = username.toLowerCase();
+                    oldUsername = oldUsername.toLowerCase();
+                }
                 // This is handled here as the IS is still not capable of updating the username via SCIM.
-                if (!StringUtils.equals(user.getUserName(), oldUser.getUserName())) {
+                if (!StringUtils.equals(username, oldUsername)) {
                     if (log.isDebugEnabled()) {
                         log.debug("Failing the request as attempting to modify username. Old username: "
                                 + oldUser.getUserName() + ", new username: " + user.getUserName());

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -646,6 +646,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, tenantDomain));
         doReturn(oldUser).when(scimUserManager).getUser(anyString(), anyMap());
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 
         boolean hasExpectedBehaviour = false;
         try {


### PR DESCRIPTION
# Purpose
> Handle the username validation by checking the userstore case sensitivity in SCIM user update.
> Fixed a test case.
> Fixes : wso2/product-is#9854

# Related PRs
> Please merge this PR after https://github.com/wso2/carbon-kernel/pull/2829