### PR TITLE
Adding default regex pattern to restrict special characters in user claim inputs

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -55,19 +55,20 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.COMMON_REGEX_VALIDATION_ERROR;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_REGEX_VIOLATION;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.GROUPS_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_REGEX_VALIDATION_DEFAULT_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.NOT_EXISTING_GROUPS_ERROR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_DISPLAYNAME;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DEFAULT_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_REG_EX_VALIDATION_ERROR;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.COMMON_REGEX_VALIDATION_ERROR;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.GROUPS_LOCAL_CLAIM;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.PROP_DISPLAYNAME;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.NOT_EXISTING_GROUPS_ERROR;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_REGEX_VIOLATION;
 
 /**
  * This is to perform SCIM related operation on User Operations.
@@ -97,8 +98,10 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
                 return true;
             }
-            // Validate claim value against the regex.
-            validateClaimValue(claims, userStoreManager);
+            // Validate claim value against the regex if user claim input regex validation configuration is enabled.
+            if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
+                validateClaimValue(claims, userStoreManager);
+            }
             this.populateSCIMAttributes(userID, claims);
             return true;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -185,8 +188,10 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             // Validate whether claim update request is for a provisioned user.
             validateClaimUpdate(getUsernameFromUserID(userID, userStoreManager));
         }
-        // Validate the claim value against the regex.
-        validateClaimValue(claimURI, claimValue, userStoreManager);
+        // Validate claim value against the regex if user claim input regex validation configuration is enabled.
+        if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
+            validateClaimValue(claimURI, claimValue, userStoreManager);
+        }
         // Validate if the groups are updated.
         validateUserGroupClaim(userID, claimURI, claimValue, userStoreManager);
         return true;
@@ -215,7 +220,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                         MOBILE_REGEX_VALIDATION_DEFAULT_ERROR);
                 break;
             default:
-                validateClaimValueForRegex(claimURI, claimValue, tenantDomain, null, null);
+                validateClaimValueForRegex(claimURI, claimValue, tenantDomain, DEFAULT_REGEX, null);
                 break;
         }
     }
@@ -313,8 +318,10 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         String modifiedLocalClaimUri = scimToLocalMappings.get(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI);
         claims.put(modifiedLocalClaimUri, lastModifiedDate);
 
-        // Validate dob and mobile value against the regex.
-        validateClaimValue(claims, userStoreManager);
+        // Validate claim value against the regex if user claim input regex validation configuration is enabled.
+        if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
+            validateClaimValue(claims, userStoreManager);
+        }
         // Validate if the groups are updated.
         validateUserGroups(userID, claims, userStoreManager);
         return true;
@@ -498,7 +505,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                             MOBILE_REGEX, MOBILE_REGEX_VALIDATION_DEFAULT_ERROR);
                     break;
                 default:
-                    validateClaimValueForRegex(claim.getKey(), claim.getValue(), tenantDomain, null, null);
+                    validateClaimValueForRegex(claim.getKey(), claim.getValue(), tenantDomain, DEFAULT_REGEX, null);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -134,7 +134,7 @@ public class SCIMCommonConstants {
     public static final String MOBILE_REGEX =
             "^\\s*(?:\\+?(\\d{1,3}))?[-. (]*(\\d{3})?[-. )]*(\\d{3})?[-. ]*(\\d{4,6})(?: *x(\\d+))?\\s*$";
     public static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "ATS-10001";
-    public static final String DEFAULT_REGEX = "[^<>`']+";
+    public static final String DEFAULT_REGEX = "[^<>`\"]+";
 
     private static final Map<String, String> groupAttributeSchemaMap = new HashMap<>();
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -80,6 +80,7 @@ public class SCIMCommonConstants {
     public static final String PAGINATION_DEFAULT_COUNT = "pagination-default-count";
     public static final String CUSTOM_USER_SCHEMA_ENABLED = "custom-user-schema-enabled";
     public static final String CUSTOM_USER_SCHEMA_URI = "custom-user-schema-uri";
+    public static final String ENABLE_REGEX_VALIDATION_FOR_USER_CLAIM_INPUTS = "UserClaimUpdate.EnableUserClaimInputRegexValidation";
 
     public static final java.lang.String ASK_PASSWORD_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword";
     public static final java.lang.String VERIFY_EMAIL_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail";
@@ -133,6 +134,7 @@ public class SCIMCommonConstants {
     public static final String MOBILE_REGEX =
             "^\\s*(?:\\+?(\\d{1,3}))?[-. (]*(\\d{3})?[-. )]*(\\d{3})?[-. ]*(\\d{4,6})(?: *x(\\d+))?\\s*$";
     public static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "ATS-10001";
+    public static final String DEFAULT_REGEX = "[^<>`']+";
 
     private static final Map<String, String> groupAttributeSchemaMap = new HashMap<>();
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -718,4 +718,15 @@ public class SCIMCommonUtils {
             return delimiter + attributeValue;
         }
     }
+
+    /**
+     * Checks whether the regex validation for user claim input is enabled.
+     *
+     * @return True if regex validation for user claims enabled.
+     */
+    public static boolean isRegexValidationForUserClaimEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil
+                .getProperty(SCIMCommonConstants.ENABLE_REGEX_VALIDATION_FOR_USER_CLAIM_INPUTS));
+    }
 }


### PR DESCRIPTION
**Purpose**

Providing a backend validation to restrict special characters such as <>``"  from user claim input values when the `enable_user_claim_input_regex_validation` configuration is enabled.

Resolves : [wso2/product-is#13174](https://github.com/wso2/product-is/issues/13174)
[wso2/product-is#13262](https://github.com/wso2/product-is/issues/13262)

Related PRs : [wso2/carbon-identity-framework#3940](https://github.com/wso2/carbon-identity-framework/pull/3940)