### PR TITLE
Fix NPE when display name of a member is empty while updating a group

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -4224,9 +4224,10 @@ public class SCIMUserManager implements UserManager {
      * @param group
      * @param userStoreDomain
      * @return
-     * @throws CharonException
+     * @throws CharonException, BadRequestException
      */
-    private void appendDomainToMembers(Group group, String userStoreDomain) throws CharonException {
+    private void appendDomainToMembers(Group group, String userStoreDomain) throws CharonException,
+            BadRequestException {
 
         if (StringUtils.isBlank(userStoreDomain) || CollectionUtils.isEmpty(group.getMembers())) {
             return;
@@ -4241,6 +4242,10 @@ public class SCIMUserManager implements UserManager {
                 for (Attribute attributeValue : attributeValues) {
                     SimpleAttribute displayNameAttribute = (SimpleAttribute) attributeValue.getSubAttribute(
                             SCIMConstants.CommonSchemaConstants.DISPLAY);
+                    if (displayNameAttribute == null) {
+                        throw new BadRequestException("Display name attribute of a member is empty while adding to " +
+                                "the group: " + group.getDisplayName());
+                    }
                     String displayName =
                             AttributeUtil.getStringValueOfAttribute(displayNameAttribute.getValue(),
                                     displayNameAttribute.getType());


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/12758

**Sample request:**


```
{
    "Operations": [
        {
            "op": "replace",
            "value": {
                "members": [
                    {
                    
                        "value": "bb69b872-217e-41ae-ac1f-3bc44a588434"
                    }
                ]
            }
        }
    ],
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ]
}
```
**Before the fix:**
NPE was logged and server return 500 error response
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Error in performing the patch operation on group resource.",
    "status": "500"
}
```

```
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException
	at org.wso2.carbon.identity.scim2.common.impl.SCIMUserManager.appendDomainToMembers(SCIMUserManager.java:4245)
	at org.wso2.carbon.identity.scim2.common.impl.SCIMUserManager.doUpdateGroup(SCIMUserManager.java:3499)
	at org.wso2.carbon.identity.scim2.common.impl.SCIMUserManager.updateGroup(SCIMUserManager.java:3461)

```

**After the fix:**
Response: 
``` 
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "Display name attribute of a member is empty while adding to the group: PRIMARY/group1",
    "detail": "Request is unparsable, syntactically incorrect, or violates schema.",
    "status": "400"
}
```