### PR TITLE
Change custom-user-schema-uri value from "urn:scim:custom:schema" to "urn:scim:wso2:schema"

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml
@@ -19,7 +19,7 @@
 <provisioning-config>
     <Property name="user-schema-extension-enabled">true</Property>
     <Property name="custom-user-schema-enabled">true</Property>
-    <Property name="custom-user-schema-uri">urn:scim:custom:schema</Property>
+    <Property name="custom-user-schema-uri">urn:scim:wso2:schema</Property>
     <Property name="patch-supported">true</Property>
     <Property name="documentationUri">http://example.com/help/scim.html</Property>
     <Property name="bulk-supported">true</Property>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/org.wso2.carbon.identity.scim2.common.feature.default.json
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/org.wso2.carbon.identity.scim2.common.feature.default.json
@@ -1,7 +1,7 @@
 {
   "scim2.enable_schema_extension": true,
   "scim2.enable_custom_schema_extension": true,
-  "scim2.custom_user_schema_uri": "urn:scim:custom:schema",
+  "scim2.custom_user_schema_uri": "urn:scim:wso2:schema",
   "scim2.max_bulk_operations": "1000",
   "scim2.max_bulk_payload": "1048576",
   "scim2.documentation_uri": "https://docs.wso2.com/display/IS580/Using+the+SCIM+2.0+REST+APIs",


### PR DESCRIPTION
This PR contains the change of custom-user-schema-uri value from "urn:scim:custom:schema" to "urn:scim:wso2:schema". After fixing the integration tests in product-is .
* * *
#### Steps to merge. 
1. Merge this PR
2. Bump the scim2 version in product-is
3. Merge the this PR in product-is ([product-is/pull/12042](https://github.com/wso2/product-is/pull/12042))