### PR TITLE
Fix incorrect format of the addresses attribute

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3752,7 +3752,7 @@ public class SCIMUserManager implements UserManager {
                     }
                     //skip simple type addresses claim because it is complex with sub types in the schema
                     if (attributes.containsKey(SCIMConstants.UserSchemaConstants.ADDRESSES_URI)) {
-                        filterAttributes(attributes, Arrays.asList(SCIMConstants.UserSchemaConstants.ADDRESSES_URI));
+                        attributes.remove(SCIMConstants.UserSchemaConstants.ADDRESSES_URI);
                     }
 
                     if (IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapper.java
@@ -536,7 +536,7 @@ public class AttributeMapper {
                 typeAttributeURI = typeAttributeURI + ".type";
                 AttributeSchema typeAttributeSchema = getAttributeSchema(userManager, typeAttributeURI, scimObjectType);
                 DefaultAttributeFactory.createAttribute(typeAttributeSchema, typeSimpleAttribute);
-                SimpleAttribute valueSimpleAttribute = new SimpleAttribute(SCIMConstants.CommonSchemaConstants.VALUE,
+                SimpleAttribute valueSimpleAttribute = new SimpleAttribute(valueSubAttributeSchema.getName(),
                         AttributeUtil.getAttributeValueFromString(attributeEntry.getValue(),
                                 valueSubAttributeSchema.getType()));
                 DefaultAttributeFactory.createAttribute(valueSubAttributeSchema, valueSimpleAttribute);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapperTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapperTest.java
@@ -93,4 +93,30 @@ public class AttributeMapperTest {
 
     }
 
+    @Test
+    public void testAddressesAttribute() throws Exception {
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:emails.home", "paul@abc.com");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:meta.resourceType", "User");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:meta.created", "2021-05-25T11:39:43Z");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:meta.location",
+                "https://localhost:9443/scim2/Users/4f6b38a0-0fd6-4852-8f87-5e9db6991357");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:emails.work", "paulSmith@abc.com");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:name.familyName", "Smith");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:meta.lastModified", "2021-05-25T21:39:43Z");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:id", "4f6b38a0-0fd6-4852-8f87-5e9db6991357");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:userType", "User");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:userName", "Paul");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:name.givenName", "Paul");
+        attributes.put("urn:ietf:params:scim:schemas:core:2.0:User:addresses.home",
+                "100 Universal City Plaza Hollywood, CA 91608 USA");
+
+        assertEquals(((User) AttributeMapper.constructSCIMObjectFromAttributes(attributes, 1)).getAddresses().get(0)
+                .getType(), "home");
+        assertEquals(((User) AttributeMapper.constructSCIMObjectFromAttributes(attributes, 1)).getAddresses().get(0)
+                .getFormatted(), "100 Universal City Plaza Hollywood, CA 91608 USA");
+
+    }
+
 }


### PR DESCRIPTION
Address attributes were received incorrectly as below in the getUser response,

 ```
"addresses": [
        {
            "value": "100 Universal City Plaza Hollywood, CA 91608 USA",
            "type": "work"
        },
        {
            "value": "456 Hollywood BlvdnHollywood, CA 91608 USA",
            "type": "home"
        }
    ]
```

With this fix, it's corrected as for the specification [1] as below,
```
"addresses": [
        {
            "formatted": "100 Universal City Plaza Hollywood, CA 91608 USA",
            "type": "work"
        },
        {
            "formatted": "456 Hollywood BlvdnHollywood, CA 91608 USA",
            "type": "home"
        }
    ],
```

[1] https://datatracker.ietf.org/doc/html/rfc7643#section-4.1.2

Resolves https://github.com/wso2/product-is/issues/11801