### PR TITLE
Fix userstore domain incorrect response issue 

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -213,6 +213,10 @@ public class SCIMUserManager implements UserManager {
             user.setUserName(IdentityUtil.addDomainToName(user.getUserName(), userStoreDomainName));
         }
 
+        if (!isUserStoreExist(userStoreDomainName)){
+            throw new BadRequestException("Invalid userstore domain.");
+        }
+
         if (StringUtils.isNotBlank(userStoreDomainName) && !isSCIMEnabled(userStoreDomainName)) {
             throw new CharonException("Cannot add user through scim to user store " + ". SCIM is not " +
                     "enabled for user store " + userStoreDomainName);
@@ -6080,5 +6084,20 @@ public class SCIMUserManager implements UserManager {
 
         return groupsList.stream().map(groupName -> UserCoreUtil.addDomainToName(groupName, userStoreDomainName))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * This method will return whether user store exist or not
+     *
+     * @param userStoreName user store name
+     * @return whether user store exist or not for the particular domain
+     */
+    private boolean isUserStoreExist(String userStoreName) {
+
+        UserStoreManager userStoreManager = carbonUM.getSecondaryUserStoreManager(userStoreName);
+        if (userStoreManager != null) {
+            return true;
+        }
+        return false;
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3760,7 +3760,7 @@ public class SCIMUserManager implements UserManager {
         if (userStoreManager == null) {
             throw new BadRequestException("Invalid userstore domain.");
         }
-        if (userStoreManager != null) {
+        else {
             try {
                 return userStoreManager.isSCIMEnabled();
             } catch (UserStoreException e) {


### PR DESCRIPTION
When user store domain is incorrect, it gives 
```{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Cannot add user through scim to user store . SCIM is not enabled for user store <domain name>","status":"500"}```

This issue is fixed in this PR.