### PR TITLE
Mandatory claim update in social login flow

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -298,6 +298,16 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             return;
         }
 
+        /*
+        Check whether this is a mandatory claim update flow by checking the MANDATORY_CLAIM_UPDATE_FLOW thread
+        local property. If it is a mandatory claim update flow, blocking the attribute editing is not required.
+         */
+        if (IdentityUtil.threadLocalProperties.get().get(FrameworkConstants.MANDATORY_CLAIM_UPDATE_FLOW) != null &&
+                (Boolean) IdentityUtil.threadLocalProperties.get().
+                        get(FrameworkConstants.MANDATORY_CLAIM_UPDATE_FLOW)) {
+            return;
+        }
+
         boolean isExistingJITProvisionedUser;
         try {
             isExistingJITProvisionedUser = UserSessionStore.getInstance().isExistingUser(username);


### PR DESCRIPTION
### Proposed changes in this pull request

With this PR changes, MANDATORY_CLAIM_UPDATE_FLOW thread-local was introduced to capture the mandatory claim update flow for social login.
Resolves: https://github.com/wso2/product-is/issues/12222

### When should this PR be merged
This PR should be merged after merging https://github.com/wso2/carbon-identity-framework/pull/3635, and upgrading the framework version