### PR TITLE
Add Backend Validation to Restrict Updating of Read Only Claims

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -103,11 +103,6 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
             for (Map.Entry<String, String> claim : claims.entrySet()) {
                 Map<String, String> claimProperties = getClaimProperties(tenantDomain, claim.getKey());
-                // Validate whether a readonly attribute is updating.
-                if (isReadOnlyAttribute(claim.getKey(), claimProperties)) {
-                    throw new UserStoreClientException(ERROR_CODE_READONLY_CLAIM_UPDATE.getMessage(),
-                            ERROR_CODE_READONLY_CLAIM_UPDATE.getCode());
-                }
                 // Validate claim value against the regex.
                 validateClaimValue(claim.getKey(), claimProperties, claim.getValue());
             }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -59,6 +59,7 @@ import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.CO
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_READONLY_CLAIM_UPDATE;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_REGEX_VIOLATION;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.GROUPS_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_LOCAL_CLAIM;
@@ -66,6 +67,7 @@ import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MO
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_REGEX_VALIDATION_DEFAULT_ERROR;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.NOT_EXISTING_GROUPS_ERROR;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_DISPLAYNAME;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_READ_ONLY;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX_VALIDATION_ERROR;
 
@@ -94,11 +96,21 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                                       String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
         try {
-            if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
+            if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled() ||
+                    MapUtils.isEmpty(claims)) {
                 return true;
             }
-            // Validate claim value against the regex.
-            validateClaimValue(claims, userStoreManager);
+            String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+            for (Map.Entry<String, String> claim : claims.entrySet()) {
+                Map<String, String> claimProperties = getClaimProperties(tenantDomain, claim.getKey());
+                // Validate whether a readonly attribute is updating.
+                if (isReadOnlyAttribute(claim.getKey(), claimProperties)) {
+                    throw new UserStoreClientException(ERROR_CODE_READONLY_CLAIM_UPDATE.getMessage(),
+                            ERROR_CODE_READONLY_CLAIM_UPDATE.getCode());
+                }
+                // Validate claim value against the regex.
+                validateClaimValue(claim.getKey(), claimProperties, claim.getValue());
+            }
             this.populateSCIMAttributes(userID, claims);
             return true;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -185,62 +197,83 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             // Validate whether claim update request is for a provisioned user.
             validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        Map<String, String> claimProperties = getClaimProperties(tenantDomain, claimURI);
+        // Validate whether a readonly attribute is updating.
+        if (isReadOnlyAttribute(claimURI, claimProperties)) {
+            throw new UserStoreClientException(ERROR_CODE_READONLY_CLAIM_UPDATE.getMessage(),
+                    ERROR_CODE_READONLY_CLAIM_UPDATE.getCode());
+        }
         // Validate the claim value against the regex.
-        validateClaimValue(claimURI, claimValue, userStoreManager);
+        validateClaimValue(claimURI, claimProperties, claimValue);
         // Validate if the groups are updated.
         validateUserGroupClaim(userID, claimURI, claimValue, userStoreManager);
         return true;
+    }
+
+    private boolean isReadOnlyAttribute(String claimURI, Map<String, String> claimProperties)
+            throws UserStoreException {
+
+        Map<String, String> scimToLocalMappings = SCIMCommonUtils.getSCIMtoLocalMappings();
+        String createdLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.CREATED_URI);
+        String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants
+                .LAST_MODIFIED_URI);
+        String resourceTypeLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants
+                .RESOURCE_TYPE_URI);
+        String externalIdLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.EXTERNAL_ID);
+        String departmentLocalClaimUri = scimToLocalMappings.get(SCIMCommonConstants.DEPARTMENT_URI);
+
+        // Skip metadata attributes and identity claims, as they are updating by the server itself.
+        if (claimURI.equals(createdLocalClaimUri) || claimURI.equals(modifiedLocalClaimUri) ||
+                claimURI.equals(resourceTypeLocalClaimUri) || claimURI.equals(externalIdLocalClaimUri) ||
+                claimURI.equals(departmentLocalClaimUri) || isIdentityClaimUpdate(claimURI)) {
+            return false;
+        }
+        return MapUtils.isNotEmpty(claimProperties) && Boolean.parseBoolean(claimProperties.get(PROP_READ_ONLY));
     }
 
     /**
      * Validate claim values against regex. Specially handles the dob and mobile claim values.
      * This method can be removed once https://github.com/wso2/product-is/issues/9816 is fixed.
      *
-     * @param claimURI         Claim URI.
-     * @param claimValue       Claim value.
-     * @param userStoreManager Userstore manager.
+     * @param claimURI        Claim URI.
+     * @param claimProperties Properties of the claim.
+     * @param claimValue      Claim value.
      * @throws UserStoreException When claim value doesn't match with regex.
      */
-    private void validateClaimValue(String claimURI, String claimValue, UserStoreManager userStoreManager)
+    private void validateClaimValue(String claimURI, Map<String, String> claimProperties, String claimValue)
             throws UserStoreException {
 
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        switch (claimURI) {
-            case DATE_OF_BIRTH_LOCAL_CLAIM:
-                validateClaimValueForRegex(claimURI, claimValue, tenantDomain, DATE_OF_BIRTH_REGEX,
-                        DOB_REG_EX_VALIDATION_DEFAULT_ERROR);
-                break;
-            case MOBILE_LOCAL_CLAIM:
-                validateClaimValueForRegex(claimURI, claimValue, tenantDomain, MOBILE_REGEX,
-                        MOBILE_REGEX_VALIDATION_DEFAULT_ERROR);
-                break;
-            default:
-                validateClaimValueForRegex(claimURI, claimValue, tenantDomain, null, null);
-                break;
+        if (MapUtils.isNotEmpty(claimProperties)) {
+            switch (claimURI) {
+                case DATE_OF_BIRTH_LOCAL_CLAIM:
+                    validateClaimValueForRegex(claimProperties, claimValue, DATE_OF_BIRTH_REGEX,
+                            DOB_REG_EX_VALIDATION_DEFAULT_ERROR);
+                    break;
+                case MOBILE_LOCAL_CLAIM:
+                    validateClaimValueForRegex(claimProperties, claimValue, MOBILE_REGEX,
+                            MOBILE_REGEX_VALIDATION_DEFAULT_ERROR);
+                    break;
+                default:
+                    validateClaimValueForRegex(claimProperties, claimValue, null, null);
+                    break;
+            }
         }
     }
 
     /**
      * Validate claim value against regex.
      *
-     * @param claimURI                    Claim URI.
+     * @param claimProperties             Claim Properties.
      * @param claimValue                  Claim value.
-     * @param tenantDomain                Tenant domain.
      * @param defaultRegex                Default regex of the claim.
      * @param defaultRegexValidationError Default error of claim for regex validation failure.
      * @throws UserStoreClientException When regex validation is failed.
      */
-    private void validateClaimValueForRegex(String claimURI, String claimValue, String tenantDomain,
+    private void validateClaimValueForRegex(Map<String, String> claimProperties, String claimValue,
                                             String defaultRegex, String defaultRegexValidationError)
             throws UserStoreClientException {
 
-        if (StringUtils.isBlank(claimURI)) {
-            if (log.isDebugEnabled()) {
-                log.debug("The claim URI is empty.");
-            }
-            return;
-        }
-        Map<String, String> claimProperties = getClaimProperties(tenantDomain, claimURI);
         if (MapUtils.isNotEmpty(claimProperties)) {
             String claimRegex = claimProperties.get(PROP_REG_EX);
             if (StringUtils.isEmpty(claimRegex)) {
@@ -295,7 +328,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                                                  UserStoreManager userStoreManager) throws UserStoreException {
         try {
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()
-                    || userStoreManager.isReadOnly()) {
+                    || userStoreManager.isReadOnly() || MapUtils.isEmpty(claims)) {
                 return true;
             }
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -308,13 +341,23 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
 
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        for (Map.Entry<String, String> claim : claims.entrySet()) {
+            Map<String, String> claimProperties = getClaimProperties(tenantDomain, claim.getKey());
+            // Validate whether a readonly attribute is updating.
+            if (isReadOnlyAttribute(claim.getKey(), claimProperties)) {
+                throw new UserStoreClientException(ERROR_CODE_READONLY_CLAIM_UPDATE.getMessage(),
+                        ERROR_CODE_READONLY_CLAIM_UPDATE.getCode());
+            }
+            // Validate claim value against the regex.
+            validateClaimValue(claim.getKey(), claimProperties, claim.getValue());
+        }
+
         String lastModifiedDate = AttributeUtil.formatDateTime(Instant.now());
         Map<String, String> scimToLocalMappings = SCIMCommonUtils.getSCIMtoLocalMappings();
         String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI);
         claims.put(modifiedLocalClaimUri, lastModifiedDate);
 
-        // Validate dob and mobile value against the regex.
-        validateClaimValue(claims, userStoreManager);
         // Validate if the groups are updated.
         validateUserGroups(userID, claims, userStoreManager);
         return true;
@@ -463,43 +506,6 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         if (hasInvalidGroups) {
             // At least one group does not exist. We need to throw an error and abort the flow.
             throw new UserStoreClientException(NOT_EXISTING_GROUPS_ERROR);
-        }
-    }
-
-    /**
-     * Validate claim values against the regex. Specially handles the dob and mobile claim values.
-     * This method can be removed once https://github.com/wso2/product-is/issues/9816 is fixed.
-     *
-     * @param claims           List of claims.
-     * @param userStoreManager Userstore manager.
-     * @throws UserStoreException When regex validation fails.
-     */
-    private void validateClaimValue(Map<String, String> claims, UserStoreManager userStoreManager)
-            throws UserStoreException {
-
-        if (MapUtils.isEmpty(claims)) {
-            if (log.isDebugEnabled()) {
-                log.debug("claim set is empty.");
-            }
-            return;
-        }
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        for (Map.Entry<String, String> claim : claims.entrySet()) {
-            if (StringUtils.isBlank(claim.getKey())) {
-                return;
-            }
-            switch (claim.getKey()) {
-                case DATE_OF_BIRTH_LOCAL_CLAIM:
-                    validateClaimValueForRegex(DATE_OF_BIRTH_LOCAL_CLAIM, claims.get(DATE_OF_BIRTH_LOCAL_CLAIM),
-                            tenantDomain, DATE_OF_BIRTH_REGEX, DOB_REG_EX_VALIDATION_DEFAULT_ERROR);
-                    break;
-                case MOBILE_LOCAL_CLAIM:
-                    validateClaimValueForRegex(MOBILE_LOCAL_CLAIM, claims.get(MOBILE_LOCAL_CLAIM), tenantDomain,
-                            MOBILE_REGEX, MOBILE_REGEX_VALIDATION_DEFAULT_ERROR);
-                    break;
-                default:
-                    validateClaimValueForRegex(claim.getKey(), claim.getValue(), tenantDomain, null, null);
-            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -83,6 +83,7 @@ public class SCIMCommonConstants {
 
     public static final java.lang.String ASK_PASSWORD_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword";
     public static final java.lang.String VERIFY_EMAIL_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail";
+    public static final java.lang.String DEPARTMENT_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department";
 
     // Identity recovery claims
     public static final String ASK_PASSWORD_CLAIM = "http://wso2.org/claims/identity/askPassword";
@@ -116,6 +117,7 @@ public class SCIMCommonConstants {
     public static final String MOBILE_LOCAL_CLAIM = "http://wso2.org/claims/mobile";
     public static final String GROUPS_LOCAL_CLAIM = "http://wso2.org/claims/groups";
     public static final String PROP_REG_EX = "RegEx";
+    public static final String PROP_READ_ONLY = "ReadOnly";
     public static final String PROP_REG_EX_VALIDATION_ERROR = "RegExValidationError";
     public static final String PROP_DISPLAYNAME = "DisplayName";
     public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR =
@@ -162,7 +164,9 @@ public class SCIMCommonConstants {
                 "The user: %s has been JIT provisioned from federated IDP: %s. " +
                         "Hence provisioned user attributes are not allowed to update"),
         ERROR_CODE_REGEX_VIOLATION("SUO-10001", "Regex validation error",
-                "%s attribute value doesn't match with %s regex pattern");
+                "%s attribute value doesn't match with %s regex pattern"),
+        ERROR_CODE_READONLY_CLAIM_UPDATE("SUO-10002", "Read-only attribute update is not allowed",
+                "%s attribute is a readonly attribute. Hence attribute value update is not allowed.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
Resolves: wso2/product-is#12837

Editing of read only claims through SCIM APIs are restricted by this PR.

Relates to: https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/401