### PR TITLE
Improve SCIMTenantMgtListener with disable capability

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMTenantMgtListener.java
@@ -34,8 +34,12 @@ public class SCIMTenantMgtListener extends AbstractIdentityTenantMgtListener {
     @Override
     public void onTenantInitialActivation(int tenantId) throws StratosException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
+        boolean isEnabled = isEnable();
+        if (!isEnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
+            }
+            return;
         }
         //Update admin user attributes.
         AdminAttributeUtil.updateAdminUser(tenantId, false);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMTenantMgtListener.java
@@ -37,9 +37,12 @@ public class SCIMTenantMgtListener extends AbstractIdentityTenantMgtListener {
         boolean isEnabled = isEnable();
         if (!isEnabled) {
             if (log.isDebugEnabled()) {
-                log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
+                log.debug("SCIMTenantMgtListener is disabled");
             }
             return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("SCIMTenantMgtListener is fired for Tenant ID : " + tenantId);
         }
         //Update admin user attributes.
         AdminAttributeUtil.updateAdminUser(tenantId, false);


### PR DESCRIPTION
## Goals
In the current implementation of the SCIMTenantMgtListener, we cannot disable the handler using configurations. With the improvement in this PR, the product admins can disable the lister if needed.