### PR TITLE
Fix the case insensitivity issue when updating the group name

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3369,7 +3369,7 @@ public class SCIMUserManager implements UserManager {
 
     private boolean isGroupDisplayNameChanged(String oldGroupDisplayName, String newGroupDisplayName) {
 
-        return !oldGroupDisplayName.equalsIgnoreCase(newGroupDisplayName);
+        return !oldGroupDisplayName.equals(newGroupDisplayName);
     }
 
     private org.wso2.carbon.user.core.common.User getUserFromUsername(String username)


### PR DESCRIPTION
## Purpose
When executing a SCIM group update request to update the same group name with case sensitivity(Ex:- update mygroup to MyGroup), it will give a log warn saying "There is no updated field in the group:... " and will not update the group name. That issue will be fixed with this PR. 
Resolves: https://github.com/wso2-enterprise/asgardeo-product/issues/1655