### PR TITLE
Introduce primary login identifire for scim operations

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -249,9 +249,21 @@ public class SCIMUserManager implements UserManager {
             // human readable username.
             if (isLoginIdentifiresEnabled() && StringUtils.isNotEmpty(getPrimaryLoginIdentifireClaim())) {
                 String immutableUserIdentifier = getUniqueUserID();
-                claimsInLocalDialect.put(getPrimaryLoginIdentifireClaim(), user.getUserName());
-                coreUser = carbonUM.addUserWithID(immutableUserIdentifier,
-                        user.getPassword(), null, claimsInLocalDialect, null);
+                if (claimsInLocalDialect.containsKey(getPrimaryLoginIdentifireClaim())) {
+                    if (claimsInLocalDialect.get(getPrimaryLoginIdentifireClaim()).equals(user.getUserName())) {
+
+                        coreUser = carbonUM.addUserWithID(immutableUserIdentifier,
+                                user.getPassword(), null, claimsInLocalDialect, null);
+                    } else {
+                        throw new BadRequestException("The claim value for " + getPrimaryLoginIdentifireClaim() + " " +
+                                "and username should be same.");
+                    }
+                } else {
+
+                    claimsInLocalDialect.put(getPrimaryLoginIdentifireClaim(), user.getUserName());
+                    coreUser = carbonUM.addUserWithID(immutableUserIdentifier,
+                            user.getPassword(), null, claimsInLocalDialect, null);
+                }
             } else {
                 // Create the user in the user core.
                 coreUser = carbonUM.addUserWithID(user.getUserName(),

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -93,5 +93,10 @@ public class SCIMCommonConstants {
 
     public static final String URL_SEPERATOR = "/";
     public static final String TENANT_URL_SEPERATOR = "/t/";
+
+    //Configuration for primary login identifiers
+    public static final String ENABLE_LOGIN_IDENTIFIRES = "LoginIdentiFires.Enable";
+    public static final String PRIMARY_LOGIN_IDENTIFIRE_CLAIM = "LoginIdentiFires.PrimaryLoginIdentifire";
+    public static final boolean DEFAULT_ENABLE_LOGIN_IDENTIFIRES = false;
 }
 


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/10631
In SCIM 2.0 get user method, currently we are setting org.wso2.carbon.user.core.common.User.getUserName() for the urn:ietf:params:scim:schemas:core:2.0:User:userName attribute.

If we have a  requirement to get the value in another claim to the urn:ietf:params:scim:schemas:core:2.0:User:userName in scim response, that is not possible.
If we want to rename the username, also having a sperate claim to store the human readable username is helpful.
So, when creating the user, we should generate a unique user id and pass it as the immutable identifire to the user core, while passing the configurable claim with the human readable username.

We can define, a configuration as a primary login identifier, and give  a preferred claim for that.
Ex:
`<LoginIdentiFires>
<Enable>true</Enable>
<PrimaryLoginIdentifire>http://wso2.org/claims/userType</PrimaryLoginIdentifire>
</LoginIdentiFires>`


In the scim component, check for this configuration, and if available, generate a UUID and provide it as the immutable username and pass this claim in the claims set.

In the get user part of the scim component, when the above configuration is enabled, the human readable scim username can be set by retrieving the value of the above defined claim.