### PR TITLE
Return 400 bad request for readonly userstore's user update

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
@@ -47,7 +47,10 @@ public class DefaultSCIMUserStoreErrorResolver implements SCIMUserStoreErrorReso
             String msg =
                     "Group name: " + groupName + " is already there in the system. Please pick another group name.";
             return new SCIMUserStoreException(msg, HttpStatus.SC_CONFLICT);
-        } else if (e.getMessage().contains(ERROR_CODE_READ_ONLY_USERSTORE)) {
+        } else if (e.getMessage().contains(ERROR_CODE_READ_ONLY_USERSTORE) ||
+                (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
+                        .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
+                                ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()))) {
             String msg = "Invalid operation. User store is read only";
             return new SCIMUserStoreException(msg, HttpStatus.SC_BAD_REQUEST);
         } else if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/12757

After the change:
response is: 400 Bad Request 
The response body is:
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Invalid operation. User store is read only",
    "status": "400"
}
```