### PR TITLE
Silently handle not having the group information in the SCIM tables

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -217,8 +217,7 @@ public class SCIMGroupHandler {
         if (groupDAO.isExistingGroup(oldRoleName, this.tenantId)) {
             groupDAO.updateRoleName(this.tenantId, oldRoleName, newRoleName);
         } else {
-            throw new IdentitySCIMException("Non-existent group: " + oldRoleName +
-                    " is trying to be updated..");
+            logger.warn("Non-existent group: " + oldRoleName + " is trying to be updated..");
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
-import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.charon3.core.objects.Group;
 
@@ -47,6 +46,7 @@ import java.util.HashSet;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -283,13 +283,13 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
 
         SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-        scimGroupHandler.updateRoleName("EXISTANT_ROLE_NAME", "NEW_ROLE_NAME");
+        scimGroupHandler.updateRoleName("EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
         verify(mockedGroupDAO).updateRoleName(anyInt(),argumentCaptor.capture(),anyString());
-        assertEquals(argumentCaptor.getValue(),"EXISTANT_ROLE_NAME");
+        assertEquals(argumentCaptor.getValue(),"EXISTENT_ROLE_NAME");
     }
 
-    @Test(expectedExceptions = IdentitySCIMException.class)
-    public void testUpdateRoleNameException() throws Exception {
+    @Test
+    public void testUpdateRoleNameNonExistent() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
         mockStatic(IdentityDatabaseUtil.class);
         mockStatic(SCIMCommonUtils.class);
@@ -300,7 +300,7 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
 
         SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
         scimGroupHandler.updateRoleName("NON_EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
-        //this method is for testing of throwing IdentitySCIMException, hence no assertion
+        verify(mockedGroupDAO, times(0)).updateRoleName(anyInt(),anyString(),anyString());
     }
 
     @Test


### PR DESCRIPTION
Public fix for [wso2-iam-internal #22](https://github.com/wso2-enterprise/wso2-iam-internal/issues/22)

When a name of a role is updated, in the [doPostUpdateRoleName](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/blob/ba564119927f4649f1cdee724c0bea71d17f958c/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java#L623) method it tries to update the relevant entries in the IDN_SCIM_GROUP table. If IDN_SCIM_GROUP table does not contain information about that role, it throws an exception.

With the current behaviour, when trying to update the name of a SP, name of the application role related to the SP is updated with the new name. But, due to the exception thrown in the middle, SP’s name is not updated. So, after attempting to update the name of an SP, SP's name and it's application role's name are not consistent. 

This PR replaces the exception throwing with a warn log. So, that sample applications and hybrid roles can be renamed without any issues. But the IDN_SCIM_GROUP table will not be updated accordingly. 