### PR TITLE
Add claim to store verifyMobile claim used to enable mobile verification

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -600,6 +600,21 @@
 "referenceTypes":[]
 },
 {
+"attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile",
+"attributeName":"verifyMobile",
+"dataType":"boolean",
+"multiValued":"false",
+"description":"Enable mobile verification during mobile number update.",
+"required":"false",
+"caseExact":"false",
+"mutability":"readwrite",
+"returned":"default",
+"uniqueness":"none",
+"subAttributes":"null",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "attributeName":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "dataType":"complex",
@@ -610,7 +625,7 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword",
+"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }


### PR DESCRIPTION
This PR introduces a new claim 'verifyMobile' to the enterprise schema extension.

Part of the fix for : https://github.com/wso2/product-is/issues/10358