### PR TITLE
Fix SCIM user creation issue when `verifyEmail` is set and the email is not provided

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -159,6 +159,10 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -99,23 +99,24 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
                 return true;
             }
-
-            // Assert whether verifyEmail claim is set and emailaddress claim is not provided.
-            if (Boolean.parseBoolean(Utils.getEmailVerifyTemporaryClaim().getValue()) &&
-                    claims.get(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS) == null) {
-                Utils.clearEmailVerifyTemporaryClaim();
-                throw new UserStoreClientException("verifyEmail claim is set, but the email addresses not provided");
-            }
-
-            // Validate claim value against the regex if user claim input regex validation configuration is enabled.
-            if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
-                validateClaimValue(claims, userStoreManager);
-            }
-            this.populateSCIMAttributes(userID, claims);
-            return true;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Error while reading isScimEnabled from userstore manager", e);
         }
+
+        // Assert whether verifyEmail claim is set and emailaddress claim is not provided.
+        if (Boolean.parseBoolean(Utils.getEmailVerifyTemporaryClaim().getValue()) &&
+                claims.get(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS) == null) {
+            Utils.clearEmailVerifyTemporaryClaim();
+            throw new UserStoreClientException("verifyEmail claim is set, but the email addresses not provided");
+        }
+
+        // Validate claim value against the regex if user claim input regex validation configuration is enabled.
+        if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
+            validateClaimValue(claims, userStoreManager);
+        }
+        this.populateSCIMAttributes(userID, claims);
+
+        return true;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
@@ -98,6 +99,14 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
                 return true;
             }
+
+            // Assert whether verifyEmail claim is set and emailaddress claim is not provided.
+            if (Boolean.parseBoolean(Utils.getEmailVerifyTemporaryClaim().getValue()) &&
+                    claims.get(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS) == null) {
+                Utils.clearEmailVerifyTemporaryClaim();
+                throw new UserStoreClientException("verifyEmail claim is set, but the email addresses not provided");
+            }
+
             // Validate claim value against the regex if user claim input regex validation configuration is enabled.
             if (SCIMCommonUtils.isRegexValidationForUserClaimEnabled()) {
                 validateClaimValue(claims, userStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -59,6 +59,7 @@ import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATT
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DATE_OF_BIRTH_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_VERIFY_EMAIL_NOT_SET;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_REGEX;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MOBILE_REGEX_VALIDATION_DEFAULT_ERROR;
@@ -107,7 +108,8 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         if (Boolean.parseBoolean(Utils.getEmailVerifyTemporaryClaim().getValue()) &&
                 claims.get(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS) == null) {
             Utils.clearEmailVerifyTemporaryClaim();
-            throw new UserStoreClientException("verifyEmail claim is set, but the email addresses not provided");
+            throw new UserStoreClientException(ERROR_CODE_VERIFY_EMAIL_NOT_SET.getMessage(),
+                    ERROR_CODE_VERIFY_EMAIL_NOT_SET.getCode());
         }
 
         // Validate claim value against the regex if user claim input regex validation configuration is enabled.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -168,7 +168,9 @@ public class SCIMCommonConstants {
                 "The user: %s has been JIT provisioned from federated IDP: %s. " +
                         "Hence provisioned user attributes are not allowed to update"),
         ERROR_CODE_REGEX_VIOLATION("SUO-10001", "Regex validation error",
-                "%s attribute value doesn't match with %s regex pattern");
+                "%s attribute value doesn't match with %s regex pattern"),
+        ERROR_CODE_VERIFY_EMAIL_NOT_SET("SUO-10002", "Error in validating email verification", "verifyEmail claim " +
+                "is set, but the email addresses are not provided");
 
         private final String code;
         private final String message;

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
                 <scope>provided</scope>
                 <version>${identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+                <version>${identity.governance.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>


### PR DESCRIPTION
If below curl request is made (ask password functionality is enabled), it returns none. But the user is already created and it returns 409 if the same request is made.

The issue is that "verifyEmail" is set as true, it is trying to send a verification mail on POST_ADD_USER since an email is not provided for the user. The user is already created.

Fix is to add a validation step on PRE_ADD_USER.

**Related issue**
- https://github.com/wso2/product-is/issues/13637