### PR TITLE
Regex validation for date of birth claim value

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -21,12 +21,16 @@ package org.wso2.carbon.identity.scim2.common.listener;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
+import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -41,13 +45,14 @@ import org.wso2.charon3.core.utils.AttributeUtil;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.TIME_SUFFIX;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 
 /**
  * This is to perform SCIM related operation on User Operations.
@@ -76,6 +81,8 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
                 return true;
             }
+            // Validate dob value against the regex.
+            validateDateOfBirthClaimValue(claims, userStoreManager);
             this.populateSCIMAttributes(userID, claims);
             return true;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -170,12 +177,36 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI);
         claims.put(modifiedLocalClaimUri, lastModifiedDate);
 
-        // Change dateOfBirth value to datetime format if dob is in yyyy-mm-dd format.
-        if (claims.containsKey(DATE_OF_BIRTH_LOCAL_CLAIM) &&
-                claims.get(DATE_OF_BIRTH_LOCAL_CLAIM).matches(DATE_OF_BIRTH_REGEX)) {
-            claims.put(DATE_OF_BIRTH_LOCAL_CLAIM, claims.get(DATE_OF_BIRTH_LOCAL_CLAIM) + TIME_SUFFIX);
-        }
+        // Validate dob value against the regex.
+        validateDateOfBirthClaimValue(claims, userStoreManager);
         return true;
+    }
+
+    private void validateDateOfBirthClaimValue(Map<String, String> claims, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        String dateOfBirthRegex = null;
+        try {
+            List<LocalClaim> localClaims =
+                    SCIMCommonComponentHolder.getClaimManagementService().getLocalClaims(tenantDomain);
+            for (LocalClaim localClaim : localClaims) {
+                if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, localClaim.getClaimURI())) {
+                    dateOfBirthRegex = localClaim.getClaimProperties().get(PROP_REG_EX);
+                }
+            }
+        } catch (ClaimMetadataException e) {
+            log.error("Error while retrieving local claim meta data.");
+        }
+        if (StringUtils.isEmpty(dateOfBirthRegex)) {
+            dateOfBirthRegex = DATE_OF_BIRTH_REGEX;
+        }
+        if (claims.containsKey(DATE_OF_BIRTH_LOCAL_CLAIM)) {
+            if (StringUtils.isNotEmpty(claims.get(DATE_OF_BIRTH_LOCAL_CLAIM)) &&
+                    !claims.get(DATE_OF_BIRTH_LOCAL_CLAIM).matches(dateOfBirthRegex)) {
+                throw new UserStoreException("Date of Birth doesn't match with the regex: " + dateOfBirthRegex);
+            }
+        }
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -174,26 +174,31 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, claimURI)) {
             String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-            String dateOfBirthRegex = null;
-            try {
-                List<LocalClaim> localClaims =
-                        SCIMCommonComponentHolder.getClaimManagementService().getLocalClaims(tenantDomain);
-                for (LocalClaim localClaim : localClaims) {
-                    if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, localClaim.getClaimURI())) {
-                        dateOfBirthRegex = localClaim.getClaimProperties().get(PROP_REG_EX);
-                    }
-                }
-            } catch (ClaimMetadataException e) {
-                log.error("Error while retrieving local claim meta data.");
-            }
+            String dateOfBirthRegex = getDateOfBirthRegex(tenantDomain);
             if (StringUtils.isEmpty(dateOfBirthRegex)) {
                 dateOfBirthRegex = DATE_OF_BIRTH_REGEX;
             }
-
             if (StringUtils.isNotEmpty(claimValue) && !claimValue.matches(dateOfBirthRegex)) {
                 throw new UserStoreException("Date of Birth doesn't match with the regex: " + dateOfBirthRegex);
             }
         }
+    }
+
+    private String getDateOfBirthRegex(String tenantDomain) {
+
+        String dateOfBirthRegex = null;
+        try {
+            List<LocalClaim> localClaims =
+                    SCIMCommonComponentHolder.getClaimManagementService().getLocalClaims(tenantDomain);
+            for (LocalClaim localClaim : localClaims) {
+                if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, localClaim.getClaimURI())) {
+                    dateOfBirthRegex = localClaim.getClaimProperties().get(PROP_REG_EX);
+                }
+            }
+        } catch (ClaimMetadataException e) {
+            log.error("Error while retrieving local claim meta data.");
+        }
+        return dateOfBirthRegex;
     }
 
     @Override
@@ -223,18 +228,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         if (claims.containsKey(DATE_OF_BIRTH_LOCAL_CLAIM)) {
             String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-            String dateOfBirthRegex = null;
-            try {
-                List<LocalClaim> localClaims =
-                        SCIMCommonComponentHolder.getClaimManagementService().getLocalClaims(tenantDomain);
-                for (LocalClaim localClaim : localClaims) {
-                    if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, localClaim.getClaimURI())) {
-                        dateOfBirthRegex = localClaim.getClaimProperties().get(PROP_REG_EX);
-                    }
-                }
-            } catch (ClaimMetadataException e) {
-                log.error("Error while retrieving local claim meta data.");
-            }
+            String dateOfBirthRegex = getDateOfBirthRegex(tenantDomain);
             if (StringUtils.isEmpty(dateOfBirthRegex)) {
                 dateOfBirthRegex = DATE_OF_BIRTH_REGEX;
             }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -45,6 +45,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.TIME_SUFFIX;
+
 /**
  * This is to perform SCIM related operation on User Operations.
  * For eg: when a user is created through UserAdmin API, we need to set some SCIM specific properties
@@ -165,6 +169,12 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         Map<String, String> scimToLocalMappings = SCIMCommonUtils.getSCIMtoLocalMappings();
         String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI);
         claims.put(modifiedLocalClaimUri, lastModifiedDate);
+
+        // Change dateOfBirth value to datetime format if dob is in yyyy-mm-dd format.
+        if (claims.containsKey(DATE_OF_BIRTH_LOCAL_CLAIM) &&
+                claims.get(DATE_OF_BIRTH_LOCAL_CLAIM).matches(DATE_OF_BIRTH_REGEX)) {
+            claims.put(DATE_OF_BIRTH_LOCAL_CLAIM, claims.get(DATE_OF_BIRTH_LOCAL_CLAIM) + TIME_SUFFIX);
+        }
         return true;
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -185,23 +185,24 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
     private void validateDateOfBirthClaimValue(Map<String, String> claims, UserStoreManager userStoreManager)
             throws UserStoreException {
 
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        String dateOfBirthRegex = null;
-        try {
-            List<LocalClaim> localClaims =
-                    SCIMCommonComponentHolder.getClaimManagementService().getLocalClaims(tenantDomain);
-            for (LocalClaim localClaim : localClaims) {
-                if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, localClaim.getClaimURI())) {
-                    dateOfBirthRegex = localClaim.getClaimProperties().get(PROP_REG_EX);
-                }
-            }
-        } catch (ClaimMetadataException e) {
-            log.error("Error while retrieving local claim meta data.");
-        }
-        if (StringUtils.isEmpty(dateOfBirthRegex)) {
-            dateOfBirthRegex = DATE_OF_BIRTH_REGEX;
-        }
         if (claims.containsKey(DATE_OF_BIRTH_LOCAL_CLAIM)) {
+            String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+            String dateOfBirthRegex = null;
+            try {
+                List<LocalClaim> localClaims =
+                        SCIMCommonComponentHolder.getClaimManagementService().getLocalClaims(tenantDomain);
+                for (LocalClaim localClaim : localClaims) {
+                    if (StringUtils.equalsIgnoreCase(DATE_OF_BIRTH_LOCAL_CLAIM, localClaim.getClaimURI())) {
+                        dateOfBirthRegex = localClaim.getClaimProperties().get(PROP_REG_EX);
+                    }
+                }
+            } catch (ClaimMetadataException e) {
+                log.error("Error while retrieving local claim meta data.");
+            }
+            if (StringUtils.isEmpty(dateOfBirthRegex)) {
+                dateOfBirthRegex = DATE_OF_BIRTH_REGEX;
+            }
+
             if (StringUtils.isNotEmpty(claims.get(DATE_OF_BIRTH_LOCAL_CLAIM)) &&
                     !claims.get(DATE_OF_BIRTH_LOCAL_CLAIM).matches(dateOfBirthRegex)) {
                 throw new UserStoreException("Date of Birth doesn't match with the regex: " + dateOfBirthRegex);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -100,5 +100,10 @@ public class SCIMCommonConstants {
     public static final String ENABLE_LOGIN_IDENTIFIERS = "LoginIdentifiers.Enable";
     public static final String PRIMARY_LOGIN_IDENTIFIER_CLAIM = "LoginIdentifiers.PrimaryLoginIdentifier";
     public static final boolean DEFAULT_ENABLE_LOGIN_IDENTIFIERS = false;
+
+    // Date of Birth related constants.
+    public static final String DATE_OF_BIRTH_LOCAL_CLAIM = "http://wso2.org/claims/dob";
+    public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
+    public static final String TIME_SUFFIX = "T00:00:00Z";
 }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -103,7 +103,7 @@ public class SCIMCommonConstants {
 
     // Date of Birth related constants.
     public static final String DATE_OF_BIRTH_LOCAL_CLAIM = "http://wso2.org/claims/dob";
+    public static final String PROP_REG_EX = "RegEx";
     public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
-    public static final String TIME_SUFFIX = "T00:00:00Z";
 }
 


### PR DESCRIPTION
## Purpose
When the local claim of dob ("http://wso2.org/claims/dob") is considered as a string in the SCIM schema after https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/330 is merged. 
and currently, there is no regex configured for local dob claim.

Here we validate the dob against the configured regex or the default regex : `^\d{4}-\d{2}-\d{2}$`, in SCIMUserOperationListener 
when adding a user and updating a user

Resolves part of https://github.com/wso2/product-is/issues/11226