### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,13 +250,13 @@
     <properties>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
-        <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
+        <inbound.auth.oauth.version>7.0.0</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.7.1</carbon.kernel.version>
-        <identity.framework.version>5.23.14</identity.framework.version>
+        <identity.framework.version>6.0.0</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
-        <identity.governance.version>1.3.11</identity.governance.version>
+        <identity.governance.version>2.0.0</identity.governance.version>
         <charon.version>4.0.4</charon.version>
 
         <!--Maven Plugin Version-->
@@ -284,7 +284,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <axis2.osgi.version.range>[.6.1-wso2v37, 2.0.0)</axis2.osgi.version.range>
         <scim.common.imp.pkg.version.range>[5.0.0, 6.0.0)</scim.common.imp.pkg.version.range>
-        <carbon.identity.framework.imp.pkg.version.range>[5.20.118, 6.0.0)
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16