### PR TITLE
Gracefully handle invalid domain name while user filtering

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpStatus;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreException;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 
 /**
@@ -44,6 +45,10 @@ public class DefaultSCIMUserStoreErrorResolver implements SCIMUserStoreErrorReso
                             ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
                 return new SCIMUserStoreException("Unable to create the user. Username is a mandatory field.",
                         HttpStatus.SC_BAD_REQUEST);
+        } else if (e instanceof org.wso2.carbon.user.core.UserStoreClientException && UserCoreErrorConstants
+                .ErrorMessages.ERROR_CODE_INVALID_DOMAIN_NAME.getCode().equals(((UserStoreClientException) e)
+                        .getErrorCode())) {
+            return new SCIMUserStoreException("Unable to proceed. Invalid domain name.", HttpStatus.SC_BAD_REQUEST);
         }
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.2.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.6.1</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m3</carbon.kernel.version>
         <identity.framework.version>5.18.25</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
:heart_eyes: Fixes https://github.com/wso2/product-is/issues/10611.
:grimacing: Depends on https://github.com/wso2/carbon-kernel/pull/2859.

:speech_balloon: While SCIM user filtering, the underneath user store manager throws a client exception with a specific error code. This PR modifies the code to read that error code and gracefully handle the error.

:raising_hand: Do not merge until,
- [x]  Dependant kernel PR is merged
- [x]   A new kernel with the merged fix is released