### PR TITLE
Resolve existing role name error gracefuly.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
@@ -43,7 +43,7 @@ public class DefaultSCIMUserStoreErrorResolver implements SCIMUserStoreErrorReso
             String msg = e.getMessage().substring(e.getMessage().indexOf(":") + 1).trim();
             return new SCIMUserStoreException(msg, HttpStatus.SC_NOT_FOUND);
         } else if (e.getMessage().contains(ERROR_CODE_EXISTING_ROLE_NAME)) {
-            String groupName = e.getMessage().substring(e.getMessage().indexOf(":") + 1).trim().split(" ")[0];
+            String groupName = e.getMessage().substring(e.getMessage().indexOf(":") + 1).trim().split("\\s+")[0];
             String msg =
                     "Group name: " + groupName + " is already there in the system. Please pick another group name.";
             return new SCIMUserStoreException(msg, HttpStatus.SC_CONFLICT);


### PR DESCRIPTION
### Purpose.

Previously when patch a group with an existing group name, the return was a 500. With this change it will change to 409.

Sample response

```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Group name: manager is already there in the system. Please pick another group name.",
    "status": "409"
}
```