### PR TITLE
Disable editing the provisioned user's attribute values

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -119,6 +119,10 @@
             <artifactId>org.wso2.carbon.identity.role.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.password.policy</artifactId>
         </dependency>
@@ -195,7 +199,8 @@
 
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
-
+                            org.wso2.carbon.identity.application.authentication.framework;
+                            version="${identity.framework.version}",
                             org.wso2.carbon.identity.base; version="${identity.framework.version}",
                             org.wso2.carbon.identity.core.*; version="${identity.framework.version}",
                             org.wso2.carbon.identity.claim.metadata.mgt.*; version="${identity.framework.version}",

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -55,7 +55,7 @@ import java.util.UUID;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX_VALIDATION_ERROR;
 
@@ -171,8 +171,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         // Validate whether claim update request is for a provisioned user.
         if (isJitProvisionEnhancedFeature()) {
-            validateJitProvisionedUserClaimUpdate(getUsernameFromUserID(userID, userStoreManager),
-                    profileName, userStoreManager);
+            validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
         // Validate dob value against the regex.
         validateDateOfBirthClaimValue(claimURI, claimValue, userStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -58,7 +58,6 @@ import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DO
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX_VALIDATION_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROVISIONED_SOURCE_CLAIM;
 
 /**
  * This is to perform SCIM related operation on User Operations.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -256,7 +256,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                                           UserStoreManager userStoreManager) throws UserStoreException {
 
         // Validate whether claim update request is for a provisioned user.
-        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled())) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
             validateClaimUpdate(userName);
         }
         return true;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
@@ -55,7 +56,6 @@ import java.util.UUID;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX_VALIDATION_ERROR;
 
@@ -170,7 +170,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                                                 UserStoreManager userStoreManager) throws UserStoreException {
 
         // Validate whether claim update request is for a provisioned user.
-        if (isJitProvisionEnhancedFeature()) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
             validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
         // Validate dob value against the regex.
@@ -228,7 +228,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         }
 
         // Validate whether claim update request is for a provisioned user.
-        if (isJitProvisionEnhancedFeature()) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
             validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
 
@@ -246,7 +246,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                                            UserStoreManager userStoreManager) throws UserStoreException {
 
         // Validate whether claim update request is for a provisioned user.
-        if (isJitProvisionEnhancedFeature()) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
             validateClaimUpdate(userName);
         }
         return true;
@@ -256,7 +256,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                                           UserStoreManager userStoreManager) throws UserStoreException {
 
         // Validate whether claim update request is for a provisioned user.
-        if (isJitProvisionEnhancedFeature()) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled())) {
             validateClaimUpdate(userName);
         }
         return true;
@@ -538,10 +538,5 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         // If http://wso2.org/claims/identity/isReadOnlyUser claim is requested, set the value checking the user store.
         claimMap.put(SCIMCommonConstants.READ_ONLY_USER_CLAIM, String.valueOf(userStoreManager.isReadOnly()));
         return true;
-    }
-
-    public static boolean isJitProvisionEnhancedFeature() {
-
-        return Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE));
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -55,7 +55,7 @@ import java.util.UUID;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX_VALIDATION_ERROR;
 
@@ -171,7 +171,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         // Validate whether claim update request is for a provisioned user.
         if (isJitProvisionEnhancedFeature()) {
-            validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager),
+            validateJitProvisionedUserClaimUpdate(getUsernameFromUserID(userID, userStoreManager),
                     profileName, userStoreManager);
         }
         // Validate dob value against the regex.
@@ -230,8 +230,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         // Validate whether claim update request is for a provisioned user.
         if (isJitProvisionEnhancedFeature()) {
-            validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager),
-                    profileName, userStoreManager);
+            validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
 
         String lastModifiedDate = AttributeUtil.formatDateTime(Instant.now());
@@ -249,7 +248,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         // Validate whether claim update request is for a provisioned user.
         if (isJitProvisionEnhancedFeature()) {
-            validateClaimUpdate(userName, profileName, userStoreManager);
+            validateClaimUpdate(userName);
         }
         return true;
     }
@@ -259,7 +258,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
 
         // Validate whether claim update request is for a provisioned user.
         if (isJitProvisionEnhancedFeature()) {
-            validateClaimUpdate(userName, profileName, userStoreManager);
+            validateClaimUpdate(userName);
         }
         return true;
     }
@@ -273,14 +272,12 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
      * Validate whether the claim update request is from a provisioned user.
      *
      * @param username         Username.
-     * @param profileName      Profile name.
-     * @param userStoreManager Userstore manager.
      * @throws UserStoreException if an error occurred while retrieving the user claim list.
      */
-    private void validateClaimUpdate(String username, String profileName,
-                                     UserStoreManager userStoreManager) throws UserStoreException {
+    private void validateClaimUpdate(String username) throws UserStoreException {
 
         boolean isAttributeSyncingEnabled = true;
+
         /*
         If attribute syncing is disabled, blocking the attribute editing is not required.
         ToDo: There should be an option to disable attribute syncing.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -83,6 +83,10 @@ public class SCIMCommonConstants {
 
     public static final String READ_ONLY_USER_CLAIM = "http://wso2.org/claims/identity/isReadOnlyUser";
 
+    public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSource";
+    public static final String SYNCED_ATTRIBUTE_EDITING_ENABLED = "JITProvisioning.EnableSyncedAttributeEditing";
+    public static final String PROVISIONED_USER = "provisionedUser";
+
     public static final String SCIM_COMPLEX_MULTIVALUED_ATTRIBUTE_SUPPORT_ENABLED = "SCIM2" +
             ".ComplexMultiValuedAttributeSupportEnabled";
     public static final String SCIM_ENABLE_FILTERING_ENHANCEMENTS = "SCIM2.EnableFilteringEnhancements";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -83,8 +83,6 @@ public class SCIMCommonConstants {
 
     public static final String READ_ONLY_USER_CLAIM = "http://wso2.org/claims/identity/isReadOnlyUser";
 
-    public static final String ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
-
     public static final String SCIM_COMPLEX_MULTIVALUED_ATTRIBUTE_SUPPORT_ENABLED = "SCIM2" +
             ".ComplexMultiValuedAttributeSupportEnabled";
     public static final String SCIM_ENABLE_FILTERING_ENHANCEMENTS = "SCIM2.EnableFilteringEnhancements";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -84,8 +84,7 @@ public class SCIMCommonConstants {
     public static final String READ_ONLY_USER_CLAIM = "http://wso2.org/claims/identity/isReadOnlyUser";
 
     public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSource";
-    public static final String SYNCED_ATTRIBUTE_EDITING_ENABLED = "JITProvisioning.EnableSyncedAttributeEditing";
-    public static final String PROVISIONED_USER = "provisionedUser";
+    public static final String ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
 
     public static final String SCIM_COMPLEX_MULTIVALUED_ATTRIBUTE_SUPPORT_ENABLED = "SCIM2" +
             ".ComplexMultiValuedAttributeSupportEnabled";
@@ -117,5 +116,48 @@ public class SCIMCommonConstants {
             "Date of Birth is not in the correct format of YYYY-MM-DD";
     public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
     public static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "ATS-10001";
+
+    /**
+     * Enum which contains the error codes and corresponding error messages.
+     */
+    public enum ErrorMessages {
+
+        // SUO - SCIM User Operations.
+        ERROR_CODE_INVALID_ATTRIBUTE_UPDATE("SUO-10000", "User attribute update is not allowed",
+                "The user: %s has been JIT provisioned from federated IDP: %s. " +
+                        "Hence provisioned user attributes are not allowed to update");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessages(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return this.description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " : " + message;
+        }
+    }
 }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -114,6 +114,7 @@ public class SCIMCommonConstants {
     public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR =
             "Date of Birth is not in the correct format of YYYY-MM-DD";
     public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
+    public static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "ATS-10001";
 
     /**
      * Enum which contains the error codes and corresponding error messages.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -122,7 +122,7 @@ public class SCIMCommonConstants {
 
         // SUO - SCIM User Operations.
         ERROR_CODE_INVALID_ATTRIBUTE_UPDATE("SUO-10000", "User attribute update is not allowed",
-                "The user: %s has been provisioned from federated IDP: %s. " +
+                "The user: %s has been JIT provisioned from federated IDP: %s. " +
                         "Hence provisioned user attributes are not allowed to update");
 
         private final String code;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -83,7 +83,6 @@ public class SCIMCommonConstants {
 
     public static final String READ_ONLY_USER_CLAIM = "http://wso2.org/claims/identity/isReadOnlyUser";
 
-    public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSource";
     public static final String ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
 
     public static final String SCIM_COMPLEX_MULTIVALUED_ATTRIBUTE_SUPPORT_ENABLED = "SCIM2" +
@@ -115,7 +114,6 @@ public class SCIMCommonConstants {
     public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR =
             "Date of Birth is not in the correct format of YYYY-MM-DD";
     public static final String DATE_OF_BIRTH_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
-    public static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "ATS-10001";
 
     /**
      * Enum which contains the error codes and corresponding error messages.
@@ -124,7 +122,7 @@ public class SCIMCommonConstants {
 
         // SUO - SCIM User Operations.
         ERROR_CODE_INVALID_ATTRIBUTE_UPDATE("SUO-10000", "User attribute update is not allowed",
-                "The user: %s has been JIT provisioned from federated IDP: %s. " +
+                "The user: %s has been provisioned from federated IDP: %s. " +
                         "Hence provisioned user attributes are not allowed to update");
 
         private final String code;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
@@ -56,8 +57,9 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE;
 
-@PrepareForTest({UserCoreUtil.class, SCIMGroupHandler.class, SCIMCommonUtils.class})
+@PrepareForTest({UserCoreUtil.class, SCIMGroupHandler.class, SCIMCommonUtils.class, IdentityUtil.class})
 public class SCIMUserOperationListenerTest extends PowerMockTestCase {
 
     private String userName = "testUser";
@@ -214,7 +216,12 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
 
         when(scimUserOperationListener.isEnable()).thenReturn(isEnabled);
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
-        assertTrue(scimUserOperationListener.doPreSetUserClaimValuesWithID(userId, claims, profile, userStoreManager));
+
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty(ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE)).thenReturn("false");
+
+        assertTrue(scimUserOperationListener.
+                doPreSetUserClaimValuesWithID(userId, claims, profile, userStoreManager));
     }
 
     @Test(expectedExceptions = UserStoreException.class)

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
@@ -57,7 +58,6 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE;
 
 @PrepareForTest({UserCoreUtil.class, SCIMGroupHandler.class, SCIMCommonUtils.class, IdentityUtil.class})
 public class SCIMUserOperationListenerTest extends PowerMockTestCase {
@@ -218,7 +218,7 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
 
         mockStatic(IdentityUtil.class);
-        when(IdentityUtil.getProperty(ENABLE_JIT_PROVISIOING_ENHANCE_FEATURE)).thenReturn("false");
+        when(IdentityUtil.getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE)).thenReturn("false");
 
         assertTrue(scimUserOperationListener.
                 doPreSetUserClaimValuesWithID(userId, claims, profile, userStoreManager));

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+                <scope>provided</scope>
+                <version>${identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
                 <version>${identity.framework.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.6.2-m9</carbon.kernel.version>
-        <identity.framework.version>5.20.59</identity.framework.version>
+        <identity.framework.version>5.20.118</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.6.2-m9</carbon.kernel.version>
-        <identity.framework.version>5.20.59</identity.framework.version>
+        <identity.framework.version>5.20.92</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.6.2-m9</carbon.kernel.version>
-        <identity.framework.version>5.20.92</identity.framework.version>
+        <identity.framework.version>5.20.59</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>


### PR DESCRIPTION
### Description
With the PR changes, editing the provisioned users synced attribute will be disabled based on the config introduced at [1]

Related issue: https://github.com/wso2/product-is/issues/12010

### Action items
This PR should be merged after merging [1] and upgrading the framework version.

[1] https://github.com/wso2/carbon-identity-framework/pull/3589