### PR TITLE
Change datatype of dateofBirth scim claim

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -527,7 +527,7 @@
 {
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:dateOfBirth",
 "attributeName":"dateOfBirth",
-"dataType":"datetime",
+"dataType":"string",
 "multiValued":"false",
 "description":"Date of birth",
 "required":"false",


### PR DESCRIPTION
Since dateOfBirth is an attribute that takes user input, having datatype as `datetime` affects the UX negatively.
Further SCIM spec doesn't have a data type as `date` only to save dates.
Hence change the data type to `string`. Refer: https://mailarchive.ietf.org/arch/msg/scim/-dh881kMaDBryhDbjAZKknvMy2o/


Resolves part of:https://github.com/wso2-enterprise/asgardeo-product/issues/1679