### PR TITLE
Add systemRoles configuration to identify read only roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,11 +301,11 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.6.2-m9</carbon.kernel.version>
-        <identity.framework.version>5.20.16</identity.framework.version>
+        <identity.framework.version>5.20.33</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>
-        <charon.version>3.3.37</charon.version>
+        <charon.version>3.3.39</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
- Resolves https://github.com/wso2/product-is/issues/11645
- Following configuration can be added to `deployment.toml` in order to enable read-only roles.

```
[system_roles]
read_only_roles = ["role1", "role2", "Administrator"]
```

- If it's defined those roles cannot be deleted, rename or update permissions via role API. Those roles can be identified with the `systemRole` meta attribute in the `GET /Roles` and `GET /Roles/{id}` response as below,

```
{
    "displayName": "Administrator",
    "meta": {
        "systemRole": true,
        "location": "https://localhost:9443/scim2/Roles/04ce8252-5b8a-4f1f-b00c-f889da4d0211"
    },
    "permissions": [
        "/permission/"
    ],
    "schemas": [
        "urn:ietf:params:scim:schemas:extension:2.0:Role"
    ],
    "groups": [
        {
            "display": "PRIMARY/Administrator",
            "value": "609a60fd-1cf8-4968-9cd8-9367d9f8cc41",
            "$ref": "https://localhost:9443/scim2/Groups/609a60fd-1cf8-4968-9cd8-9367d9f8cc41"
        }
    ],
    "id": "04ce8252-5b8a-4f1f-b00c-f889da4d0211",
    "users": [
        {
            "display": "admin@wso2.com",
            "value": "18d84cfc-8289-4f38-9fbf-c2e6ac949c8f",
            "$ref": "https://localhost:9443/scim2/Users/18d84cfc-8289-4f38-9fbf-c2e6ac949c8f"
        }
    ]
}
```

- Depends on: https://github.com/wso2/carbon-identity-framework/pull/3491 and https://github.com/wso2/charon/pull/315