### PR TITLE
Remove getting the total role count from DB for filterUsers

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -258,19 +258,8 @@ public class SCIMRoleManager implements RoleManager {
         }
         List<Object> scimRoles = getScimRolesList(roles);
 
-        int rolesCount;
-        try {
-            rolesCount = roleManagementService.getRolesCount(tenantDomain);
-        } catch (IdentityRoleManagementException e) {
-            throw new CharonException(
-                    String.format("Error occurred while getting the total number of roles: %s", searchFilter), e);
-        }
         // Set total number of results to 0th index.
-        if (rolesCount == 0) {
-            filteredRoles.set(0, scimRoles.size());
-        } else {
-            filteredRoles.set(0, rolesCount);
-        }
+        filteredRoles.set(0, scimRoles.size());
         // Add the results list.
         filteredRoles.addAll(scimRoles);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -571,7 +571,11 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN);
         List<Object> listRolesWithGET = roleManager.listRolesWithGET(rootNode, 2, (Integer) count, null, null);
         int totalRolesCount = (Integer)listRolesWithGET.get(0);
-        assertEquals(totalRolesCount, 5);
+        if (rootNode == null) {
+            assertEquals(totalRolesCount, 5);
+        } else {
+            assertEquals(totalRolesCount, roleList.size());
+        }
         assertTrue(true, "list roles works as expected");
     }
 


### PR DESCRIPTION
## Purpose
* Remove getting the total count from DB for filterUsers. Filter user should show the number of results for the query in the `totalResults` attribute
* Fix https://github.com/wso2/product-is/issues/13823