### PR TITLE
Use method level variable to iterate through userstores

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1720,16 +1720,17 @@ public class SCIMUserManager implements UserManager {
             } else {
                 int totalUserCount = 0;
                 // If pagination and domain name are not given, then perform filtering on all available user stores.
-                while (carbonUM != null) {
+                AbstractUserStoreManager userStoreManager = carbonUM;
+                while (userStoreManager != null) {
                     // If carbonUM is not an instance of Abstract User Store Manger we can't get the domain name.
-                    if (carbonUM instanceof AbstractUserStoreManager) {
-                        domainName = carbonUM.getRealmConfiguration().getUserStoreProperty("DomainName");
+                    if (userStoreManager instanceof AbstractUserStoreManager) {
+                        domainName = userStoreManager.getRealmConfiguration().getUserStoreProperty("DomainName");
                         users = getFilteredUsersFromMultiAttributeFiltering(node, offset, maxLimit,
                                 sortBy, sortOrder, domainName);
                         totalUserCount += users.size();
                         filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
                     }
-                    carbonUM = (AbstractUserStoreManager) carbonUM.getSecondaryUserStoreManager();
+                    userStoreManager = (AbstractUserStoreManager) userStoreManager.getSecondaryUserStoreManager();
                 }
                 //set the total results
                 filteredUsers.set(0, totalUserCount);

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.2.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.6.1</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m3</carbon.kernel.version>
         <identity.framework.version>5.18.25</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
:heart_eyes: Fixes https://github.com/wso2/product-is/issues/10509.

:speech_balloon: While Iterating user stores to list users, the `carbonUM` variable value gets reassigned with the next user store manager. However, this is a class-level variable that should not be modified because if this object instance is reused, that can cause unexpected behavioral changes. This PR instruct the code to use a method-level variable.

🙋 Do not merge until,

- [x]  Dependant kernel PR is merged
- [x]  A new kernel with the merged fix is released