### PR TITLE
Fix the issue in scim total results calculation

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -95,6 +95,8 @@ public class SCIMCommonConstants {
     public static final String SCIM_ENABLE_FILTERING_ENHANCEMENTS = "SCIM2.EnableFilteringEnhancements";
     public static final String SCIM_ENABLE_FILTER_USERS_AND_GROUPS_ONLY_FROM_PRIMARY_DOMAIN =
             "SCIM2.FilterUsersAndGroupsOnlyFromPrimaryDomain";
+    public static final String SCIM_ENABLE_CONSIDER_MAX_LIMIT_FOR_TOTAL_RESULT =
+            "SCIM2.ConsiderMaxLimitForTotalResult";
     public static final String SCIM_ENABLE_MANDATE_DOMAIN_FOR_GROUPNAMES_IN_GROUPS_RESPONSE =
             "SCIM2.MandateDomainForGroupNamesInGroupsResponse";
     public static final String SCIM_ENABLE_MANDATE_DOMAIN_FOR_USERNAMES_AND_GROUPNAMES_IN_RESPONSE =

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -407,6 +407,18 @@ public class SCIMCommonUtils {
     }
 
     /**
+     * Checks whether the identity.xml config is available to consider max user limit for total results.If that property
+     * enabled, then this will return true.
+     *
+     * @return whether 'ConsiderMaxLimitForTotalResult' property is enabled in identity.xml.
+     */
+    public static boolean isConsiderMaxLimitForTotalResultEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil
+                .getProperty(SCIMCommonConstants.SCIM_ENABLE_CONSIDER_MAX_LIMIT_FOR_TOTAL_RESULT));
+    }
+
+    /**
      * Checks whether the identity.xml config is available for prepending the 'PRIMARY/' in each role and
      * which belong to Primary domain in the response of Groups endpoints.
      *


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/12813#issuecomment-1004543880

Before the fix we have consider max user list value while calculating total results, hence if number of users is higher than max user list then total result shows the max user list value instead of actual number of users. 

With this fix we have introduced a config "ConsiderMaxLimitForTotalResult" to decide whether to consider the max user limit value during the total result. If the property disabled then total result will shows the actual number of users. Default value of this proerty is false. This fix has been added to scim endpoints /scim2/Users, scim2/Users?startindex=1&count=2(pagination),scim2/Users?filter=username+sw+ni(filtering)