### PR TITLE
Changing the response type for listGroupsWithGET and listRolesWithGet

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -38,6 +38,7 @@ import org.wso2.charon3.core.extensions.RoleManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.Role;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.RolesGetResponse;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.OperationNode;
@@ -175,13 +176,13 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     @Override
-    public List<Object> listRolesWithGET(Node rootNode, Integer startIndex, Integer count, String sortBy,
-            String sortOrder) throws CharonException, NotImplementedException, BadRequestException {
+    public RolesGetResponse listRolesWithGET(Node rootNode, Integer startIndex, Integer count, String sortBy,
+                            String sortOrder) throws CharonException, NotImplementedException, BadRequestException {
 
         if (sortBy != null || sortOrder != null) {
             throw new NotImplementedException("Sorting is not supported.");
         } else if (count != null && count == 0) {
-            return Collections.emptyList();
+            return new RolesGetResponse(0, Collections.emptyList());
         } else if (rootNode != null) {
             return filterRoles(rootNode, count, startIndex, sortBy, sortOrder);
         } else {
@@ -200,7 +201,7 @@ public class SCIMRoleManager implements RoleManager {
      * @return Detailed user list.
      * @throws CharonException Error filtering the roles.
      */
-    private List<Object> filterRoles(Node node, Integer count, Integer startIndex, String sortBy, String sortOrder)
+    private RolesGetResponse filterRoles(Node node, Integer count, Integer startIndex, String sortBy, String sortOrder)
             throws CharonException, NotImplementedException, BadRequestException {
 
         // Handle single attribute search.
@@ -225,7 +226,7 @@ public class SCIMRoleManager implements RoleManager {
      * @return Filtered roles.
      * @throws CharonException Error filtering the roles.
      */
-    private List<Object> filterRolesBySingleAttribute(ExpressionNode node, Integer count, Integer startIndex,
+    private RolesGetResponse filterRolesBySingleAttribute(ExpressionNode node, Integer count, Integer startIndex,
             String sortBy, String sortOrder) throws CharonException, BadRequestException {
 
         String attributeName = node.getAttributeValue();
@@ -241,9 +242,6 @@ public class SCIMRoleManager implements RoleManager {
             throw new BadRequestException(errorMessage);
         }
 
-        List<Object> filteredRoles = new ArrayList<>();
-        // 0th index is to store total number of results.
-        filteredRoles.add(0);
         String searchFilter = getSearchFilter(filterOperation, attributeValue);
         if (log.isDebugEnabled()) {
             log.debug(String.format("Filtering roleNames from search filter: %s", searchFilter));
@@ -256,14 +254,8 @@ public class SCIMRoleManager implements RoleManager {
                     String.format("Error occurred while listing roles based on the search filter: %s", searchFilter),
                     e);
         }
-        List<Object> scimRoles = getScimRolesList(roles);
-
-        // Set total number of results to 0th index.
-        filteredRoles.set(0, scimRoles.size());
-        // Add the results list.
-        filteredRoles.addAll(scimRoles);
-
-        return filteredRoles;
+        List<Role> scimRoles = getScimRolesList(roles);
+        return new RolesGetResponse(scimRoles.size(), scimRoles);
     }
 
     /**
@@ -312,30 +304,26 @@ public class SCIMRoleManager implements RoleManager {
      * @return List of roles.
      * @throws CharonException Error while listing users
      */
-    private List<Object> listRoles(Integer count, Integer startIndex, String sortBy, String sortOrder)
+    private RolesGetResponse listRoles(Integer count, Integer startIndex, String sortBy, String sortOrder)
             throws CharonException, BadRequestException {
 
-        List<Object> rolesList = new ArrayList<>();
+        List<Role> rolesList = new ArrayList<>();
         try {
-            // 0th index is to store total number of results.
-            rolesList.add(0);
             List<RoleBasicInfo> roles = roleManagementService
                     .getRoles(count, startIndex, sortBy, sortOrder, tenantDomain);
-            List<Object> scimRoles = getScimRolesList(roles);
+            List<Role> scimRoles = getScimRolesList(roles);
 
-            // Set total number of results to 0th index.
-            rolesList.set(0, scimRoles.size());
             // Add the results list.
             rolesList.addAll(scimRoles);
         } catch (IdentityRoleManagementException e) {
             throw new CharonException("Error occurred while listing roles.", e);
         }
-        return rolesList;
+        return new RolesGetResponse(rolesList.size(), rolesList);
     }
 
-    private List<Object> getScimRolesList(List<RoleBasicInfo> roles) throws BadRequestException, CharonException {
+    private List<Role> getScimRolesList(List<RoleBasicInfo> roles) throws BadRequestException, CharonException {
 
-        List<Object> scimRoles = new ArrayList<>();
+        List<Role> scimRoles = new ArrayList<>();
         for (RoleBasicInfo roleBasicInfo : roles) {
             Role scimRole = new Role();
             scimRole.setDisplayName(roleBasicInfo.getName());
@@ -522,7 +510,7 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     @Override
-    public List<Object> listRolesWithPost(SearchRequest searchRequest)
+    public RolesGetResponse listRolesWithPost(SearchRequest searchRequest)
             throws NotImplementedException, BadRequestException, CharonException {
 
         return listRolesWithGET(searchRequest.getFilter(), searchRequest.getStartIndex(), searchRequest.getCount(),

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -44,6 +44,7 @@ import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.Role;
 import org.wso2.charon3.core.objects.User;
+import org.wso2.charon3.core.objects.plainobjects.RolesGetResponse;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.OperationNode;
@@ -402,8 +403,8 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             throws NotImplementedException, BadRequestException, CharonException {
 
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN);
-        List<Object> roles = roleManager.listRolesWithGET(null, 1, 0, null, null);
-        assertEquals(roles.size(), 0);
+        RolesGetResponse rolesResponse = roleManager.listRolesWithGET(null, 1, 0, null, null);
+        assertEquals(rolesResponse.getRoles().size(), 0);
     }
 
     @DataProvider(name = "dataProviderForListRolesWithGETInvalidLimit")
@@ -848,9 +849,9 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             CharonException {
 
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN2);
-        List<Object> roles = roleManager.listRolesWithPost(getDummySearchRequest(null, 2, 0,
+        RolesGetResponse rolesResponse = roleManager.listRolesWithPost(getDummySearchRequest(null, 2, 0,
                 null, null));
-        assertEquals(roles.size(), 0);
+        assertEquals(rolesResponse.getRoles().size(), 0);
     }
 
     @DataProvider(name = "dataProviderForListRolesWithPOSTInvalidLimit")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
+import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
@@ -425,10 +426,10 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
 
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
-        List<Object> roleList = scimUserManager.listGroupsWithGET(node, 1, 1, null, null,
+        GroupsGetResponse groupsResponse = scimUserManager.listGroupsWithGET(node, 1, 1, null, null,
                 null, requiredAttributes);
 
-        assertEquals(roleList.size(), 2);
+        assertEquals(groupsResponse.getGroups().size(), 1);
 
     }
 
@@ -674,12 +675,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/scim2/Groups");
 
         SCIMUserManager scimUserManager = new SCIMUserManager(abstractUserStoreManager, mockedClaimManager);
-        List<Object> roleList = scimUserManager
+        GroupsGetResponse groupsResponse = scimUserManager
                 .listGroupsWithGET(null, 1, null, null, null, "Application", requiredAttributes);
-        roleList.remove(0); //The first entry is the count of roles.
-        assertEquals("Application/Apple", ((Group) roleList.get(0)).getDisplayName());
-        assertEquals("Application/MyApp", ((Group) roleList.get(1)).getDisplayName());
-        assertEquals(roleList.size(), 2);
+        assertEquals(groupsResponse.getGroups().get(0).getDisplayName(), "Application/Apple");
+        assertEquals(groupsResponse.getGroups().get(1).getDisplayName(), "Application/MyApp");
+        assertEquals(groupsResponse.getGroups().size(), 2);
     }
 
     @DataProvider(name = "listApplicationRoles")
@@ -731,11 +731,10 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/scim2/Groups");
 
         SCIMUserManager scimUserManager = new SCIMUserManager(abstractUserStoreManager, mockedClaimManager);
-        List<Object> roleList = scimUserManager
+        GroupsGetResponse groupsResponse = scimUserManager
                 .listGroupsWithGET(node, 1, null, null, null, "Application", requiredAttributes);
-        roleList.remove(0); //The first entry is the count of roles.
-        assertEquals("Application/MyApp", ((Group) roleList.get(0)).getDisplayName());
-        assertEquals(roleList.size(), 1);
+        assertEquals(groupsResponse.getGroups().get(0).getDisplayName(), "Application/MyApp");
+        assertEquals(groupsResponse.getGroups().size(), 1);
     }
 
     @DataProvider(name = "applicationDomainWithFilters")

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>
-        <charon.version>3.4.24</charon.version>
+        <charon.version>4.0.1</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
## Purpose
An extension of https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/426 to make the return type of listGroupsWithGET and listRolesWithGet consistent with the changes made to the return type of listUsersWithGET.

## Goals
The same functionality is maintained while changing the return type from a _List_ to a _custom java object_.

## Depends on
- [ ] https://github.com/wso2/charon/pull/372

## Test environment
Ubuntu 20.04, WSO2IS-5.12.0-beta2-SNAPSHOT