### PR TITLE
Fix considering custom schema attribute: entitlements as a multivalued attribute.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5620,20 +5620,20 @@ public class SCIMUserManager implements UserManager {
     private SCIMDefinitions.DataType getCustomAttrDataType(String dataType) {
 
         dataType = dataType.toUpperCase();
-        switch (dataType) {
-            case SCIMDefinitions.DataType.BOOLEAN.name():
+        switch (SCIMDefinitions.DataType.valueOf(dataType)) {
+            case BOOLEAN:
                 return SCIMDefinitions.DataType.BOOLEAN;
-            case SCIMDefinitions.DataType.DECIMAL.name():
+            case DECIMAL:
                 return SCIMDefinitions.DataType.DECIMAL;
-            case SCIMDefinitions.DataType.INTEGER.name():
+            case INTEGER:
                 return SCIMDefinitions.DataType.INTEGER;
-            case SCIMDefinitions.DataType.DATE_TIME.name():
+            case DATE_TIME:
                 return SCIMDefinitions.DataType.DATE_TIME;
-            case SCIMDefinitions.DataType.BINARY.name():
+            case BINARY:
                 return SCIMDefinitions.DataType.BINARY;
-            case SCIMDefinitions.DataType.REFERENCE.name():
+            case REFERENCE:
                 return SCIMDefinitions.DataType.REFERENCE;
-            case SCIMDefinitions.DataType.COMPLEX.name():
+            case COMPLEX:
                 return SCIMDefinitions.DataType.COMPLEX;
             default:
                 return SCIMDefinitions.DataType.STRING;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5619,22 +5619,24 @@ public class SCIMUserManager implements UserManager {
 
     private SCIMDefinitions.DataType getCustomAttrDataType(String dataType) {
 
-        if (SCIMDefinitions.DataType.BOOLEAN.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.BOOLEAN;
-        } else if (SCIMDefinitions.DataType.DECIMAL.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.DECIMAL;
-        } else if (SCIMDefinitions.DataType.INTEGER.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.INTEGER;
-        } else if (SCIMDefinitions.DataType.DATE_TIME.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.DATE_TIME;
-        } else if (SCIMDefinitions.DataType.BINARY.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.BINARY;
-        } else if (SCIMDefinitions.DataType.REFERENCE.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.REFERENCE;
-        } else if (SCIMDefinitions.DataType.COMPLEX.name().equalsIgnoreCase(dataType)) {
-            return SCIMDefinitions.DataType.COMPLEX;
-        } else {
-            return SCIMDefinitions.DataType.STRING;
+        dataType = dataType.toUpperCase();
+        switch (dataType) {
+            case SCIMDefinitions.DataType.BOOLEAN.name():
+                return SCIMDefinitions.DataType.BOOLEAN;
+            case SCIMDefinitions.DataType.DECIMAL.name():
+                return SCIMDefinitions.DataType.DECIMAL;
+            case SCIMDefinitions.DataType.INTEGER.name():
+                return SCIMDefinitions.DataType.INTEGER;
+            case SCIMDefinitions.DataType.DATE_TIME.name():
+                return SCIMDefinitions.DataType.DATE_TIME;
+            case SCIMDefinitions.DataType.BINARY.name():
+                return SCIMDefinitions.DataType.BINARY;
+            case SCIMDefinitions.DataType.REFERENCE.name():
+                return SCIMDefinitions.DataType.REFERENCE;
+            case SCIMDefinitions.DataType.COMPLEX.name():
+                return SCIMDefinitions.DataType.COMPLEX;
+            default:
+                return SCIMDefinitions.DataType.STRING;
         }
     }
 
@@ -5688,7 +5690,7 @@ public class SCIMUserManager implements UserManager {
                 attribute.setType(SCIMDefinitions.DataType.STRING);
             }
 
-        } else if (isCustomSchemaAttr) {
+        } else if (customAttrDataType != null) {
             attribute.setType(getCustomAttrDataType(customAttrDataType));
         } else if (isBooleanAttribute(attribute.getName())) {
             attribute.setType(SCIMDefinitions.DataType.BOOLEAN);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5548,7 +5548,7 @@ public class SCIMUserManager implements UserManager {
         }
 
         AbstractAttribute attribute;
-        if (isComplexAttribute(name, isCustomSchemaAttr)) {
+        if (isComplexAttribute(name) && !isCustomSchemaAttr) {
             attribute = new ComplexAttribute(name);
         } else {
             attribute = new SimpleAttribute(name, null);
@@ -5559,11 +5559,7 @@ public class SCIMUserManager implements UserManager {
         return attribute;
     }
 
-    private boolean isComplexAttribute(String name, boolean isCustomSchemaAttr) {
-
-        if (isCustomSchemaAttr) {
-            return false;
-        }
+    private boolean isComplexAttribute(String name) {
 
         switch (name) {
             case "manager":
@@ -5583,19 +5579,12 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
-    private boolean isBooleanAttribute(String name, boolean isCustomSchemaAttr) {
+    private boolean isBooleanAttribute(String name) {
 
-        if (isCustomSchemaAttr) {
-            return false;
-        }
         return "active".equals(name);
     }
 
-    private boolean isMultivaluedAttribute(String name, boolean isCustomSchemaAttr) {
-
-        if (isCustomSchemaAttr) {
-            return false;
-        }
+    private boolean isMultivaluedAttribute(String name) {
 
         switch (name) {
             case "emails":
@@ -5649,13 +5638,13 @@ public class SCIMUserManager implements UserManager {
                 attribute.setType(SCIMDefinitions.DataType.STRING);
             }
 
-        } else if (isBooleanAttribute(attribute.getName(), isCustomSchemaAttr)) {
+        } else if (isBooleanAttribute(attribute.getName()) && !isCustomSchemaAttr) {
             attribute.setType(SCIMDefinitions.DataType.BOOLEAN);
         } else {
             attribute.setType(SCIMDefinitions.DataType.STRING);
         }
 
-        attribute.setMultiValued(isMultivaluedAttribute(attribute.getName(), isCustomSchemaAttr));
+        attribute.setMultiValued(isMultivaluedAttribute(attribute.getName()) && !isCustomSchemaAttr);
         attribute.setReturned(SCIMDefinitions.Returned.DEFAULT);
         attribute.setUniqueness(SCIMDefinitions.Uniqueness.NONE);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5681,6 +5681,8 @@ public class SCIMUserManager implements UserManager {
         attribute.setCaseExact(false);
         if (attribute instanceof ComplexAttribute) {
             attribute.setType(SCIMDefinitions.DataType.COMPLEX);
+        } else if (customAttrDataType != null) {
+            attribute.setType(getCustomAttrDataType(customAttrDataType));
         } else if (isEnterpriseExtensionAttr) {
             AttributeSchema attributeSchema = SCIMUserSchemaExtensionBuilder.getInstance().getExtensionSchema()
                     .getSubAttributeSchema(attribute.getName());
@@ -5690,8 +5692,6 @@ public class SCIMUserManager implements UserManager {
                 attribute.setType(SCIMDefinitions.DataType.STRING);
             }
 
-        } else if (customAttrDataType != null) {
-            attribute.setType(getCustomAttrDataType(customAttrDataType));
         } else if (isBooleanAttribute(attribute.getName())) {
             attribute.setType(SCIMDefinitions.DataType.BOOLEAN);
         } else {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5542,26 +5542,26 @@ public class SCIMUserManager implements UserManager {
 
         String name = scimClaim.getClaimURI();
         String claimDielectURI = scimClaim.getClaimDialectURI();
-        boolean isCustomScemaAttr = StringUtils.equalsIgnoreCase(claimDielectURI,getCustomSchemaURI());
+        boolean isCustomSchemaAttr = StringUtils.equalsIgnoreCase(claimDielectURI,getCustomSchemaURI());
         if (name.startsWith(scimClaim.getClaimDialectURI())) {
             name = name.substring(scimClaim.getClaimDialectURI().length() + 1);
         }
 
         AbstractAttribute attribute;
-        if (isComplexAttribute(name, isCustomScemaAttr)) {
+        if (isComplexAttribute(name, isCustomSchemaAttr)) {
             attribute = new ComplexAttribute(name);
         } else {
             attribute = new SimpleAttribute(name, null);
         }
 
-        populateBasicAttributes(mappedLocalClaim, attribute, isExtensionAttr, isCustomScemaAttr);
+        populateBasicAttributes(mappedLocalClaim, attribute, isExtensionAttr, isCustomSchemaAttr);
 
         return attribute;
     }
 
-    private boolean isComplexAttribute(String name, boolean isCustomScemaAttr) {
+    private boolean isComplexAttribute(String name, boolean isCustomSchemaAttr) {
 
-        if (isCustomScemaAttr) {
+        if (isCustomSchemaAttr) {
             return false;
         }
 
@@ -5583,17 +5583,17 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
-    private boolean isBooleanAttribute(String name, boolean isCustomScemaAttr) {
+    private boolean isBooleanAttribute(String name, boolean isCustomSchemaAttr) {
 
-        if (isCustomScemaAttr) {
+        if (isCustomSchemaAttr) {
             return false;
         }
         return "active".equals(name);
     }
 
-    private boolean isMultivaluedAttribute(String name, boolean isCustomScemaAttr) {
+    private boolean isMultivaluedAttribute(String name, boolean isCustomSchemaAttr) {
 
-        if (isCustomScemaAttr) {
+        if (isCustomSchemaAttr) {
             return false;
         }
 
@@ -5620,7 +5620,7 @@ public class SCIMUserManager implements UserManager {
      * @param attribute
      */
     private void populateBasicAttributes(LocalClaim mappedLocalClaim, AbstractAttribute attribute, boolean
-            isEnterpriseExtensionAttr, boolean isCustomScemaAttr) {
+            isEnterpriseExtensionAttr, boolean isCustomSchemaAttr) {
 
         if (mappedLocalClaim != null) {
             attribute.setDescription(mappedLocalClaim.getClaimProperty(ClaimConstants.DESCRIPTION_PROPERTY));
@@ -5649,13 +5649,13 @@ public class SCIMUserManager implements UserManager {
                 attribute.setType(SCIMDefinitions.DataType.STRING);
             }
 
-        } else if (isBooleanAttribute(attribute.getName(), isCustomScemaAttr)) {
+        } else if (isBooleanAttribute(attribute.getName(), isCustomSchemaAttr)) {
             attribute.setType(SCIMDefinitions.DataType.BOOLEAN);
         } else {
             attribute.setType(SCIMDefinitions.DataType.STRING);
         }
 
-        attribute.setMultiValued(isMultivaluedAttribute(attribute.getName(), isCustomScemaAttr));
+        attribute.setMultiValued(isMultivaluedAttribute(attribute.getName(), isCustomSchemaAttr));
         attribute.setReturned(SCIMDefinitions.Returned.DEFAULT);
         attribute.setUniqueness(SCIMDefinitions.Uniqueness.NONE);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5542,7 +5542,7 @@ public class SCIMUserManager implements UserManager {
 
         String name = scimClaim.getClaimURI();
         String claimDielectURI = scimClaim.getClaimDialectURI();
-        boolean isCustomScemaAttr = claimDielectURI.equalsIgnoreCase(getCustomSchemaURI());
+        boolean isCustomScemaAttr = StringUtils.equalsIgnoreCase(claimDielectURI,getCustomSchemaURI());
         if (name.startsWith(scimClaim.getClaimDialectURI())) {
             name = name.substring(scimClaim.getClaimDialectURI().length() + 1);
         }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5543,7 +5543,7 @@ public class SCIMUserManager implements UserManager {
 
         String name = scimClaim.getClaimURI();
         String claimDielectURI = scimClaim.getClaimDialectURI();
-        boolean isCustomSchemaAttr = StringUtils.equalsIgnoreCase(claimDielectURI,getCustomSchemaURI());
+        boolean isCustomSchemaAttr = StringUtils.equalsIgnoreCase(claimDielectURI, getCustomSchemaURI());
         boolean isComplexInAdditionalProp = false;
         if (mappedLocalClaim != null && mappedLocalClaim.getClaimProperties() != null) {
             for (Map.Entry<String, String> claimProperty : mappedLocalClaim.getClaimProperties().entrySet()) {


### PR DESCRIPTION
### Purpose
Check whether the attribute is custom schema attribute before assigning properties by considering the attribute name. If it's a custom schema attribute, it will be a simple, single valued attribute now on although it's name is hardcoded to consider it as a complex, multivalued attribute.

### Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/14422
- https://github.com/wso2-enterprise/asgardeo-product/issues/11072