### PR TITLE
Remove unnecessary error logs and add them as debug logs

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3877,7 +3877,6 @@ public class SCIMUserManager implements UserManager {
                     // Carbon specific roles do not possess SCIM info, hence skipping them.
                     continue;
                 }
-
                 Group groupObject = groupMetaAttributesCache.get(groupName);
                 if (groupObject == null && !groupMetaAttributesCache.containsKey(groupName)) {
                     org.wso2.carbon.user.core.common.Group userGroup =
@@ -6054,13 +6053,17 @@ public class SCIMUserManager implements UserManager {
         if (StringUtils.isNotBlank(group.getCreatedDate())) {
             scimGroup.setCreatedInstant(Date.from(AttributeUtil.parseDateTime(group.getCreatedDate())).toInstant());
         } else {
-            log.error("Group created date is not specified for group: " + groupName);
+            if (log.isDebugEnabled()) {
+                log.debug("Group created date is not specified for group: " + groupName);
+            }
         }
         if (StringUtils.isNotBlank(group.getLastModifiedDate())) {
             scimGroup.setLastModifiedInstant(
                     Date.from(AttributeUtil.parseDateTime(group.getLastModifiedDate())).toInstant());
         } else {
-            log.error("Group last modified date is not specified for group: " + groupName);
+            if (log.isDebugEnabled()) {
+                log.debug("Group last modified date is not specified for group: " + groupName);
+            }
         }
         return scimGroup;
     }


### PR DESCRIPTION
Could see below error logs when we:
1.  plug a secondary userstore which does not support uniqueID for groups feature
2. Call /groups or /scim2/me apis

```

TID: [-1234] [scim2] [2022-04-05 11:05:16,877] [7763389c-6c1a-4cae-8c36-ea4287d11062] ERROR {org.wso2.carbon.identity.scim2.common.impl.SCIMUserManager} - Group created date is not specified for group: admin
TID: [-1234] [scim2] [2022-04-05 11:05:16,878] [7763389c-6c1a-4cae-8c36-ea4287d11062] ERROR {org.wso2.carbon.identity.scim2.common.impl.SCIMUserManager} - Group last modified date is not specified for group: admin

```

This PR modifies those error logs into debug logs.

Related PRs:
https://github.com/wso2/carbon-kernel/pull/3251