### PR TITLE
Add ge and le operations for SCIM user filtering

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1933,6 +1933,10 @@ public class SCIMUserManager implements UserManager {
                 conditionOperation = ExpressionOperation.EW.toString();
             } else if (SCIMCommonConstants.CO.equals(operation)) {
                 conditionOperation = ExpressionOperation.CO.toString();
+            } else if (SCIMCommonConstants.GE.equals(operation)) {
+                conditionOperation = ExpressionOperation.GE.toString();
+            } else if (SCIMCommonConstants.LE.equals(operation)) {
+                conditionOperation = ExpressionOperation.LE.toString();
             } else {
                 conditionOperation = operation;
             }
@@ -4185,7 +4189,9 @@ public class SCIMUserManager implements UserManager {
 
         return !filterOperation.equalsIgnoreCase(SCIMCommonConstants.EQ) && !filterOperation
                 .equalsIgnoreCase(SCIMCommonConstants.CO) && !filterOperation.equalsIgnoreCase(SCIMCommonConstants.SW)
-                && !filterOperation.equalsIgnoreCase(SCIMCommonConstants.EW);
+                && !filterOperation.equalsIgnoreCase(SCIMCommonConstants.EW)
+                && !filterOperation.equalsIgnoreCase(SCIMCommonConstants.GE)
+                && !filterOperation.equalsIgnoreCase(SCIMCommonConstants.LE);
     }
 
     private Set<org.wso2.carbon.user.core.common.User> getUserListOfRoles(List<String> roleNames)

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -44,6 +44,8 @@ public class SCIMCommonConstants {
     public static final String CO = "co";
     public static final String SW = "sw";
     public static final String EW = "ew";
+    public static final String GE = "ge";
+    public static final String LE = "le";
 
     public static final String APPLICATION_DOMAIN = "Application";
     public static final String INTERNAL_DOMAIN = "Internal";

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.2.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.6.2-m3</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m7</carbon.kernel.version>
         <identity.framework.version>5.18.25</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/11214
This PR has to be merged only after merging https://github.com/wso2/carbon-kernel/pull/2922

## Purpose
This PR is to add the following operations for SCIM user filtering with LDAP user stores. 
- ge (greater than or equal)
- le (less than or equal)