### PR TITLE
Support JDK 11 and JDK 17 Compilation

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,7 +1,7 @@
 # This workflow will build the project on pull requests with tests
 # Uses:
 #   OS: ubuntu-lates
-#   JDK: Adopt JDK 8
+#   JDK: Adopt JDK 11 and Adopt JDK 17
 
 name: PR Builder
 
@@ -17,12 +17,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11 and 17
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11, 17 ]
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Adopt JDK 11 and 17

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # identity-inbound-provisioning-scim2
+
+## Building from the source
+
+If you want to build **identity-inbound-provisioning-scim2** from the source code:
+
+1. Install Java 11 (or Java 17)
+2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi#)
+3. Get a clone or download the source from this repository (https://github.com/wso2-extensions/identity-inbound-provisioning-scim2)
+4. Run the Maven command ``mvn clean install`` from the ``identity-inbound-provisioning-scim2`` directory.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# identity-inbound-provisioning-scim2
+## Welcome to the WSO2 Identity Server (IS) identity-inbound-provisioning-scim2.
+
+WSO2 IS is one of the best Identity Servers, which enables you to offload your identity and user entitlement management burden totally from your application. It comes with many features, supports many industry standards and most importantly it allows you to extent it according to your security requirements. This repo contains Authenticators written to work with different third party systems.
+
+With WSO2 IS, there are lot of provisioning capabilities available. There are 3 major concepts as Inbound, outbound provisioning and Just-In-Time provisioning. Inbound provisioning means , provisioning users and groups from an external system to IS. Outbound provisioning means , provisioning users from IS to other external systems. JIT provisioning means , once a user tries to login from an external IDP, a user can be created on the fly in IS with JIT. Repos under this account holds such components invlove in communicating with external systems.
 
 ## Building from the source
 

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -233,6 +233,9 @@
                         --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.time=ALL-UNNAMED
+                        --add-opens java.base/java.text=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -23,7 +23,6 @@
         <relativePath>../../pom.xml</relativePath>
         <version>3.0.3-SNAPSHOT</version>
     </parent>
-
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.scim2.common</artifactId>
     <name>WSO2 Carbon - SCIM 2.0 - Common Component</name>
@@ -33,7 +32,6 @@
         <dependency>
             <groupId>com.sun.xml.parsers</groupId>
             <artifactId>jaxp-ri</artifactId>
-            <version>1.4.5</version>
         </dependency>
         <dependency>
             <groupId>commons-collections.wso2</groupId>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -31,6 +31,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.sun.xml.parsers</groupId>
+            <artifactId>jaxp-ri</artifactId>
+            <version>1.4.5</version>
+        </dependency>
+        <dependency>
             <groupId>commons-collections.wso2</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -130,6 +130,11 @@
             <artifactId>org.wso2.carbon.identity.password.policy</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -232,6 +232,7 @@
                     <argLine>
                         --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.1.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -23,6 +23,7 @@
         <relativePath>../../pom.xml</relativePath>
         <version>3.1.2-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.scim2.common</artifactId>
     <name>WSO2 Carbon - SCIM 2.0 - Common Component</name>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -246,6 +246,7 @@
                         --add-opens java.base/java.util.stream=ALL-UNNAMED
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/java.security=ALL-UNNAMED
+                        --add-opens=java.base/sun.reflect.misc=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -236,6 +236,11 @@
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/java.time=ALL-UNNAMED
                         --add-opens java.base/java.text=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.util.stream=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.security=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -165,7 +165,7 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
         mockStatic(SCIMCommonUtils.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
-        when(connection.prepareStatement(nullable(String.class))).thenReturn(mockedPreparedStatement);
+        when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
         when(StringUtils.isNotEmpty(nullable(String.class))).thenReturn(true);
         when(SCIMCommonUtils.getPrimaryFreeGroupName(nullable(String.class))).thenReturn("directors");
         when(mockedPreparedStatement.executeQuery()).thenReturn(resultSet);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Calendar;
 import java.util.Set;
 import java.util.HashSet;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyMap;
@@ -164,14 +165,14 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
         mockStatic(SCIMCommonUtils.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
-        when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
-        when(StringUtils.isNotEmpty(anyString())).thenReturn(true);
-        when(SCIMCommonUtils.getPrimaryFreeGroupName(anyString())).thenReturn("directors");
+        when(connection.prepareStatement(nullable(String.class))).thenReturn(mockedPreparedStatement);
+        when(StringUtils.isNotEmpty(nullable(String.class))).thenReturn(true);
+        when(SCIMCommonUtils.getPrimaryFreeGroupName(nullable(String.class))).thenReturn("directors");
         when(mockedPreparedStatement.executeQuery()).thenReturn(resultSet);
         when(mockedGroupDAO.getGroupNameById(1, "5")).thenReturn("directors");
         assertEquals(new SCIMGroupHandler(1).getGroupName("5"), "directors", "asserting for existance");
 
-        when(StringUtils.isNotEmpty(anyString())).thenReturn(false);
+        when(StringUtils.isNotEmpty(nullable(String.class))).thenReturn(false);
         assertNull(new SCIMGroupHandler(1).getGroupName("NON_EXISITNG_GROUP_NAME"), "asserting for non existance");
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
@@ -54,7 +55,7 @@ import static org.testng.Assert.fail;
  * Contains the unit test cases for IdentitySCIMManager.
  */
 @PrepareForTest({SCIMCommonUtils.class, PrivilegedCarbonContext.class, SCIMCommonComponentHolder.class,CharonConfiguration.class})
-
+@PowerMockIgnore({"javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
 public class IdentitySCIMManagerTest extends PowerMockTestCase {
 
     @Mock

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -483,6 +483,7 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
                     }
                     return null;
                 });
+
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN);
         assertThrows(CharonException.class, () -> roleManager.
                 listRolesWithGET(rootNode, startIndex, 2, null, null));
@@ -506,7 +507,8 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         when(mockRoleManagementService.getRoles(anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenThrow(unExpectedErrorThrower(tenantDomain, sError,
                         "Error while listing roles in tenantDomain: "));
-        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
+        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class),
+                nullable(String.class), anyString())).
                 thenThrow(unExpectedErrorThrower(tenantDomain, sError,
                         "Error while listing roles in tenantDomain: "));
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
@@ -561,9 +563,10 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         Node rootNode = generateNodeBasedOnNodeType(nodeType, "name", operation);
         List<RoleBasicInfo> roleList = getDummyRoleBasicInfoList();
 
-        when(mockRoleManagementService.getRoles(nullable(Integer.class), anyInt(), nullable(String.class), nullable(String.class), anyString())).
+        when(mockRoleManagementService.getRoles(anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenAnswer(invocationOnMock -> roleList);
-        when(mockRoleManagementService.getRoles(anyString(), nullable(Integer.class), anyInt(), nullable(String.class), nullable(String.class), anyString())).
+        when(mockRoleManagementService.getRoles(anyString(), nullable(Integer.class), anyInt(), nullable(String.class),
+                nullable(String.class), anyString())).
                 thenAnswer(invocationOnMock -> roleList);
         when(mockRoleManagementService.getRolesCount(anyString())).thenAnswer(invocationOnMock -> 5);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -300,6 +300,7 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         org.wso2.carbon.identity.role.mgt.core.Role role = getDummyIdentityRole(roleId, roleName, domain, tenantDomain,
                 isEmptyLists);
+        System.out.println(role);
         Map<String, Boolean> attributeMap = null;
         if (attributeKey != null) {
             // If attributeKey is not null, Add dummy data to attributeMap.
@@ -310,6 +311,7 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         SCIMRoleManager scimRoleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
         Role scimRole = scimRoleManager.getRole(roleId, attributeMap);
+        System.out.println(scimRole);
         assertScimRoleFull(scimRole, roleId);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -127,7 +127,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
     public void setUpMethod() {
 
         mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonUtils.getSCIMRoleURL(anyString())).thenReturn(DUMMY_SCIM_URL);
         when(SCIMCommonUtils.getSCIMRoleURL(nullable(String.class))).thenReturn(DUMMY_SCIM_URL);
         when(mockRoleManagementService.getSystemRoles()).thenReturn(SYSTEM_ROLES);
     }
@@ -222,8 +221,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             throws IdentityRoleManagementException, BadRequestException, CharonException, ConflictException {
 
         Role role = getDummyRole(roleId, roleDisplayName);
-        when(mockRoleManagementService.addRole(anyString(), anyListOf(String.class), anyListOf(String.class),
-                anyListOf(String.class), anyString())).thenReturn(new RoleBasicInfo(roleId, roleDisplayName));
         when(mockRoleManagementService.addRole(nullable(String.class), anyListOf(String.class), anyListOf(String.class),
                 anyListOf(String.class), anyString())).thenReturn(new RoleBasicInfo(roleId, roleDisplayName));
         SCIMRoleManager scimRoleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
@@ -435,16 +432,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
                     }
                     return null;
                 });
-        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString()))
-                .thenAnswer(invocationOnMock -> {
-                    Integer countArg = invocationOnMock.getArgument(1);
-                    if (countArg != null && countArg < 0) {
-                        String errorMessage = String.format("Invalid limit requested. Limit value should be " +
-                                "greater than or equal to zero. limit: %s", count);
-                        throw new IdentityRoleManagementClientException(INVALID_LIMIT.getCode(), errorMessage);
-                    }
-                    return null;
-                });
         when(mockRoleManagementService.getRoles(nullable(String.class), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString()))
                 .thenAnswer(invocationOnMock -> {
                     Integer countArg = invocationOnMock.getArgument(1);
@@ -485,17 +472,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
                     }
                     return null;
                 });
-        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString()))
-                .thenAnswer(invocationOnMock -> {
-                    Integer startIndexArg = invocationOnMock.getArgument(2);
-                    if (startIndexArg != null && startIndexArg < 0) {
-                        String errorMessage =
-                                "Invalid offset requested. offset value should be greater than or " +
-                                        "equal to zero. offset: " + startIndexArg;
-                        throw new IdentityRoleManagementClientException(INVALID_LIMIT.getCode(), errorMessage);
-                    }
-                    return null;
-                });
         when(mockRoleManagementService.getRoles(nullable(String.class), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString()))
                 .thenAnswer(invocationOnMock -> {
                     Integer startIndexArg = invocationOnMock.getArgument(2);
@@ -507,11 +483,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
                     }
                     return null;
                 });
-
-        if(rootNode!=null){
-            System.out.println(rootNode.toString());
-        }
-
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, SAMPLE_TENANT_DOMAIN);
         assertThrows(CharonException.class, () -> roleManager.
                 listRolesWithGET(rootNode, startIndex, 2, null, null));
@@ -593,10 +564,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         when(mockRoleManagementService.getRoles(nullable(Integer.class), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenAnswer(invocationOnMock -> roleList);
         when(mockRoleManagementService.getRoles(anyString(), nullable(Integer.class), anyInt(), nullable(String.class), nullable(String.class), anyString())).
-                thenAnswer(invocationOnMock -> roleList);
-        when(mockRoleManagementService.getRoles(anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
-                thenAnswer(invo dcationOnMock -> roleList);
-        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenAnswer(invocationOnMock -> roleList);
         when(mockRoleManagementService.getRolesCount(anyString())).thenAnswer(invocationOnMock -> 5);
 
@@ -991,8 +958,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             throws IdentityRoleManagementException {
 
         Node rootNode = generateNodeBasedOnNodeType(nodeType, "name");
-        System.out.println(nodeType);
-        System.out.println(rootNode);
 
         when(mockRoleManagementService.getRoles(anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenThrow(unExpectedErrorThrower(tenantDomain, sError,

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -61,7 +61,8 @@ import java.util.HashSet;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyListOf;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -960,12 +961,14 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
             throws IdentityRoleManagementException {
 
         Node rootNode = generateNodeBasedOnNodeType(nodeType, "name");
+        System.out.println(nodeType);
+        System.out.println(rootNode);
 
-        when(mockRoleManagementService.getRoles(anyInt(), anyInt(), anyString(), anyString(), anyString())).
+        when(mockRoleManagementService.getRoles(anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenThrow(unExpectedErrorThrower(tenantDomain, sError,
                         "Error while listing roles in tenantDomain: "));
-        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), anyString(),
-                anyString(), anyString())).thenThrow(unExpectedErrorThrower(tenantDomain, sError,
+        when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class),
+                nullable(String.class), anyString())).thenThrow(unExpectedErrorThrower(tenantDomain, sError,
                 "Error while listing roles in tenantDomain: "));
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
         assertThrows(CharonException.class, () -> roleManager.

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -595,7 +595,7 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         when(mockRoleManagementService.getRoles(anyString(), nullable(Integer.class), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenAnswer(invocationOnMock -> roleList);
         when(mockRoleManagementService.getRoles(anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
-                thenAnswer(invocationOnMock -> roleList);
+                thenAnswer(invo dcationOnMock -> roleList);
         when(mockRoleManagementService.getRoles(anyString(), anyInt(), anyInt(), nullable(String.class), nullable(String.class), anyString())).
                 thenAnswer(invocationOnMock -> roleList);
         when(mockRoleManagementService.getRolesCount(anyString())).thenAnswer(invocationOnMock -> 5);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -128,6 +128,7 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         mockStatic(SCIMCommonUtils.class);
         when(SCIMCommonUtils.getSCIMRoleURL(anyString())).thenReturn(DUMMY_SCIM_URL);
+        when(SCIMCommonUtils.getSCIMRoleURL(nullable(String.class))).thenReturn(DUMMY_SCIM_URL);
         when(mockRoleManagementService.getSystemRoles()).thenReturn(SYSTEM_ROLES);
     }
 
@@ -297,7 +298,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         org.wso2.carbon.identity.role.mgt.core.Role role = getDummyIdentityRole(roleId, roleName, domain, tenantDomain,
                 isEmptyLists);
-        System.out.println(role);
         Map<String, Boolean> attributeMap = null;
         if (attributeKey != null) {
             // If attributeKey is not null, Add dummy data to attributeMap.
@@ -308,7 +308,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         SCIMRoleManager scimRoleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
         Role scimRole = scimRoleManager.getRole(roleId, attributeMap);
-        System.out.println(scimRole);
         assertScimRoleFull(scimRole, roleId);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -224,6 +224,8 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
         Role role = getDummyRole(roleId, roleDisplayName);
         when(mockRoleManagementService.addRole(anyString(), anyListOf(String.class), anyListOf(String.class),
                 anyListOf(String.class), anyString())).thenReturn(new RoleBasicInfo(roleId, roleDisplayName));
+        when(mockRoleManagementService.addRole(nullable(String.class), anyListOf(String.class), anyListOf(String.class),
+                anyListOf(String.class), anyString())).thenReturn(new RoleBasicInfo(roleId, roleDisplayName));
         SCIMRoleManager scimRoleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
         Role createdRole = scimRoleManager.createRole(role);
         assertEquals(createdRole.getDisplayName(), roleDisplayName);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -300,7 +300,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         org.wso2.carbon.identity.role.mgt.core.Role role = getDummyIdentityRole(roleId, roleName, domain, tenantDomain,
                 isEmptyLists);
-        System.out.println(role);
         Map<String, Boolean> attributeMap = null;
         if (attributeKey != null) {
             // If attributeKey is not null, Add dummy data to attributeMap.
@@ -311,7 +310,6 @@ public class SCIMRoleManagerTest extends PowerMockTestCase {
 
         SCIMRoleManager scimRoleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);
         Role scimRole = scimRoleManager.getRole(roleId, attributeMap);
-        System.out.println(scimRole);
         assertScimRoleFull(scimRole, roleId);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -293,10 +293,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         org.wso2.carbon.user.core.common.User user = new org.wso2.carbon.user.core.common.User();
         user.setUsername("testUserName");
         user.setUserID(UUID.randomUUID().toString());
-        when(mockedUserStoreManager.getUser(anyString(), anyString())).thenReturn(user);
-
         when(mockedUserStoreManager.getUser(nullable(String.class), nullable(String.class))).thenReturn(user);
-
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         CommonTestUtils.initPrivilegedCarbonContext(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         mockStatic(ClaimMetadataHandler.class);
@@ -417,12 +414,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(list);
         org.wso2.carbon.user.core.common.Group[] groupsArray = {buildUserCoreGroupResponse(roleName, "1234",
                 "dummyDomain")};
-        when(mockedUserStoreManager.listGroups(any(Condition.class), anyString(), anyInt(),
-                anyInt(), anyString(), anyString())).thenReturn(Arrays.asList(groupsArray.clone()));
-
         when(mockedUserStoreManager.listGroups(any(Condition.class), nullable(String.class), anyInt(),
                 nullable(Integer.class), nullable(String.class), nullable(String.class))).thenReturn(Arrays.asList(groupsArray.clone()));
-
         when(mockedUserStoreManager.getGroupByGroupName(roleName, null)).
                 thenReturn(buildUserCoreGroupResponse(roleName, "123456789", null));
         whenNew(RealmConfiguration.class).withAnyArguments().thenReturn(mockRealmConfig);
@@ -467,14 +460,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-
-        //whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
-        //when(mockedGroupDAO.listSCIMGroups()).thenReturn(anySet());
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
-
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForPrimary);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForSecondary);
 
@@ -548,23 +535,15 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/givenname", "testUser", "default"))
                 .thenReturn(filteredUsers);
-        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), anyInt(),
-                anyInt(), anyString(), anyString())).thenReturn(filteredUsers);
-
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), nullable(String.class), nullable(String.class), anyInt(),
                 nullable(Integer.class), nullable(String.class), nullable(String.class))).thenReturn(filteredUsers);
-
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         when(mockedGroupDAO.listSCIMGroups(anyInt())).thenReturn(anySet());
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManager);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);
 
@@ -671,15 +650,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
         if(domain=="PRIMARY"){
             when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
+        } else {
+            when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManager);
         }
-
-        if(domain=="SECONDARY"){
-            when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManagerJDBC);
-        }
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManagerJDBC);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);
 
@@ -1147,10 +1122,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
-        doReturn(oldUser).when(scimUserManager).getUser(anyString(), anyMap());
-
         doReturn(oldUser).when(scimUserManager).getUser(nullable(String.class), nullable(Map.class));
-
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 
@@ -1208,7 +1180,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         mockStatic(SCIMCommonComponentHolder.class);
         when(SCIMCommonComponentHolder.getRolePermissionManagementService())
                 .thenReturn(mockedRolePermissionManagementService);
-        when(mockedRolePermissionManagementService.getRolePermissions(anyString(), anyInt())).thenReturn(permission);
         when(mockedRolePermissionManagementService.getRolePermissions(nullable(String.class), anyInt())).thenReturn(permission);
         String[] actual = scimUserManager.getGroupPermissions(roleName);
         assertEquals(actual, expected);
@@ -1354,27 +1325,15 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(user.getDomainQualifiedUsername()).thenReturn(domainQualifiedUserName);
 
         mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
-        when(mockedUserStoreManager.getUserWithID(anyString(), any(), anyString())).thenReturn(user);
-
         when(mockedUserStoreManager.getUserWithID(anyString(), nullable(String[].class), anyString())).thenReturn(user);
-
         when(mockedUserStoreManager.getTenantId()).thenReturn(1234567);
-        when(mockedUserStoreManager.getUserClaimValuesWithID(anyString(), any(), anyString()))
-                .thenReturn(userClaimValues);
-
         when(mockedUserStoreManager.getUserClaimValuesWithID(nullable(String.class), any(), nullable(String.class)))
                 .thenReturn(userClaimValues);
-
         when(mockedUserStoreManager.isRoleAndGroupSeparationEnabled()).thenReturn(isRoleAndGroupSeparationEnabled);
-        when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(groupsList);
-
         when(mockedUserStoreManager.getRoleListOfUserWithID(nullable(String.class))).thenReturn(groupsList);
-
         when(mockedUserStoreManager.getHybridRoleListOfUser(anyString(), anyString())).thenReturn(rolesList);
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
-
         for (String group : groupsList) {
             when(mockedUserStoreManager.getGroupByGroupName(group, null)).
                     thenReturn(buildUserCoreGroupResponse(group, "123456", "dummyDomain"));
@@ -1624,7 +1583,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.isExistingUserWithID(anyString())).thenReturn(true);
         when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(true);
-        when(mockedUserStoreManager.getUserList(anyString(), anyString(), anyString())).thenReturn(existingUserList);
         when(mockedUserStoreManager.getUserList(anyString(), anyString(), nullable(String.class))).thenReturn(existingUserList);
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString()))
                 .thenReturn(secondaryUserStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -281,8 +281,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         MemberModifier.field(AbstractUserStoreManager.class, "userStoreManagerHolder")
                 .set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
 
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
@@ -1374,8 +1372,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getHybridRoleListOfUser(anyString(), anyString())).thenReturn(rolesList);
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
-
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1619,6 +1619,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.isExistingUserWithID(anyString())).thenReturn(true);
         when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(true);
         when(mockedUserStoreManager.getUserList(anyString(), anyString(), anyString())).thenReturn(existingUserList);
+        when(mockedUserStoreManager.getUserList(anyString(), anyString(), nullable(String.class))).thenReturn(existingUserList);
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString()))
                 .thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1116,6 +1116,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         User newUser = new User();
         newUser.setUserName("newUser");
+        newUser.setId("newUserId");
 
         mockStatic(ApplicationManagementService.class);
         when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
@@ -1123,7 +1124,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
-        doReturn(oldUser).when(scimUserManager).getUser(nullable(String.class), anyMap());
+        doReturn(oldUser).when(scimUserManager).getUser(anyString(), anyMap());
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 
@@ -1324,11 +1325,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(user.getUserStoreDomain()).thenReturn(userStoreDomainName);
         when(user.getUsername()).thenReturn((username));
         when(user.getDomainQualifiedUsername()).thenReturn(domainQualifiedUserName);
+        when(user.getUserID()).thenReturn((userId));
 
         mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getUserWithID(anyString(), nullable(String[].class), anyString())).thenReturn(user);
         when(mockedUserStoreManager.getTenantId()).thenReturn(1234567);
-        when(mockedUserStoreManager.getUserClaimValuesWithID(nullable(String.class), any(), nullable(String.class)))
+        when(mockedUserStoreManager.getUserClaimValuesWithID(anyString(), any(), nullable(String.class)))
                 .thenReturn(userClaimValues);
         when(mockedUserStoreManager.isRoleAndGroupSeparationEnabled()).thenReturn(isRoleAndGroupSeparationEnabled);
         when(mockedUserStoreManager.getRoleListOfUserWithID(nullable(String.class))).thenReturn(groupsList);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -104,8 +104,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyMap;
-
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
@@ -660,20 +659,27 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
 
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), eq(count),
-                anyInt(), anyString(), anyString())).thenReturn(filteredUsersWithPagination);
+                anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithPagination);
 
 
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), eq(configuredMaxLimit),
-                anyInt(), anyString(), anyString())).thenReturn(filteredUsersWithoutPagination);
+                anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithoutPagination);
 
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), eq(users.size()),
-                anyInt(), anyString(), anyString())).thenReturn(filteredUsersWithoutPagination);
+                anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithoutPagination);
 
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-        whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.listSCIMGroups(anyInt())).thenReturn(anySet());
+        if(domain=="PRIMARY"){
+            when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
+        }
+
+        if(domain=="SECONDARY"){
+            when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManagerJDBC);
+        }
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManagerJDBC);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1187,7 +1187,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         mockStatic(SCIMCommonComponentHolder.class);
         when(SCIMCommonComponentHolder.getRolePermissionManagementService())
                 .thenReturn(mockedRolePermissionManagementService);
-        when(mockedRolePermissionManagementService.getRolePermissions(nullable(String.class), anyInt())).thenReturn(permission);
+        when(mockedRolePermissionManagementService.getRolePermissions(eq(roleName), anyInt())).thenReturn(permission);
         String[] actual = scimUserManager.getGroupPermissions(roleName);
         assertEquals(actual, expected);
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1446,7 +1446,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
         doReturn(usersGetResponse).when(scimUserManager)
-                .listUsersWithGET(any(), any(), any(), anyString(), anyString(), anyString(), anyMap());
+                .listUsersWithGET(any(), any(), any(), nullable(String.class), nullable(String.class), nullable(String.class), anyMap());
         UsersGetResponse users = scimUserManager.listUsersWithPost(searchRequest, requiredAttributes);
         assertEquals(users, usersGetResponse);
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -466,8 +466,10 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         when(mockedGroupDAO.listSCIMGroups()).thenReturn(anySet());
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForPrimary);
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForSecondary);
 
@@ -1135,6 +1137,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
         doReturn(oldUser).when(scimUserManager).getUser(anyString(), anyMap());
+
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 
@@ -1339,14 +1342,26 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getUserWithID(anyString(), any(), anyString())).thenReturn(user);
+
+        when(mockedUserStoreManager.getUserWithID(anyString(), nullable(String[].class), anyString())).thenReturn(user);
+
         when(mockedUserStoreManager.getTenantId()).thenReturn(1234567);
         when(mockedUserStoreManager.getUserClaimValuesWithID(anyString(), any(), anyString()))
                 .thenReturn(userClaimValues);
+
+        when(mockedUserStoreManager.getUserClaimValuesWithID(nullable(String.class), any(), nullable(String.class)))
+                .thenReturn(userClaimValues);
+
         when(mockedUserStoreManager.isRoleAndGroupSeparationEnabled()).thenReturn(isRoleAndGroupSeparationEnabled);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(groupsList);
+
+        when(mockedUserStoreManager.getRoleListOfUserWithID(nullable(String.class))).thenReturn(groupsList);
+
         when(mockedUserStoreManager.getHybridRoleListOfUser(anyString(), anyString())).thenReturn(rolesList);
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
+
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 
         for (String group : groupsList) {
             when(mockedUserStoreManager.getGroupByGroupName(group, null)).

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -282,8 +282,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         MemberModifier.field(AbstractUserStoreManager.class, "userStoreManagerHolder")
                 .set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
 
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
-
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
@@ -470,10 +468,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-        whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.listSCIMGroups()).thenReturn(anySet());
 
-        when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
+        //whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
+        //when(mockedGroupDAO.listSCIMGroups()).thenReturn(anySet());
+
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
+
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForPrimary);
 
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
@@ -503,7 +503,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         user.setUserID(UUID.randomUUID().toString());
         user.setUsername("testUser3");
         user.setUserStoreDomain("SECONDARY");
-
         users.add(user);
 
         return new Object[][]{
@@ -1367,7 +1366,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getHybridRoleListOfUser(anyString(), anyString())).thenReturn(rolesList);
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
 
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -127,7 +127,7 @@ import static org.testng.Assert.assertTrue;
         IdentityTenantUtil.class, AbstractUserStoreManager.class, Group.class, UserCoreUtil.class,
         ApplicationManagementService.class, RolePermissionManagementService.class, SCIMCommonComponentHolder.class,
         SCIMUserManager.class})
-@PowerMockIgnore("java.sql.*")
+@PowerMockIgnore({"java.sql.*","javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
 public class SCIMUserManagerTest extends PowerMockTestCase {
 
     private static final String USERNAME_LOCAL_CLAIM = "http://wso2.org/claims/username";

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1144,6 +1144,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
         doReturn(oldUser).when(scimUserManager).getUser(anyString(), anyMap());
 
+        doReturn(oldUser).when(scimUserManager).getUser(nullable(String.class), nullable(Map.class));
+
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -281,6 +281,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         MemberModifier.field(AbstractUserStoreManager.class, "userStoreManagerHolder")
                 .set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
 
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -416,6 +416,10 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 "dummyDomain")};
         when(mockedUserStoreManager.listGroups(any(Condition.class), anyString(), anyInt(),
                 anyInt(), anyString(), anyString())).thenReturn(Arrays.asList(groupsArray.clone()));
+
+        when(mockedUserStoreManager.listGroups(any(Condition.class), nullable(String.class), anyInt(),
+                nullable(Integer.class), nullable(String.class), nullable(String.class))).thenReturn(Arrays.asList(groupsArray.clone()));
+
         when(mockedUserStoreManager.getGroupByGroupName(roleName, null)).
                 thenReturn(buildUserCoreGroupResponse(roleName, "123456789", null));
         whenNew(RealmConfiguration.class).withAnyArguments().thenReturn(mockRealmConfig);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -459,7 +459,9 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
+        whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
+        when(mockedGroupDAO.listSCIMGroups()).thenReturn(anySet());
+        when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForPrimary);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForSecondary);
@@ -479,17 +481,26 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
     @DataProvider(name = "listUser")
     public Object[][] listUser() throws Exception {
 
-        List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>() {{
-            add(new org.wso2.carbon.user.core.common.User(UUID.randomUUID().toString(), "testUser1", "testUser1"));
-            add(new org.wso2.carbon.user.core.common.User(UUID.randomUUID().toString(), "testUser2", "testUser2"));
-        }};
+        List<org.wso2.carbon.user.core.common.User> users = new ArrayList<>();
 
-        org.wso2.carbon.user.core.common.User user = new org.wso2.carbon.user.core.common.User();
-        user.setUserID(UUID.randomUUID().toString());
-        user.setUsername("testUser3");
-        user.setUserStoreDomain("SECONDARY");
+        org.wso2.carbon.user.core.common.User user1 = new org.wso2.carbon.user.core.common.User();
+        user1.setUserID(UUID.randomUUID().toString());
+        user1.setUsername("testUser1");
+        user1.setUserStoreDomain("PRIMARY");
 
-        users.add(user);
+        org.wso2.carbon.user.core.common.User user2 = new org.wso2.carbon.user.core.common.User();
+        user2.setUserID(UUID.randomUUID().toString());
+        user2.setUsername("testUser2");
+        user2.setUserStoreDomain("PRIMARY");
+
+        org.wso2.carbon.user.core.common.User user3 = new org.wso2.carbon.user.core.common.User();
+        user3.setUserID(UUID.randomUUID().toString());
+        user3.setUsername("testUser3");
+        user3.setUserStoreDomain("SECONDARY");
+
+        users.add(user1);
+        users.add(user2);
+        users.add(user3);
 
         return new Object[][]{
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -98,14 +98,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anySet;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyMap;
 
 import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
@@ -1178,6 +1179,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(SCIMCommonComponentHolder.getRolePermissionManagementService())
                 .thenReturn(mockedRolePermissionManagementService);
         when(mockedRolePermissionManagementService.getRolePermissions(anyString(), anyInt())).thenReturn(permission);
+        when(mockedRolePermissionManagementService.getRolePermissions(nullable(String.class), anyInt())).thenReturn(permission);
         String[] actual = scimUserManager.getGroupPermissions(roleName);
         assertEquals(actual, expected);
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -283,6 +283,9 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 .set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
 
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
+
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
+
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
         when(mockedUserStoreManager.getRoleListOfUser(anyString())).thenReturn(userRoles);
         mockStatic(AttributeMapper.class);
@@ -294,6 +297,9 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         user.setUsername("testUserName");
         user.setUserID(UUID.randomUUID().toString());
         when(mockedUserStoreManager.getUser(anyString(), anyString())).thenReturn(user);
+
+        when(mockedUserStoreManager.getUser(nullable(String.class), nullable(String.class))).thenReturn(user);
+
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         CommonTestUtils.initPrivilegedCarbonContext(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         mockStatic(ClaimMetadataHandler.class);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -547,10 +547,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), anyInt(),
                 anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsers);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-        whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.listSCIMGroups(anyInt())).thenReturn(anySet());
-        when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
-        when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
 
@@ -739,7 +735,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         }};
 
         when(mockClaimMetadataManagementService.getLocalClaims(anyString())).thenReturn(localClaimList);
-        when(mockClaimMetadataManagementService.getExternalClaims(nullable(String.class), anyString())).thenReturn(externalClaimList);
+        when(mockClaimMetadataManagementService.getExternalClaims(anyString(), anyString())).thenReturn(externalClaimList);
         UsersGetResponse userResponse = scimUserManager.listUsersWithGET(node, 1, count, null, null, domain,
                 requiredClaimsMap);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -459,8 +459,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-        whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.listSCIMGroups()).thenReturn(anySet());
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(isScimEnabledForPrimary);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -281,8 +281,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         MemberModifier.field(AbstractUserStoreManager.class, "userStoreManagerHolder")
                 .set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
 
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
-
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
         when(mockedUserStoreManager.getRoleListOfUser(anyString())).thenReturn(userRoles);
         mockStatic(AttributeMapper.class);
@@ -293,7 +292,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         org.wso2.carbon.user.core.common.User user = new org.wso2.carbon.user.core.common.User();
         user.setUsername("testUserName");
         user.setUserID(UUID.randomUUID().toString());
-        when(mockedUserStoreManager.getUser(nullable(String.class), nullable(String.class))).thenReturn(user);
+        when(mockedUserStoreManager.getUser(anyString(), nullable(String.class))).thenReturn(user);
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         CommonTestUtils.initPrivilegedCarbonContext(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         mockStatic(ClaimMetadataHandler.class);
@@ -414,8 +413,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(list);
         org.wso2.carbon.user.core.common.Group[] groupsArray = {buildUserCoreGroupResponse(roleName, "1234",
                 "dummyDomain")};
-        when(mockedUserStoreManager.listGroups(any(Condition.class), nullable(String.class), anyInt(),
-                nullable(Integer.class), nullable(String.class), nullable(String.class))).thenReturn(Arrays.asList(groupsArray.clone()));
+        when(mockedUserStoreManager.listGroups(any(Condition.class), anyString(), anyInt(),
+                anyInt(), nullable(String.class), nullable(String.class))).thenReturn(Arrays.asList(groupsArray.clone()));
         when(mockedUserStoreManager.getGroupByGroupName(roleName, null)).
                 thenReturn(buildUserCoreGroupResponse(roleName, "123456789", null));
         whenNew(RealmConfiguration.class).withAnyArguments().thenReturn(mockRealmConfig);
@@ -489,6 +488,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         user.setUserID(UUID.randomUUID().toString());
         user.setUsername("testUser3");
         user.setUserStoreDomain("SECONDARY");
+
         users.add(user);
 
         return new Object[][]{
@@ -535,17 +535,15 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/userid", "*", null)).thenReturn(users);
         when(mockedUserStoreManager.getUserListWithID("http://wso2.org/claims/givenname", "testUser", "default"))
                 .thenReturn(filteredUsers);
-        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), nullable(String.class), nullable(String.class), anyInt(),
-                nullable(Integer.class), nullable(String.class), nullable(String.class))).thenReturn(filteredUsers);
+        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), anyInt(),
+                anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsers);
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         when(mockedGroupDAO.listSCIMGroups(anyInt())).thenReturn(anySet());
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
-        when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
-        when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManager);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);
+        when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
+        when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
 
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
         when(mockedRealmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_MAX_USER_LIST))
@@ -587,6 +585,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         testUser1Attributes.put("http://wso2.org/claims/givenname", "testUser");
         testUser1Attributes.put("http://wso2.org/claims/emailaddress", "testUser1@wso2.com");
         testUser1.setAttributes(testUser1Attributes);
+        testUser1.setUserStoreDomain("PRIMARY");
         users.add(testUser1);
 
         org.wso2.carbon.user.core.common.User testUser2 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
@@ -595,6 +594,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         testUser2Attributes.put("http://wso2.org/claims/givenname", "testUser");
         testUser2Attributes.put("http://wso2.org/claims/emailaddress", "testUser2@wso2.com");
         testUser2.setAttributes(testUser2Attributes);
+        testUser2.setUserStoreDomain("PRIMARY");
         users.add(testUser2);
 
         return new Object[][]{
@@ -640,7 +640,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), eq(count),
                 anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithPagination);
 
-
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), eq(configuredMaxLimit),
                 anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithoutPagination);
 
@@ -648,11 +647,13 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithoutPagination);
 
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
-        if(domain=="PRIMARY"){
+
+        if(domain.equals("PRIMARY")){
             when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
         } else {
             when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManager);
         }
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManagerJDBC);
@@ -729,7 +730,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         }};
 
         when(mockClaimMetadataManagementService.getLocalClaims(anyString())).thenReturn(localClaimList);
-        when(mockClaimMetadataManagementService.getExternalClaims(anyString(), anyString())).thenReturn(externalClaimList);
+        when(mockClaimMetadataManagementService.getExternalClaims(nullable(String.class), anyString())).thenReturn(externalClaimList);
         UsersGetResponse userResponse = scimUserManager.listUsersWithGET(node, 1, count, null, null, domain,
                 requiredClaimsMap);
 
@@ -1122,7 +1123,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
-        doReturn(oldUser).when(scimUserManager).getUser(nullable(String.class), nullable(Map.class));
+        doReturn(oldUser).when(scimUserManager).getUser(nullable(String.class), anyMap());
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 
@@ -1333,7 +1334,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getRoleListOfUserWithID(nullable(String.class))).thenReturn(groupsList);
         when(mockedUserStoreManager.getHybridRoleListOfUser(anyString(), anyString())).thenReturn(rolesList);
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
-        when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);
+
         for (String group : groupsList) {
             when(mockedUserStoreManager.getGroupByGroupName(group, null)).
                     thenReturn(buildUserCoreGroupResponse(group, "123456", "dummyDomain"));

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1338,7 +1338,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedUserStoreManager.getUserClaimValuesWithID(anyString(), any(), nullable(String.class)))
                 .thenReturn(userClaimValues);
         when(mockedUserStoreManager.isRoleAndGroupSeparationEnabled()).thenReturn(isRoleAndGroupSeparationEnabled);
-        when(mockedUserStoreManager.getRoleListOfUserWithID(nullable(String.class))).thenReturn(groupsList);
+        when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(groupsList);
         when(mockedUserStoreManager.getHybridRoleListOfUser(anyString(), anyString())).thenReturn(rolesList);
         when(mockedUserStoreManager.getRealmConfiguration()).thenReturn(mockedRealmConfig);
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(secondaryUserStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1375,6 +1375,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
         when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
 
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(nullable(String.class))).thenReturn(secondaryUserStoreManager);
+
         for (String group : groupsList) {
             when(mockedUserStoreManager.getGroupByGroupName(group, null)).
                     thenReturn(buildUserCoreGroupResponse(group, "123456", "dummyDomain"));

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -540,11 +540,21 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 .thenReturn(filteredUsers);
         when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), anyInt(),
                 anyInt(), anyString(), anyString())).thenReturn(filteredUsers);
+
+        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), nullable(String.class), nullable(String.class), anyInt(),
+                nullable(Integer.class), nullable(String.class), nullable(String.class))).thenReturn(filteredUsers);
+
         when(mockedUserStoreManager.getRoleListOfUserWithID(anyString())).thenReturn(new ArrayList<>());
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         when(mockedGroupDAO.listSCIMGroups(anyInt())).thenReturn(anySet());
+
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(mockedUserStoreManager);
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("PRIMARY")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
+
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(null)).thenReturn(secondaryUserStoreManager);
+
         when(mockedUserStoreManager.getSecondaryUserStoreManager("SECONDARY")).thenReturn(secondaryUserStoreManager);
         when(secondaryUserStoreManager.isSCIMEnabled()).thenReturn(true);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
@@ -48,6 +49,7 @@ import static org.testng.Assert.assertNull;
 
 
 @PrepareForTest({IdentityUtil.class, UserCoreUtil.class, IdentityTenantUtil.class, ServiceURLBuilder.class})
+@PowerMockIgnore({"javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
 public class SCIMCommonUtilsTest extends PowerMockTestCase {
 
     private static final String ID = "8a439cf6-3c6b-47d2-94bf-34d072495af3";

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -19,16 +19,16 @@
 
     <test name="facebook-authenticator-all" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtilsTest"/>
+<!--            <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtilsTest"/>-->
             <class name="org.wso2.carbon.identity.scim2.common.utils.AttributeMapperTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>
+<!--            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>-->
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>
         </classes>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -19,7 +19,7 @@
 
     <test name="facebook-authenticator-all" preserve-order="true" parallel="false">
         <classes>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtilsTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtilsTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AttributeMapperTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -24,11 +24,11 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
-<!--            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
-<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>
         </classes>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -28,7 +28,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
-<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>
         </classes>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -27,7 +27,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -23,7 +23,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.AttributeMapperTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>-->
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
 <!--            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>-->

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -25,11 +25,11 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>-->
             <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
-<!--            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
+            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>-->
-<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>
         </classes>
     </test>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -25,7 +25,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
             <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -23,13 +23,13 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.AttributeMapperTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>
-            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
+<!--            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerTest"/>-->
+<!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>-->
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>
         </classes>
     </test>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -24,7 +24,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>-->
-<!--            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>-->
 <!--            <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>-->
 <!--            <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMUserManagerTest"/>-->

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -23,7 +23,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.utils.AttributeMapperTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AuthenticationSchemaTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessorTest"/>
-<!--            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>-->
+            <class name="org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandlerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListenerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManagerTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtilTest"/>

--- a/components/org.wso2.carbon.identity.scim2.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath> ../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath> ../../pom.xml</relativePath>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.1.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath> ../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.scim2.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/pom.xml
@@ -93,7 +93,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.1.0</version>
                 <configuration>
                     <warName>scim2</warName>
                 </configuration>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.1.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.1.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.provider.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.1.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.scim2.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
         <artifactId>identity-inbound-provisioning-scim2</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
                 <groupId>com.sun.xml.parsers</groupId>
                 <artifactId>jaxp-ri</artifactId>
                 <version>1.4.5</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <!-- Mockito Versions are Updated  -->
         <mockito.version>2.23.4</mockito.version>
         <powermock.version>2.0.2</powermock.version>
-        <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>identity-inbound-provisioning-scim2</artifactId>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
     <name>WSO2 Carbon - SCIM Provisioning Module</name>
     <description>
         SCIM 2.0 Implementation for C4

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>identity-inbound-provisioning-scim2</artifactId>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <name>WSO2 Carbon - SCIM Provisioning Module</name>
     <description>
         SCIM 2.0 Implementation for C4

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
         </carbon.identity.framework.imp.pkg.version.range>
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
-        <testng.version>7.0.0</testng.version>
+        <testng.version>6.9.10</testng.version>
         <jacoco.version>0.8.4</jacoco.version>
         <!-- Mockito Versions are Updated  -->
         <mockito.version>2.23.4</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v37</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v80</axis2.wso2.version>
 
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
                 <version>${identity.framework.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+                <scope>test</scope>
+                <version>${identity.framework.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
@@ -247,7 +253,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.7.0-beta9</carbon.kernel.version>
-        <identity.framework.version>5.20.418</identity.framework.version>
+        <identity.framework.version>5.21.7</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>com.sun.xml.parsers</groupId>
                 <artifactId>jaxp-ri</artifactId>
-                <version>1.4.5</version>
+                <version>${jaxp-ri-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -299,6 +299,8 @@
 
         <findsecbugs-plugin.version>1.10.1</findsecbugs-plugin.version>
         <spotbugs-maven-plugin.version>4.5.3.0</spotbugs-maven-plugin.version>
+
+        <jaxp-ri-version>1.4.5</jaxp-ri-version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -276,9 +276,9 @@
         </carbon.identity.framework.imp.pkg.version.range>
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
-        <testng.version>6.9.10</testng.version>
+        <testng.version>7.0.0</testng.version>
         <jacoco.version>0.8.4</jacoco.version>
-<!--        <powermock.version>1.7.0</powermock.version>-->
+        <!-- Mockito Versions are Updated  -->
         <mockito.version>2.23.4</mockito.version>
         <powermock.version>2.0.2</powermock.version>
         <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>identity-inbound-provisioning-scim2</artifactId>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.1.2-SNAPSHOT</version>
     <name>WSO2 Carbon - SCIM Provisioning Module</name>
     <description>
         SCIM 2.0 Implementation for C4

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.sun.xml.parsers</groupId>
+                <artifactId>jaxp-ri</artifactId>
+                <version>1.4.5</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>${javax.ws.rs-api.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.7.0</carbon.kernel.version>
+        <carbon.kernel.version>4.7.1</carbon.kernel.version>
         <identity.framework.version>5.23.14</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -252,8 +252,8 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.7.0-beta9</carbon.kernel.version>
-        <identity.framework.version>5.21.7</identity.framework.version>
+        <carbon.kernel.version>4.7.0</carbon.kernel.version>
+        <identity.framework.version>5.23.14</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.3.11</identity.governance.version>
@@ -265,7 +265,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v80</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v37</axis2.wso2.version>
 
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>
 


### PR DESCRIPTION
### Purpose
Update the repository from mockito 1 to mockito 2 to support JDK 11 and JDK 17 compilation.

### When should this PR be merged
After this PR is merged to the main branch, we can't build the branch on JDK 8

### Version checked,

- openjdk "11.0.16.1"
- openjdk "17.0.4.1"

### Related Issue
https://github.com/wso2/product-is/issues/14224