### PR TITLE
Propagate User Store Errors Through SCIM API

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -184,7 +184,6 @@
 
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
-                            org.apache.commons.httpclient.*; version="${commons-httpclient.wso2.osgi.version}",
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
@@ -199,7 +198,6 @@
 
                             org.wso2.carbon.identity.base; version="${identity.framework.version}",
                             org.wso2.carbon.identity.core.*; version="${identity.framework.version}",
-                            org.wso2.carbon.identity.provisioning.*; version="${identity.framework.version}",
                             org.wso2.carbon.identity.claim.metadata.mgt.*; version="${identity.framework.version}",
                             org.wso2.carbon.identity.role.mgt.core.*; version="${identity.framework.version}",
                             org.wso2.carbon.user.mgt.*;version="${identity.framework.version}"

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/extenstion/SCIMUserStoreErrorResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/extenstion/SCIMUserStoreErrorResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.extenstion;
+
+import org.wso2.carbon.user.api.UserStoreException;
+
+/**
+ * This extension point can be used to define how internal errors should be mapped to relevant API errors.
+ */
+public interface SCIMUserStoreErrorResolver {
+
+    /**
+     * Resolve a given user store exception to a proper Charon Exception with status code. implementation should
+     * return null if the implementing class does not know or does not wish to translate the exception, so that
+     * any other translator can get chance to do the resolving. The default resolver will resolve an exception
+     * ultimately if no custom resolver resolves it.
+     *
+     * @param e User store exception thrown.
+     * @return Resolved charon exception with proper http status code, NULL if the impl doesn't know how to resolve.
+     */
+    SCIMUserStoreException resolve(UserStoreException e);
+
+    /**
+     * Provide an order value for the implementation. Should be a positive integer.
+     * implementation with the highest order get picked first.
+     *
+     * @return Order of the impl.
+     */
+    int getOrder();
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/extenstion/SCIMUserStoreException.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/extenstion/SCIMUserStoreException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.extenstion;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * This exception is used in the SCIM User Store Error Resolver extension point, to return any internal errors to
+ * the SCIM API layer. Since SCIM API returns only an error message (detail) and http error code, this
+ * exception is designed to accept only those two.
+ */
+public class SCIMUserStoreException extends IdentityException {
+
+    private static final long serialVersionUID = 3477076930782578976L;
+    private final int httpStatusCode;
+
+    public SCIMUserStoreException(String errorMessage, int httpStatusCode) {
+
+        super(errorMessage);
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public int getHttpStatusCode() {
+
+        return httpStatusCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
+import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
+import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreException;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
+
+/**
+ * Default implementation of SCIMUserStoreErrorResolver. Should be used to resolve errors thrown by default
+ * user store managers packed in the product.
+ */
+public class DefaultSCIMUserStoreErrorResolver implements SCIMUserStoreErrorResolver {
+
+    private static final String ERROR_CODE_USER_NOT_FOUND = "30007";
+
+    @Override
+    public SCIMUserStoreException resolve(UserStoreException e) {
+
+        if (e.getMessage().contains(ERROR_CODE_USER_NOT_FOUND)) {
+            String msg = e.getMessage().substring(e.getMessage().indexOf(":") + 1).trim();
+            return new SCIMUserStoreException(msg, HttpStatus.SC_NOT_FOUND);
+        } else if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
+                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USERNAME_CANNOT_BE_EMPTY.getCode(),
+                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
+                return new SCIMUserStoreException("Unable to create the user. Username is a mandatory field.",
+                        HttpStatus.SC_BAD_REQUEST);
+        }
+        return null;
+    }
+
+    @Override
+    public int getOrder() {
+
+        return 0;
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -32,6 +32,8 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
+import org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.listener.SCIMTenantMgtListener;
 import org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListener;
 import org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtil;
@@ -92,6 +94,10 @@ public class SCIMCommonComponent {
             SCIMTenantMgtListener scimTenantMgtListener = new SCIMTenantMgtListener();
             tenantMgtListenerServiceReg = ctx.getBundleContext().registerService(TenantMgtListener.class,
                     scimTenantMgtListener, null);
+
+            // Register default implementation of SCIMUserStoreErrorResolver
+            ctx.getBundleContext().registerService(SCIMUserStoreErrorResolver.class.getName(),
+                    new DefaultSCIMUserStoreErrorResolver(), null);
 
             //Update super tenant user/group attributes.
             AdminAttributeUtil.updateAdminUser(MultitenantConstants.SUPER_TENANT_ID, true);
@@ -186,7 +192,7 @@ public class SCIMCommonComponent {
      */
     @Reference(
             name = "claimManagementService",
-            service = org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService .class,
+            service = org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService.class,
             cardinality = ReferenceCardinality.MANDATORY,
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetClaimMetadataManagementService")
@@ -237,6 +243,27 @@ public class SCIMCommonComponent {
             logger.debug("RoleManagementService unset in SCIMCommonComponent bundle.");
         }
         SCIMCommonComponentHolder.setRoleManagementService(null);
+    }
+
+    /**
+     * Set SCIMUserStoreErrorResolver implementation
+     *
+     * @param scimUserStoreErrorResolver SCIMUserStoreErrorResolver
+     */
+    @Reference(
+            name = "scim.user.store.error.resolver",
+            service = org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetScimUserStoreErrorResolver")
+    protected void setScimUserStoreErrorResolver(SCIMUserStoreErrorResolver scimUserStoreErrorResolver) {
+
+        SCIMCommonComponentHolder.addScimUserStoreErrorResolver(scimUserStoreErrorResolver);
+    }
+
+    protected void unsetScimUserStoreErrorResolver(SCIMUserStoreErrorResolver scimUserStoreErrorResolver) {
+
+        SCIMCommonComponentHolder.removeScimUserStoreErrorResolver(scimUserStoreErrorResolver);
     }
 
     @Deactivate

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
@@ -19,9 +19,14 @@
 package org.wso2.carbon.identity.scim2.common.internal;
 
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * SCIM service holder class.
@@ -33,6 +38,7 @@ public class SCIMCommonComponentHolder {
     private static ClaimMetadataManagementService claimManagementService;
     private static RolePermissionManagementService rolePermissionManagementService;
     private static RoleManagementService roleManagementService;
+    private static final List<SCIMUserStoreErrorResolver> scimUserStoreErrorResolvers = new ArrayList<>();
 
     /**
      * Get realm service.
@@ -112,5 +118,22 @@ public class SCIMCommonComponentHolder {
     public static RoleManagementService getRoleManagementService() {
 
         return roleManagementService;
+    }
+
+    public static List<SCIMUserStoreErrorResolver> getScimUserStoreErrorResolverList() {
+
+        return scimUserStoreErrorResolvers;
+    }
+
+    public static void addScimUserStoreErrorResolver(SCIMUserStoreErrorResolver scimUserStoreErrorResolver) {
+
+        scimUserStoreErrorResolvers.add(scimUserStoreErrorResolver);
+        scimUserStoreErrorResolvers.sort(Comparator.comparing(SCIMUserStoreErrorResolver::getOrder).reversed());
+    }
+
+    public static void removeScimUserStoreErrorResolver(SCIMUserStoreErrorResolver scimUserStoreErrorResolver) {
+
+        scimUserStoreErrorResolvers.remove(scimUserStoreErrorResolver);
+        scimUserStoreErrorResolvers.sort(Comparator.comparing(SCIMUserStoreErrorResolver::getOrder).reversed());
     }
 }


### PR DESCRIPTION
### Purpose
Resolve wso2/product-is#10468

### Approach
- A new extension point has been introduced in the SCIM component to provide proper HTTP error code mapping. Developers can use this extension point to define specific errors and matching error codes to be sent in the API response when they develop their own custom user store managers.
- We register a default implementation that can be used to resolve errors of the default user store managers of the product.
- The extension point requires to define an order for each implementation, which will be used to loop if more than one registered implementations are found. The impl with the highest order value will be executed first. The default implementation has the order value 0.

Note: This change will not change any error messages or exceptions of the current SCIM implementation. We only add the capability to change them. We need to fully implement the DefaultSCIMUserStoreErrorResolver to send proper error messages through the SCIM API.
