### PR TITLE
Fix SCIM2 multi attribute filtering when primary userstore domain name is changed

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2255,7 +2255,14 @@ public class SCIMUserManager implements UserManager {
 
         try {
             if (StringUtils.isEmpty(domainName)) {
-                domainName = "PRIMARY";
+                domainName = carbonUM.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.
+                        PROPERTY_DOMAIN_NAME);
+                if (StringUtils.isEmpty(domainName)) {
+                    domainName = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Primary user store DomainName picked as " + domainName);
+                }
             }
             Map<String, String> attributes = getAllAttributes(domainName);
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
resolves - https://github.com/wso2/product-is/issues/15286
- According to the current implementations, if the user is in the primary user store, it is taking the domain name as PRIMARY from a hard-coded constant variable from the source code itself.
- This is resolved by reading the domain name from the realm configurations.