### PR TITLE
Set Correct Type for Boolean Attributes

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5576,7 +5576,6 @@ public class SCIMUserManager implements UserManager {
         return "active".equals(name);
     }
 
-
     private boolean isMultivaluedAttribute(String name) {
 
         switch (name) {


### PR DESCRIPTION
**Brief Description**
The Attribute type of boolean attributes such as `Active` are not correctly set in the scim2/Schemas API request. 
This PR fixes this issue (https://github.com/wso2/product-is/issues/13978)

**Related issues**
https://github.com/wso2/product-is/issues/13978