### PR TITLE
Changing ServiceProviderConfig to show cursor pagination is enabled.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
@@ -193,6 +193,8 @@ public class IdentitySCIMManager {
                             Integer.parseInt(scimConfigProcessor.getProperty(SCIMCommonConstants.FILTER_MAX_RESULTS)));
             charonConfiguration.setCountValueForPagination
                     (Integer.parseInt(scimConfigProcessor.getProperty(SCIMCommonConstants.PAGINATION_DEFAULT_COUNT)));
+            charonConfiguration.setPaginationSupport(
+                    Boolean.parseBoolean(scimConfigProcessor.getProperty(SCIMCommonConstants.CURSOR_SUPPORTED)));
 
             ArrayList<Object[]> schemaList = new ArrayList<>();
             for (AuthenticationSchema authenticationSchema : scimConfigProcessor.getAuthenticationSchemas()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManager.java
@@ -193,8 +193,9 @@ public class IdentitySCIMManager {
                             Integer.parseInt(scimConfigProcessor.getProperty(SCIMCommonConstants.FILTER_MAX_RESULTS)));
             charonConfiguration.setCountValueForPagination
                     (Integer.parseInt(scimConfigProcessor.getProperty(SCIMCommonConstants.PAGINATION_DEFAULT_COUNT)));
-            charonConfiguration.setPaginationSupport(
-                    Boolean.parseBoolean(scimConfigProcessor.getProperty(SCIMCommonConstants.CURSOR_SUPPORTED)));
+            charonConfiguration.setCursorPaginationSupport(
+                    Boolean.parseBoolean(scimConfigProcessor
+                            .getProperty(SCIMCommonConstants.CURSOR_PAGINATION_SUPPORTED)));
 
             ArrayList<Object[]> schemaList = new ArrayList<>();
             for (AuthenticationSchema authenticationSchema : scimConfigProcessor.getAuthenticationSchemas()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -81,7 +81,7 @@ public class SCIMCommonConstants {
     public static final String CUSTOM_USER_SCHEMA_ENABLED = "custom-user-schema-enabled";
     public static final String CUSTOM_USER_SCHEMA_URI = "custom-user-schema-uri";
     public static final String ENABLE_REGEX_VALIDATION_FOR_USER_CLAIM_INPUTS = "UserClaimUpdate.EnableUserClaimInputRegexValidation";
-    public static final String CURSOR_SUPPORTED = "cursor-supported";
+    public static final String CURSOR_PAGINATION_SUPPORTED = "cursor-pagination-supported";
     public static final java.lang.String ASK_PASSWORD_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword";
     public static final java.lang.String VERIFY_EMAIL_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail";
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -81,7 +81,7 @@ public class SCIMCommonConstants {
     public static final String CUSTOM_USER_SCHEMA_ENABLED = "custom-user-schema-enabled";
     public static final String CUSTOM_USER_SCHEMA_URI = "custom-user-schema-uri";
     public static final String ENABLE_REGEX_VALIDATION_FOR_USER_CLAIM_INPUTS = "UserClaimUpdate.EnableUserClaimInputRegexValidation";
-
+    public static final String CURSOR_SUPPORTED = "cursor-supported";
     public static final java.lang.String ASK_PASSWORD_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword";
     public static final java.lang.String VERIFY_EMAIL_URI = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail";
 

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml
@@ -31,6 +31,7 @@
     <Property name="sort-supported">false</Property>
     <Property name="etag-supported">false</Property>
     <Property name="pagination-default-count">100</Property>
+    <Property name="cursor-supported">true</Property>
     <authenticationSchemes>
         <schema id="1">
             <Property name="name">OAuth Bearer Token</Property>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml
@@ -31,7 +31,7 @@
     <Property name="sort-supported">false</Property>
     <Property name="etag-supported">false</Property>
     <Property name="pagination-default-count">100</Property>
-    <Property name="cursor-supported">true</Property>
+    <Property name="cursor-pagination-supported">true</Property>
     <authenticationSchemes>
         <schema id="1">
             <Property name="name">OAuth Bearer Token</Property>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml.j2
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml.j2
@@ -31,7 +31,7 @@
     <Property name="changePassword">true</Property>
     <Property name="sort-supported">false</Property>
     <Property name="etag-supported">false</Property>
-    <Property name="cursor-supported">true</Property>
+    <Property name="cursor-pagination-supported">true</Property>
     <authenticationSchemes>
         <schema id="1">
             <Property name="name">OAuth Bearer Token</Property>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml.j2
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/charon-config.xml.j2
@@ -31,6 +31,7 @@
     <Property name="changePassword">true</Property>
     <Property name="sort-supported">false</Property>
     <Property name="etag-supported">false</Property>
+    <Property name="cursor-supported">true</Property>
     <authenticationSchemes>
         <schema id="1">
             <Property name="name">OAuth Bearer Token</Property>


### PR DESCRIPTION
## Purpose
As per the [cursor based pagination draft by Matt Peterson](https://datatracker.ietf.org/doc/html/draft-peterson-scim-cursor-pagination-00#section-2), A SCIM Service provider implementing cursor-based pagination SHOULD include the following additional attribute in the JSON document returned by the/ServiceProviderConfig endpoint:

{
        "schemas": [
        "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
        ...
        "pagination": {
        "cursor":true
        },
        .....
}

A part in completion of: https://github.com/wso2/product-is/issues/13294

## Goals
When the ServiceProviderConfig endpoint is called, it will inform the user that cursor pagination is supported.

## Related PRs
https://github.com/wso2/charon/pull/370

## Test environment
JDK 1.8, Ubuntu 20.04, WSO2IS-5.12.0-alpha14, Chrome. 