### PR TITLE
Fix sub organization user & group resource path with custom domains

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -128,23 +128,16 @@ public class SCIMCommonUtils {
 
         String scimURL;
         try {
-            String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-            if (organizationRoutingSupported && StringUtils.isNotBlank(organizationId)) {
-                String serverUrl = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
-                scimURL = serverUrl + SCIMCommonConstants.ORGANIZATION_PATH_PARAM + organizationId +
-                        SCIMCommonConstants.SCIM2_ENDPOINT;
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                scimURL = ServiceURLBuilder.create().addPath(SCIMCommonConstants.SCIM2_ENDPOINT).build()
+                        .getAbsolutePublicURL();
             } else {
-                if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                    scimURL = ServiceURLBuilder.create().addPath(SCIMCommonConstants.SCIM2_ENDPOINT).build()
-                            .getAbsolutePublicURL();
+                String serverUrl = ServiceURLBuilder.create().build().getAbsolutePublicURL();
+                String tenantDomain = getTenantDomainFromContext();
+                if (isNotASuperTenantFlow(tenantDomain)) {
+                    scimURL = serverUrl + "/t/" + tenantDomain + SCIMCommonConstants.SCIM2_ENDPOINT;
                 } else {
-                    String serverUrl = ServiceURLBuilder.create().build().getAbsolutePublicURL();
-                    String tenantDomain = getTenantDomainFromContext();
-                    if (isNotASuperTenantFlow(tenantDomain)) {
-                        scimURL = serverUrl + "/t/" + tenantDomain + SCIMCommonConstants.SCIM2_ENDPOINT;
-                    } else {
-                        scimURL = serverUrl + SCIMCommonConstants.SCIM2_ENDPOINT;
-                    }
+                    scimURL = serverUrl + SCIMCommonConstants.SCIM2_ENDPOINT;
                 }
             }
             return scimURL;


### PR DESCRIPTION
## Purpose
When building the resource URL of sub-organization users & groups , `o/<org-id>` is manually appended to make the resource path organization qualified. But when custom host configurations are added for the parent organization, asgardeo service url builder builds the public url of the sub-organization with `o/<org-id>` which results in having `o/<org-id>` twice in the resource URL.

With https://github.com/wso2/carbon-identity-framework/pull/4372 service URL builder is capable of appending the `o/<org-id>` part if the organization id is set in the context.