### PR TITLE
Construct SCIMObject skipping the invalid attributes

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
@@ -301,19 +301,25 @@ public class AttributeMapper {
                 }
                 attributeNames = tempAttributeNames.toArray(attributeNames);
             }
+            try {
+                if (attributeNames.length == 1) {
 
-            if (attributeNames.length == 1) {
+                    constructSCIMObjectFromAttributesOfLevelOne(attributeEntry, scimObject, attributeNames,
+                            scimObjectType);
 
-                constructSCIMObjectFromAttributesOfLevelOne(attributeEntry, scimObject, attributeNames, scimObjectType);
+                } else if (attributeNames.length == 2) {
 
-            } else if (attributeNames.length == 2) {
+                    constructSCIMObjectFromAttributesOfLevelTwo(attributeEntry, scimObject, attributeNames,
+                            scimObjectType);
 
-                constructSCIMObjectFromAttributesOfLevelTwo(attributeEntry, scimObject, attributeNames, scimObjectType);
+                } else if (attributeNames.length == 3) {
 
-            } else if (attributeNames.length == 3) {
-
-                constructSCIMObjectFromAttributesOfLevelThree(attributeEntry, scimObject,
-                        attributeNames, scimObjectType);
+                    constructSCIMObjectFromAttributesOfLevelThree(attributeEntry, scimObject,
+                            attributeNames, scimObjectType);
+                }
+            } catch (CharonException e) {
+                log.error(e);
+                continue;
             }
         }
         return scimObject;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
@@ -319,7 +319,6 @@ public class AttributeMapper {
                 }
             } catch (CharonException e) {
                 log.error(e);
-                continue;
             }
         }
         return scimObject;


### PR DESCRIPTION
When converting the User core object to SCIMObject, skip the invalid attributes.
Resolves: https://github.com/wso2-enterprise/asgardeo-product/issues/1679

### When to merge

- [ ] After merging https://github.com/wso2/charon/pull/305
- [ ] Bump Charon version in this repo
