### PR TITLE
Checking the user claim regex validation configuration before validating user claims

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -99,8 +99,10 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
                 return true;
             }
-            // Validate claim value against the regex.
-            validateClaimValue(claims, userStoreManager);
+            // Validate claim value against the regex if user claim input regex validation configuration is enabled.
+            if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
+                validateClaimValue(claims, userStoreManager);
+            }
             this.populateSCIMAttributes(userID, claims);
             return true;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -315,8 +317,10 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI);
         claims.put(modifiedLocalClaimUri, lastModifiedDate);
 
-        // Validate claim value against the regex.
-        validateClaimValue(claims, userStoreManager);
+        // Validate claim value against the regex if user claim input regex validation configuration is enabled.
+        if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
+            validateClaimValue(claims, userStoreManager);
+        }
         // Validate if the groups are updated.
         validateUserGroups(userID, claims, userStoreManager);
         return true;
@@ -500,9 +504,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                             MOBILE_REGEX, MOBILE_REGEX_VALIDATION_DEFAULT_ERROR);
                     break;
                 default:
-                    if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
-                        validateClaimValueForRegex(claim.getKey(), claim.getValue(), tenantDomain, DEFAULT_REGEX, null);
-                    }
+                    validateClaimValueForRegex(claim.getKey(), claim.getValue(), tenantDomain, DEFAULT_REGEX, null);
             }
         }
     }


### PR DESCRIPTION
**Purpose**

Checking whether the user claim input regex validation configuration is enabled before validating user claim input values.

Resolves : [wso2/product-is#3174](https://github.com/wso2/product-is/issues/13174)
Related PR : [wso2-extensions/identity-inbound-provisioning-scim2#409](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/409)