### PR TITLE
Convert the error logs into debug logs

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMGroupResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMGroupResolver.java
@@ -215,7 +215,9 @@ public class SCIMGroupResolver extends AbstractIdentityGroupResolver {
         try {
             groupName = groupDAO.getGroupNameById(tenantId, groupID);
             if (StringUtils.isBlank(groupName)) {
-                log.error(String.format("No group found with id: %s in tenant: %s", groupID, tenantId));
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("No group found with id: %s in tenant: %s", groupID, tenantId));
+                }
                 return true;
             }
         } catch (IdentitySCIMException e) {
@@ -261,7 +263,9 @@ public class SCIMGroupResolver extends AbstractIdentityGroupResolver {
         try {
             groupName = groupDAO.getGroupNameById(tenantId, groupID);
             if (StringUtils.isBlank(groupName)) {
-                log.error(String.format("No group found with id: %s in tenant: %s", groupID, tenantId));
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("No group found with id: %s in tenant: %s", groupID, tenantId));
+                }
                 return true;
             }
             attributes = groupDAO.getSCIMGroupAttributes(tenantId, groupName);


### PR DESCRIPTION
### Purpose
* Converting error logs of group endpoint into debug logs because we should not log any errors in the server if the group id does not exist (It's a client-side error, so throwing 404 would be enough).

### Related PR(s)
* https://github.com/wso2/charon/pull/383