### PR TITLE
Fix the case insensitivity issue when updating the group name

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3168,7 +3168,7 @@ public class SCIMUserManager implements UserManager {
         oldGroupName = SCIMCommonUtils.getGroupNameWithDomain(oldGroupName);
         newGroupName = SCIMCommonUtils.getGroupNameWithDomain(newGroupName);
 
-        if (!StringUtils.equalsIgnoreCase(oldGroupName, newGroupName)) {
+        if (!StringUtils.equals(oldGroupName, newGroupName)) {
             // Update group name in carbon UM.
             carbonUM.updateRoleName(oldGroupName, newGroupName);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.2.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.6.2-m7</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m8</carbon.kernel.version>
         <identity.framework.version>5.18.25</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
**Purpose**
When executing a SCIM group update request to update the same group name with case sensitivity(Ex:- update mygroup to MyGroup), it will give a log warn saying "There is no updated field in the group:... " and will not update the group name. That issue will be fixed with this PR.
Resolves: wso2-enterprise/asgardeo-product#1655
Related PR: https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/338