### PR TITLE
Remove member attribute from the group response

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2187,6 +2187,7 @@ public class SCIMUserManager implements UserManager {
                 SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(carbonUM.getTenantId());
                 scimGroupHandler.createSCIMAttributes(group);
                 carbonUM.addRoleWithID(group.getDisplayName(), null, null, false);
+                group.getAttributeList().remove(SCIMConstants.GroupSchemaConstants.MEMBERS);
                 if (log.isDebugEnabled()) {
                     log.debug("Group: " + group.getDisplayName() + " is created through SCIM.");
                 }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9619
If the member attribute doesn't have the value then the member will not be added to the group endpoint hence removing it from the response.
