### PR TITLE
Fix `Internal/everyone` Role Not Getting Displayed Issue

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5275,8 +5275,7 @@ public class SCIMUserManager implements UserManager {
 
         List<String> scimDisabledHybridRoles = new ArrayList<>();
         for (String role : roles) {
-            if (!scimRoles.contains(role) && SCIMCommonUtils.isHybridRole(role) && !UserCoreUtil.isEveryoneRole(role,
-                    carbonUM.getRealmConfiguration())) {
+            if (!scimRoles.contains(role) && SCIMCommonUtils.isHybridRole(role)) {
                 scimDisabledHybridRoles.add(role);
             }
         }


### PR DESCRIPTION
This PR adds internal/everyone role to scim groups when listing user roles.