### PR TITLE
Return userStoreClientException on dob regex validation failure

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -204,7 +204,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                 }
             }
         } catch (ClaimMetadataException e) {
-            log.error("Error while retrieving local claim meta data.");
+            log.error("Error while retrieving local claim meta data.", e);
         }
         return DateOfBirthClaimProperties;
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -105,7 +105,8 @@ public class SCIMCommonConstants {
     public static final String DATE_OF_BIRTH_LOCAL_CLAIM = "http://wso2.org/claims/dob";
     public static final String PROP_REG_EX = "RegEx";
     public static final String PROP_REG_EX_VALIDATION_ERROR = "RegExValidationError";
-    public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR = "Date of Birth is not in the correct format";
+    public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR =
+            "Date of Birth is not in the correct format of YYYY-MM-DD";
     public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
 }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -104,6 +104,8 @@ public class SCIMCommonConstants {
     // Date of Birth related constants.
     public static final String DATE_OF_BIRTH_LOCAL_CLAIM = "http://wso2.org/claims/dob";
     public static final String PROP_REG_EX = "RegEx";
+    public static final String PROP_REG_EX_VALIDATION_ERROR = "RegExValidationError";
+    public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR = "Date of Birth is not in the correct format";
     public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
 }
 


### PR DESCRIPTION
### Purpose
Fixes part of wso2/product-is#11226

If the user added dob is not matching with the configured regex, returns a userStoreClientException.

The admin can configure the regex validation error message under the local claim properties with key = `RegExValidationError` as follows.
![Screenshot from 2021-02-11 20-46-16](https://user-images.githubusercontent.com/25483865/107656524-44d54600-6caa-11eb-8028-e58fc21b5ae2.png)

If this error is configured, the user will be prompted that configured error.

![Screenshot from 2021-02-11 20-24-51](https://user-images.githubusercontent.com/25483865/107656819-8a920e80-6caa-11eb-85ec-afa6ddaa6dfb.png)

Otherwise, the default regex validation error will be shown.


![Screenshot from 2021-02-11 20-22-04](https://user-images.githubusercontent.com/25483865/107656690-6b937c80-6caa-11eb-9839-b41ea9279391.png)


