### PR TITLE
Sub attribute names made unique in the scim2-schema-extension.config

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -1,7 +1,7 @@
 [
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName",
-"attributeName":"displayName",
+"attributeName":"manager.displayName",
 "dataType":"string",
 "multiValued":"false",
 "description":"The displayName of the User's manager.",
@@ -16,7 +16,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref",
-"attributeName":"$ref",
+"attributeName":"manager.$ref",
 "dataType":"reference",
 "multiValued":"false",
 "description":"The URI of the SCIM resource representing the User's manager.",
@@ -31,7 +31,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value",
-"attributeName":"value",
+"attributeName":"manager.value",
 "dataType":"string",
 "multiValued":"false",
 "description":"The id of the SCIM resource representing the User's manager.",
@@ -55,7 +55,7 @@
 "mutability":"readwrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"value $ref displayName",
+"subAttributes":"manager.value manager.$ref manager.displayName",
 "canonicalValues":[],
 "referenceTypes":[]
 },
@@ -166,7 +166,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value",
-"attributeName":"value",
+"attributeName":"pendingEmails.value",
 "dataType":"string",
 "multiValued":"false",
 "description":"Store email to be updated as a temporary claim till email verification happens.",
@@ -190,7 +190,7 @@
 "mutability":"readOnly",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"value",
+"subAttributes":"pendingEmails.value",
 "canonicalValues":[],
 "referenceTypes":[]
 },


### PR DESCRIPTION
#### Purpose
> Resolves https://github.com/wso2/product-is/issues/9548

#### Approach
> The `attributeName` is used as the key when building the extension config map. This causes the configs having the same `attributeName` to get overwritten by the last config being read. Making the attribute names unique resolves this issue. This would not cause an issue when the schema is being read as the `attributeURI` is used to pull configs from the schema.