### PR TITLE
Changing the response type of GET and POST/.Search

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.6.20-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1954,9 +1954,8 @@ public class SCIMUserManager implements UserManager {
 
         if (userList == null) {
             return new UsersGetResponse(0, Collections.emptyList());
-        } else {
-            return new UsersGetResponse(totalUsers, userList);
         }
+        return new UsersGetResponse(totalUsers, userList);
     }
 
     /**
@@ -2009,8 +2008,8 @@ public class SCIMUserManager implements UserManager {
     }
 
 
-    private List<User> getMultiAttributeFilteredUsersWithMaxLimit(Node node, Map<String, Boolean> requiredAttributes, int offset,
-                                                        String sortBy, String sortOrder, String domainName, int maxLimit)
+    private List<User> getMultiAttributeFilteredUsersWithMaxLimit(Node node, Map<String, Boolean> requiredAttributes,
+                           int offset, String sortBy, String sortOrder, String domainName, int maxLimit)
             throws CharonException, BadRequestException {
 
         List<User> filteredUsers = new ArrayList<>();

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -49,7 +49,6 @@ import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolv
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
-import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
@@ -88,6 +87,7 @@ import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.Role;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1369,8 +1369,8 @@ public class SCIMUserManager implements UserManager {
             // Check which APIs should the filter needs to follow.
             if (isUseLegacyAPIs(limit)) {
                 users = filterUsersUsingLegacyAPIs(node, limit, offset, domainName);
+                filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
                 if (SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
-                    filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
                     return getDetailedUsers(filteredUsers, users.size());
                 }
             } else {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1985,8 +1985,8 @@ public class SCIMUserManager implements UserManager {
             filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
         } else {
             int maxLimit = getMaxLimit(domainName);
-            filteredUsers = getMultiAttributeFilteredUsersWithMaxLimit(node, requiredAttributes, offset, sortBy
-                    , sortOrder, domainName, maxLimit);
+            users = getMultiAttributeFilteredUsersWithMaxLimit(node, offset, sortBy, sortOrder, domainName, maxLimit);
+            filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
         }
         // Check that total user count matching the client query needs to be calculated.
         if (isJDBCUSerStore(domainName) || isAllConfiguredUserStoresJDBC() ||
@@ -2008,16 +2008,15 @@ public class SCIMUserManager implements UserManager {
     }
 
 
-    private List<User> getMultiAttributeFilteredUsersWithMaxLimit(Node node, Map<String, Boolean> requiredAttributes,
-                           int offset, String sortBy, String sortOrder, String domainName, int maxLimit)
+    private Set<org.wso2.carbon.user.core.common.User> getMultiAttributeFilteredUsersWithMaxLimit(Node node, int offset,
+                                           String sortBy, String sortOrder, String domainName, int maxLimit)
             throws CharonException, BadRequestException {
 
-        List<User> filteredUsers = new ArrayList<>();
-        Set<org.wso2.carbon.user.core.common.User> users;
+        Set<org.wso2.carbon.user.core.common.User> users = null;
         if (StringUtils.isNotEmpty(domainName)) {
             users = getFilteredUsersFromMultiAttributeFiltering(node, offset, maxLimit, sortBy, sortOrder, domainName,
                     false);
-            return getFilteredUserDetails(users, requiredAttributes);
+            return users;
         } else {
             AbstractUserStoreManager tempCarbonUM = carbonUM;
             // If pagination and domain name are not given, then perform filtering on all available user stores.
@@ -2027,13 +2026,12 @@ public class SCIMUserManager implements UserManager {
                     domainName = tempCarbonUM.getRealmConfiguration().getUserStoreProperty("DomainName");
                     users = getFilteredUsersFromMultiAttributeFiltering(node, offset, maxLimit, sortBy, sortOrder,
                             domainName, false);
-                    filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
                 }
                 // If secondary user store manager assigned to carbonUM then global variable carbonUM will contains the
                 // secondary user store manager.
                 tempCarbonUM = (AbstractUserStoreManager) tempCarbonUM.getSecondaryUserStoreManager();
             }
-            return filteredUsers;
+            return users;
         }
     }
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -88,6 +88,7 @@ import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.Role;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
+import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.charon3.core.protocol.ResponseCodeConstants;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -2795,7 +2796,7 @@ public class SCIMUserManager implements UserManager {
     }
 
     @Override
-    public List<Object> listGroupsWithGET(Node rootNode, int startIndex, int count, String sortBy, String sortOrder,
+    public GroupsGetResponse listGroupsWithGET(Node rootNode, int startIndex, int count, String sortBy, String sortOrder,
                                           String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
@@ -2813,7 +2814,7 @@ public class SCIMUserManager implements UserManager {
     }
 
     @Override
-    public List<Object> listGroupsWithGET(Node rootNode, Integer startIndex, Integer count, String sortBy,
+    public GroupsGetResponse listGroupsWithGET(Node rootNode, Integer startIndex, Integer count, String sortBy,
                                           String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
@@ -2860,13 +2861,12 @@ public class SCIMUserManager implements UserManager {
      * @throws CharonException If an error occurred.
      * @throws BadRequestException If an error occurred.
      */
-    private List<Object> listGroups(int startIndex, Integer count, String sortBy, String sortOrder, String domainName,
-                                    Map<String, Boolean> requiredAttributes) throws CharonException,
+    private GroupsGetResponse listGroups(int startIndex, Integer count, String sortBy, String sortOrder, String domainName,
+                                         Map<String, Boolean> requiredAttributes) throws CharonException,
             BadRequestException {
 
-        List<Object> groupList = new ArrayList<>();
-        // 0th index is to store total number of results.
-        groupList.add(0);
+        GroupsGetResponse groupsResponse = new GroupsGetResponse(0, Collections.emptyList());
+        List<Group> groupList = new ArrayList<>();
         try {
             Set<String> groupNames;
             if (carbonUM.isRoleAndGroupSeparationEnabled()) {
@@ -2925,9 +2925,9 @@ public class SCIMUserManager implements UserManager {
         } catch (IdentitySCIMException | BadRequestException e) {
             throw new CharonException("Error in retrieving SCIM Group information from database.", e);
         }
-        // Set the totalResults value in index 0.
-        groupList.set(0, groupList.size() - 1);
-        return groupList;
+        groupsResponse.setTotalGroups(groupList.size());
+        groupsResponse.setGroups(groupList);
+        return groupsResponse;
     }
 
     /**
@@ -3018,7 +3018,7 @@ public class SCIMUserManager implements UserManager {
      * @throws NotImplementedException Complex filters are used.
      * @throws CharonException         Unknown node operation.
      */
-    private List<Object> filterGroups(Node rootNode, int startIndex, Integer count, String sortBy, String sortOrder,
+    private GroupsGetResponse filterGroups(Node rootNode, int startIndex, Integer count, String sortBy, String sortOrder,
                                       String domainName, Map<String, Boolean> requiredAttributes)
             throws NotImplementedException, CharonException, BadRequestException {
 
@@ -3048,7 +3048,7 @@ public class SCIMUserManager implements UserManager {
      * @return Filtered groups
      * @throws CharonException Error in Filtering
      */
-    private List<Object> filterGroupsBySingleAttribute(ExpressionNode node, int startIndex, int count, String sortBy,
+    private GroupsGetResponse filterGroupsBySingleAttribute(ExpressionNode node, int startIndex, int count, String sortBy,
                                                        String sortOrder, String domainName,
                                                        Map<String, Boolean> requiredAttributes)
             throws CharonException, BadRequestException {
@@ -3069,9 +3069,7 @@ public class SCIMUserManager implements UserManager {
         // EnableFilteringEnhancements' properties in identity.xml or domain name embedded in the filter attribute
         // value.
         domainName = resolveDomain(domainName, node);
-        List<Object> filteredGroups = new ArrayList<>();
-        // 0th index is to store total number of results.
-        filteredGroups.add(0);
+        List<Group> filteredGroups = new ArrayList<>();
         try {
             List<String> groupsList = new ArrayList<>(getGroupList(node, domainName));
 
@@ -3094,9 +3092,7 @@ public class SCIMUserManager implements UserManager {
                         }
                     } else {
                         // Returning null will send a resource not found error to client by Charon.
-                        filteredGroups.clear();
-                        filteredGroups.add(0);
-                        return filteredGroups;
+                        return new GroupsGetResponse(0, null);
                     }
                 }
             }
@@ -3108,9 +3104,7 @@ public class SCIMUserManager implements UserManager {
             throw resolveError(e, "Error in filtering group with filter: " + attributeName + " + " +
                     filterOperation + " + " + attributeValue);
         }
-        // Set the totalResults value in index 0.
-        filteredGroups.set(0, filteredGroups.size() - 1);
-        return filteredGroups;
+        return new GroupsGetResponse(filteredGroups.size(), filteredGroups);
     }
 
     /**
@@ -3722,7 +3716,7 @@ public class SCIMUserManager implements UserManager {
     }
 
     @Override
-    public List<Object> listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
+    public GroupsGetResponse listGroupsWithPost(SearchRequest searchRequest, Map<String, Boolean> requiredAttributes)
             throws BadRequestException, NotImplementedException, CharonException {
 
         return listGroupsWithGET(searchRequest.getFilter(), searchRequest.getStartIndex(), searchRequest.getCount(),

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1996,7 +1996,7 @@ public class SCIMUserManager implements UserManager {
                 maxLimit = Math.max(maxLimit, limit);
             }
             // Get total users based on the filter query.
-            totalResults += getMultiAttributeFilteredUsersWithMaxLimit(node, requiredAttributes, 1, sortBy,
+            totalResults += getMultiAttributeFilteredUsersWithMaxLimit(node, 1, sortBy,
                     sortOrder, domainName, maxLimit).size();
         } else {
             totalResults += filteredUsers.size();

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -44,6 +44,7 @@ import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.Role;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.RolesGetResponse;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.OperationNode;
@@ -402,8 +403,8 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             throws NotImplementedException, BadRequestException, CharonException {
 
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN);
-        List<Object> roles = roleManager.listRolesWithGET(null, 1, 0, null, null);
-        assertEquals(roles.size(), 0);
+        RolesGetResponse rolesResponse = roleManager.listRolesWithGET(null, 1, 0, null, null);
+        assertEquals(rolesResponse.getRoles().size(), 0);
     }
 
     @DataProvider(name = "dataProviderForListRolesWithGETInvalidLimit")
@@ -855,9 +856,9 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             CharonException {
 
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN2);
-        List<Object> roles = roleManager.listRolesWithPost(getDummySearchRequest(null, 2, 0,
+        RolesGetResponse rolesResponse = roleManager.listRolesWithPost(getDummySearchRequest(null, 2, 0,
                 null, null));
-        assertEquals(roles.size(), 0);
+        assertEquals(rolesResponse.getRoles().size(), 0);
     }
 
     @DataProvider(name = "dataProviderForListRolesWithPOSTInvalidLimit")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -570,12 +570,12 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         when(mockRoleManagementService.getRolesCount(anyString())).thenAnswer(invocationOnMock -> 5);
 
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN);
-        List<Object> listRolesWithGET = roleManager.listRolesWithGET(rootNode, 2, (Integer) count, null, null);
-        int totalRolesCount = (Integer)listRolesWithGET.get(0);
+        RolesGetResponse rolesResponse = roleManager.listRolesWithGET(rootNode, 2, (Integer) count, null, null);
+
         if (rootNode == null) {
-            assertEquals(totalRolesCount, 5);
+            assertEquals(rolesResponse.getTotalRoles(), 5);
         } else {
-            assertEquals(totalRolesCount, roleList.size());
+            assertEquals(rolesResponse.getTotalRoles(), roleList.size());
         }
         assertTrue(true, "list roles works as expected");
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolv
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
+import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
@@ -431,10 +432,10 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
 
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
-        List<Object> roleList = scimUserManager.listGroupsWithGET(node, 1, 1, null, null,
+        GroupsGetResponse groupsResponse = scimUserManager.listGroupsWithGET(node, 1, 1, null, null,
                 null, requiredAttributes);
 
-        assertEquals(roleList.size(), 2);
+        assertEquals(groupsResponse.getGroups().size(), 1);
 
     }
 
@@ -952,12 +953,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/scim2/Groups");
 
         SCIMUserManager scimUserManager = new SCIMUserManager(abstractUserStoreManager, mockedClaimManager);
-        List<Object> roleList = scimUserManager
+        GroupsGetResponse groupsResponse = scimUserManager
                 .listGroupsWithGET(null, 1, null, null, null, "Application", requiredAttributes);
-        roleList.remove(0); //The first entry is the count of roles.
-        assertEquals(((Group) roleList.get(0)).getDisplayName(), "Application/Apple");
-        assertEquals(((Group) roleList.get(1)).getDisplayName(), "Application/MyApp");
-        assertEquals(roleList.size(), 2);
+
+        assertEquals(groupsResponse.getGroups().get(0).getDisplayName(), "Application/Apple");
+        assertEquals(groupsResponse.getGroups().get(1).getDisplayName(), "Application/MyApp");
+        assertEquals(groupsResponse.getGroups().size(), 2);
     }
 
     @DataProvider(name = "listApplicationRoles")
@@ -1009,11 +1010,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/scim2/Groups");
 
         SCIMUserManager scimUserManager = new SCIMUserManager(abstractUserStoreManager, mockedClaimManager);
-        List<Object> roleList = scimUserManager
+        GroupsGetResponse groupsResponse = scimUserManager
                 .listGroupsWithGET(node, 1, null, null, null, "Application", requiredAttributes);
-        roleList.remove(0); //The first entry is the count of roles.
-        assertEquals(((Group) roleList.get(0)).getDisplayName(), "Application/MyApp");
-        assertEquals(roleList.size(), 1);
+
+        assertEquals(groupsResponse.getGroups().get(0).getDisplayName(), "Application/MyApp");
+        assertEquals(groupsResponse.getGroups().size(), 1);
     }
 
     @DataProvider(name = "applicationDomainWithFilters")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -726,11 +726,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockClaimMetadataManagementService.getLocalClaims(anyString())).thenReturn(localClaimList);
         when(mockClaimMetadataManagementService.getExternalClaims(anyString(), anyString())).thenReturn(externalClaimList);
-        List<Object> result = scimUserManager.listUsersWithGET(node, 1, count, null, null, domain,
+        UsersGetResponse userResponse = scimUserManager.listUsersWithGET(node, 1, count, null, null, domain,
                 requiredClaimsMap);
 
-        assertEquals(expectedResultCount, result.size());
-        assertEquals(expectedTotalCount, result.get(0));
+        assertEquals(expectedResultCount, userResponse.getUsers().size());
+        assertEquals(expectedTotalCount, userResponse.getTotalUsers());
     }
 
     @DataProvider(name = "getDataForFilterUsersWithPagination")
@@ -802,7 +802,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser2);
                             add(testUser3);
                         }},
-                        true, false, "PRIMARY", 2, 4, 3, 3},
+                        true, false, "PRIMARY", 2, 4, 2, 3},
                 {users, "name.givenName eq testUser",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
@@ -813,7 +813,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser2);
                             add(testUser3);
                         }},
-                        false, false, "PRIMARY", 2, 4, 3, 2},
+                        false, false, "PRIMARY", 2, 4, 2, 2},
 
                 {users, "name.givenName eq testUser",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
@@ -825,7 +825,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser2);
                             add(testUser3);
                         }},
-                        true, false, "SECONDARY", 2, 4, 3, 3},
+                        true, false, "SECONDARY", 2, 4, 2, 3},
                 {users, "name.givenName eq testUser",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
@@ -836,7 +836,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser2);
                             add(testUser3);
                         }},
-                        true, true, "SECONDARY", 2, 4, 3, 3},
+                        true, true, "SECONDARY", 2, 4, 2, 3},
 
                 {users, "name.givenName sw testUser and name.givenName co New",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
@@ -846,7 +846,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser4);
                             add(testUser5);
                         }},
-                        true, false, "PRIMARY", 1, 4, 2, 2},
+                        true, false, "PRIMARY", 1, 4, 1, 2},
                 {users, "name.givenName sw testUser and name.givenName co New",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser4);
@@ -855,7 +855,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser4);
                             add(testUser5);
                         }},
-                        false, false, "PRIMARY", 1, 4, 2, 1},
+                        false, false, "PRIMARY", 1, 4, 1, 1},
 
                 {users, "name.givenName sw testUser and name.givenName co New",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
@@ -865,7 +865,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser4);
                             add(testUser5);
                         }},
-                        true, false, "SECONDARY", 1, 4, 2, 2},
+                        true, false, "SECONDARY", 1, 4, 1, 2},
                 {users, "name.givenName sw testUser and name.givenName co New",
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser4);
@@ -874,7 +874,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                             add(testUser4);
                             add(testUser5);
                         }},
-                        false, false, "SECONDARY", 1, 4, 2, 2},
+                        false, false, "SECONDARY", 1, 4, 1, 2},
 
         };
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -113,9 +113,9 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /*
  * Unit tests for SCIMUserManager
@@ -474,7 +474,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         requiredClaimsMap.put("urn:ietf:params:scim:schemas:core:2.0:User:userName", false);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
         UsersGetResponse result = scimUserManager.listUsersWithGET(null, 1, 0, null, null, requiredClaimsMap);
-        assertEquals(expectedResultCount, result.getUsers().size());
+        assertEquals(result.getUsers().size(), expectedResultCount);
     }
 
     @DataProvider(name = "listUser")
@@ -496,18 +496,18 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
                 // If SCIM is enabled for both primary and secondary, result should contain a total of 4 entries,
                 // including the metadata in index position.
-                {users, true, true, 4},
+                {users, true, true, 3},
 
                 // If SCIM is enabled for primary but not for secondary, result should contain 3 entries including
                 // the metadata in index position and 2 users [testUser1, testUser2] from primary user-store domain.
-                {users, true, false, 3},
+                {users, true, false, 2},
 
                 // If SCIM is enabled for secondary but not for primary, result should contain 2 entries including
                 // the metadata in index position and 1 users [SECONDARY/testUser3] from secondary user-store domain.
-                {users, false, true, 2},
+                {users, false, true, 1},
 
                 // If no users are present in user-stores, result should contain a single entry for metadata.
-                {Collections.EMPTY_LIST, true, true, 1}
+                {Collections.EMPTY_LIST, true, true, 0}
         };
     }
 
@@ -572,7 +572,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         UsersGetResponse result = scimUserManager.listUsersWithGET(node, 1, null, null, null, null,
                 requiredClaimsMap);
-        assertEquals(expectedResultCount, result.getUsers().size());
+        assertEquals(result.getUsers().size(), expectedResultCount);
     }
 
     @DataProvider(name = "userInfoForFiltering")
@@ -598,12 +598,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         return new Object[][]{
 
-                {users, "name.givenName eq testUser", 3,
+                {users, "name.givenName eq testUser", 2,
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
                             add(testUser2);
                         }}},
-                {users, "name.givenName eq testUser and emails eq testUser1@wso2.com", 2,
+                {users, "name.givenName eq testUser and emails eq testUser1@wso2.com", 1,
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
                         }}}
@@ -955,8 +955,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         List<Object> roleList = scimUserManager
                 .listGroupsWithGET(null, 1, null, null, null, "Application", requiredAttributes);
         roleList.remove(0); //The first entry is the count of roles.
-        assertEquals("Application/Apple", ((Group) roleList.get(0)).getDisplayName());
-        assertEquals("Application/MyApp", ((Group) roleList.get(1)).getDisplayName());
+        assertEquals(((Group) roleList.get(0)).getDisplayName(), "Application/Apple");
+        assertEquals(((Group) roleList.get(1)).getDisplayName(), "Application/MyApp");
         assertEquals(roleList.size(), 2);
     }
 
@@ -1012,7 +1012,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         List<Object> roleList = scimUserManager
                 .listGroupsWithGET(node, 1, null, null, null, "Application", requiredAttributes);
         roleList.remove(0); //The first entry is the count of roles.
-        assertEquals("Application/MyApp", ((Group) roleList.get(0)).getDisplayName());
+        assertEquals(((Group) roleList.get(0)).getDisplayName(), "Application/MyApp");
         assertEquals(roleList.size(), 1);
     }
 
@@ -1131,7 +1131,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
             }
         }
 
-        assertTrue("UserName claim update is not properly handled.", hasExpectedBehaviour);
+        assertTrue(hasExpectedBehaviour, "UserName claim update is not properly handled.");
     }
 
     @Test
@@ -1165,7 +1165,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         List<Attribute> list = scimUserManager.getUserSchema();
-        assertEquals(3, list.size());
+        assertEquals(list.size(), 3);
     }
 
     @Test(dataProvider = "groupPermission")
@@ -1178,7 +1178,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 .thenReturn(mockedRolePermissionManagementService);
         when(mockedRolePermissionManagementService.getRolePermissions(anyString(), anyInt())).thenReturn(permission);
         String[] actual = scimUserManager.getGroupPermissions(roleName);
-        assertEquals(expected, actual);
+        assertEquals(actual, expected);
     }
 
     @DataProvider(name = "groupPermission")
@@ -1369,13 +1369,13 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
         User scimUser = scimUserManager.getUser(userId, requiredAttributes);
-        assertEquals(expectedNoOfAttributes, scimUser.getAttributeList().size());
+        assertEquals(scimUser.getAttributeList().size(), expectedNoOfAttributes);
         // Check whether the added multi valued attributes for the addresses attribute are contained.
-        assertEquals(2,
-                ((MultiValuedAttribute) scimUser.getAttribute("addresses")).getAttributeValues().size());
-        assertEquals(expectedUserName, scimUser.getUserName());
-        assertEquals(expectedNoOfGroups, scimUser.getGroups().size());
-        assertEquals(expectedNoOfRoles, scimUser.getRoles().size());
+        assertEquals(
+                ((MultiValuedAttribute) scimUser.getAttribute("addresses")).getAttributeValues().size(), 2);
+        assertEquals(scimUser.getUserName(), expectedUserName);
+        assertEquals(scimUser.getGroups().size(), expectedNoOfGroups);
+        assertEquals(scimUser.getRoles().size(), expectedNoOfRoles);
     }
 
     @DataProvider(name = "exceptionHandlingConfigurations")
@@ -1438,15 +1438,14 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
     public void testListUsersWithPost() throws Exception {
 
         SearchRequest searchRequest = new SearchRequest();
-        List<Object> listOfUsers = new ArrayList<>();
-
+        UsersGetResponse usersGetResponse = new UsersGetResponse(0, Collections.emptyList());
         Map<String, Boolean> requiredAttributes = new HashMap<>();
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
-        doReturn(listOfUsers).when(scimUserManager)
+        doReturn(usersGetResponse).when(scimUserManager)
                 .listUsersWithGET(any(), any(), any(), anyString(), anyString(), anyString(), anyMap());
         UsersGetResponse users = scimUserManager.listUsersWithPost(searchRequest, requiredAttributes);
-        assertEquals(listOfUsers, users);
+        assertEquals(users, usersGetResponse);
     }
 
     @Test(expectedExceptions = NotFoundException.class)

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
+import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
@@ -472,8 +473,9 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         HashMap<String, Boolean> requiredClaimsMap = new HashMap<>();
         requiredClaimsMap.put("urn:ietf:params:scim:schemas:core:2.0:User:userName", false);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
-        List<Object> result = scimUserManager.listUsersWithGET(null, 1, 0, null, null, requiredClaimsMap);
-        assertEquals(expectedResultCount, result.size());
+        UsersGetResponse result = scimUserManager.listUsersWithGET(null, 1, 0, null,
+                null, requiredClaimsMap);
+        assertEquals(expectedResultCount, result.getUsers().size());
     }
 
     @DataProvider(name = "listUser")
@@ -569,9 +571,9 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
             node = filterTreeManager.buildTree();
         }
 
-        List<Object> result = scimUserManager.listUsersWithGET(node, 1, null, null, null, null,
+        UsersGetResponse result = scimUserManager.listUsersWithGET(node, 1, null, null, null, null,
                 requiredClaimsMap);
-        assertEquals(expectedResultCount, result.size());
+        assertEquals(expectedResultCount, result.getUsers().size());
     }
 
     @DataProvider(name = "userInfoForFiltering")
@@ -1444,7 +1446,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
         doReturn(listOfUsers).when(scimUserManager)
                 .listUsersWithGET(any(), any(), any(), anyString(), anyString(), anyString(), anyMap());
-        List<Object> users = scimUserManager.listUsersWithPost(searchRequest, requiredAttributes);
+        UsersGetResponse users = scimUserManager.listUsersWithPost(searchRequest, requiredAttributes);
         assertEquals(listOfUsers, users);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -473,8 +473,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         HashMap<String, Boolean> requiredClaimsMap = new HashMap<>();
         requiredClaimsMap.put("urn:ietf:params:scim:schemas:core:2.0:User:userName", false);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
-        UsersGetResponse result = scimUserManager.listUsersWithGET(null, 1, 0, null,
-                null, requiredClaimsMap);
+        UsersGetResponse result = scimUserManager.listUsersWithGET(null, 1, 0, null, null, requiredClaimsMap);
         assertEquals(expectedResultCount, result.getUsers().size());
     }
 

--- a/components/org.wso2.carbon.identity.scim2.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath> ../../pom.xml</relativePath>
-        <version>1.6.20-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.6.20-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.6.20-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.6.20-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>identity-inbound-provisioning-scim2</artifactId>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.6.20-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>WSO2 Carbon - SCIM Provisioning Module</name>
     <description>
         SCIM 2.0 Implementation for C4

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>
-        <charon.version>3.4.24</charon.version>
+        <charon.version>4.0.2-SNAPSHOT</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>
-        <charon.version>4.0.2-SNAPSHOT</charon.version>
+        <charon.version>4.0.1</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
## Purpose
In my attempts to implement cursor based pagination, it was noticed that the current method of returning the total number of results along with the list of users/roles/groups for GET requests and POST/.Search requests was to allocate the 1st position of a _List_ to carry the total results and the remainder to carry the users. 
It is not appropriate to store different data types in a _List_ therefore it was decided to refactor the code to change the return type to a custom java object which comprises of the users and total results. With the intention of supporting forwards cursor and backwards cursor for cursor pagination (Implemented [here](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/417/commits/59a04cbd536928b7d620134ba12322d0f62d40ad) and [here](https://github.com/wso2/charon/pull/368/commits/7389fa01853122f80cdd8a3b1e8810bd0e20bd07#diff-32914d3be281f9ccb36fe8cc05d50a694f7364dbf5b6ba7623f7d29103998f38)).

Additionally, changes were made to the return type of listGroupsWithGET (GroupsGetResponse object) and listRolesWithGet (RolesGetResponse object) to stay consistent with the changes made to the return type of listUsersWithGET.

## Goals
The same functionality is maintained while;

- Changing the return type of listUsersWithGET from a _List_ to a _custom java object_ : UsersGetResponse.
- Changing the return type of listGroupsWithGET from a _List_ to a _custom java object_ : GroupsGetResponse.
- Changing the return type of listRolesWithGET from a _List_ to a _custom java object_ : RolesGetResponse.

## Depends on PRs:

- [x] https://github.com/wso2/charon/pull/371
- [x] https://github.com/wso2/charon/pull/372

## Test environment
Ubuntu 20.04, WSO2IS-5.12.0-beta2-SNAPSHOT
