### PR TITLE
Fix group rename and group delete issues

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2787,7 +2787,7 @@ public class SCIMUserManager implements UserManager {
 
                 //delete group in carbon UM
                 carbonUM.deleteRole(groupName);
-                carbonUM.deleteHybridGroup(groupName);
+                carbonUM.removeGroupByNameFromRoleMapping(groupName);
 
                 //we do not update Identity_SCIM DB here since it is updated in SCIMUserOperationListener's methods.
                 if (log.isDebugEnabled()) {
@@ -3390,8 +3390,8 @@ public class SCIMUserManager implements UserManager {
                         addedMemberIdsFromUserstore.toArray(new String[0]));
             }
 
-            // Update the group name in the hybrid group-role mapper.
-            carbonUM.updateHybridGroupName(currentGroupName, newGroupName);
+            // Update the group name in UM_HYBRID_GROUP_ROLE table.
+            carbonUM.updateGroupName(currentGroupName, newGroupName);
 
         } catch (UserStoreException e) {
             throw resolveError(e, e.getMessage());

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2787,7 +2787,7 @@ public class SCIMUserManager implements UserManager {
 
                 //delete group in carbon UM
                 carbonUM.deleteRole(groupName);
-                carbonUM.removeGroupByNameFromRoleMapping(groupName);
+                carbonUM.removeGroupRoleMappingByGroupName(groupName);
 
                 //we do not update Identity_SCIM DB here since it is updated in SCIMUserOperationListener's methods.
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2787,6 +2787,7 @@ public class SCIMUserManager implements UserManager {
 
                 //delete group in carbon UM
                 carbonUM.deleteRole(groupName);
+                carbonUM.deleteHybridGroup(groupName);
 
                 //we do not update Identity_SCIM DB here since it is updated in SCIMUserOperationListener's methods.
                 if (log.isDebugEnabled()) {
@@ -3388,6 +3389,9 @@ public class SCIMUserManager implements UserManager {
                         deletedMemberIdsFromUserstore.toArray(new String[0]),
                         addedMemberIdsFromUserstore.toArray(new String[0]));
             }
+
+            // Update the group name in the hybrid group-role mapper.
+            carbonUM.updateHybridGroupName(currentGroupName, newGroupName);
 
         } catch (UserStoreException e) {
             throw resolveError(e, e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.7.0-beta5</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-beta9</carbon.kernel.version>
         <identity.framework.version>5.20.418</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
##Purpose

Resolves https://github.com/wso2/product-is/issues/13534 , https://github.com/wso2/product-is/issues/14122

ATM, renaming a group will remove the assigned roles of the group. This is due to not updating the UM_HYBRID_GROUP_ROLE table when renaming the group name. And also delete group won't remove the group from this table, due to this issue, if the new group name has old group name which has some assigned roles, those roles will be added to the currrent goup. Fixed both issues.

Dependent PR: https://github.com/wso2/carbon-kernel/pull/3355