### PR TITLE
Revert "Sub attribute names made unique in the scim2-schema-extension.config"

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -1,7 +1,7 @@
 [
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName",
-"attributeName":"manager.displayName",
+"attributeName":"displayName",
 "dataType":"string",
 "multiValued":"false",
 "description":"The displayName of the User's manager.",
@@ -16,7 +16,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref",
-"attributeName":"manager.$ref",
+"attributeName":"$ref",
 "dataType":"reference",
 "multiValued":"false",
 "description":"The URI of the SCIM resource representing the User's manager.",
@@ -31,7 +31,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value",
-"attributeName":"manager.value",
+"attributeName":"value",
 "dataType":"string",
 "multiValued":"false",
 "description":"The id of the SCIM resource representing the User's manager.",
@@ -55,7 +55,7 @@
 "mutability":"readwrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"manager.value manager.$ref manager.displayName",
+"subAttributes":"value $ref displayName",
 "canonicalValues":[],
 "referenceTypes":[]
 },
@@ -166,7 +166,7 @@
 },
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value",
-"attributeName":"pendingEmails.value",
+"attributeName":"value",
 "dataType":"string",
 "multiValued":"false",
 "description":"Store email to be updated as a temporary claim till email verification happens.",
@@ -190,7 +190,7 @@
 "mutability":"readOnly",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"pendingEmails.value",
+"subAttributes":"value",
 "canonicalValues":[],
 "referenceTypes":[]
 },


### PR DESCRIPTION
Reverting this as this would change the format of the request payloads.