### PR TITLE
Fix SCIM bulk import with the ask password option failure

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -119,15 +119,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.getCustomSchemaURI;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils
-        .isFilterUsersAndGroupsOnlyFromPrimaryDomainEnabled;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.isFilteringEnhancementsEnabled;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.isNotifyUserstoreStatusEnabled;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.mandateDomainForGroupNamesInGroupsResponse;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils
-        .mandateDomainForUsernamesAndGroupNamesInResponse;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.prependDomain;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.*;
 import static org.wso2.carbon.user.core.UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_ROLES_CLAIM;
 
@@ -6077,15 +6069,8 @@ public class SCIMUserManager implements UserManager {
                 return schema;
             }
             try {
-                SCIMCustomSchemaProcessor scimCustomSchemaProcessor = new SCIMCustomSchemaProcessor();
-                List<SCIMCustomAttribute> attributes =
-                        scimCustomSchemaProcessor.getCustomAttributes(IdentityTenantUtil.getTenantDomain(carbonUM.getTenantId()),
-                                getCustomSchemaURI());
-                AttributeSchema attributeSchema = SCIMCustomSchemaExtensionBuilder.getInstance()
-                        .buildUserCustomSchemaExtension(attributes);
-                SCIMCustomAttributeSchemaCache.getInstance().addSCIMCustomAttributeSchema(carbonUM.getTenantId(), attributeSchema);
-                return attributeSchema;
-            } catch (InternalErrorException | UserStoreException | IdentitySCIMException e) {
+                buildCustomSchema(carbonUM.getTenantId());
+            } catch (UserStoreException e) {
                 throw new CharonException("Error while building scim custom schema", e);
             }
         }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -52,7 +52,6 @@ import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
-import org.wso2.carbon.identity.scim2.common.utils.SCIMCustomSchemaProcessor;
 import org.wso2.carbon.user.api.ClaimMapping;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.PaginatedUserStoreManager;
@@ -72,11 +71,19 @@ import org.wso2.carbon.user.core.model.OperationalOperation;
 import org.wso2.carbon.user.core.model.UniqueIDUserClaimSearchEntry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.RolePermissionException;
-import org.wso2.charon3.core.attributes.*;
+import org.wso2.charon3.core.attributes.AbstractAttribute;
+import org.wso2.charon3.core.attributes.Attribute;
+import org.wso2.charon3.core.attributes.ComplexAttribute;
+import org.wso2.charon3.core.attributes.MultiValuedAttribute;
+import org.wso2.charon3.core.attributes.SimpleAttribute;
 import org.wso2.charon3.core.config.SCIMConfigConstants;
-import org.wso2.charon3.core.config.SCIMCustomSchemaExtensionBuilder;
 import org.wso2.charon3.core.config.SCIMUserSchemaExtensionBuilder;
-import org.wso2.charon3.core.exceptions.*;
+import org.wso2.charon3.core.exceptions.BadRequestException;
+import org.wso2.charon3.core.exceptions.CharonException;
+import org.wso2.charon3.core.exceptions.ConflictException;
+import org.wso2.charon3.core.exceptions.ForbiddenException;
+import org.wso2.charon3.core.exceptions.NotFoundException;
+import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.Role;
@@ -119,7 +126,16 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR;
-import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.*;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.buildCustomSchema;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.getCustomSchemaURI;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils
+        .isFilterUsersAndGroupsOnlyFromPrimaryDomainEnabled;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.isFilteringEnhancementsEnabled;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.isNotifyUserstoreStatusEnabled;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.mandateDomainForGroupNamesInGroupsResponse;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils
+        .mandateDomainForUsernamesAndGroupNamesInResponse;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.prependDomain;
 import static org.wso2.carbon.user.core.UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_ROLES_CLAIM;
 
@@ -6069,7 +6085,7 @@ public class SCIMUserManager implements UserManager {
                 return schema;
             }
             try {
-                buildCustomSchema(carbonUM.getTenantId());
+                return buildCustomSchema(carbonUM.getTenantId());
             } catch (UserStoreException e) {
                 throw new CharonException("Error while building scim custom schema", e);
             }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -764,7 +764,7 @@ public class SCIMCommonUtils {
      * Returns SCIM2 custom AttributeSchema of the tenant.
      *
      * @param tenantId  Tenant ID.
-     * @return scim2 custom schema
+     * @return scim2 custom schema.
      * @throws CharonException If an error occurred in retrieving custom schema.
      */
     public static AttributeSchema buildCustomSchema(int tenantId) throws CharonException {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -764,8 +764,8 @@ public class SCIMCommonUtils {
      * Returns SCIM2 custom AttributeSchema of the tenant.
      *
      * @param tenantId  Tenant ID.
-     * @return Returns scim2 custom schema
-     * @throws CharonException IF an error occurred in retrieving custom schema.
+     * @return scim2 custom schema
+     * @throws CharonException If an error occurred in retrieving custom schema.
      */
     public static AttributeSchema buildCustomSchema(int tenantId) throws CharonException {
 

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/util/SupportUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/util/SupportUtils.java
@@ -138,9 +138,6 @@ public class SupportUtils {
             log.debug("Building scim2 custom attribute schema for tenant with Id: " + tenantId);
         }
 
-        if (!SCIMCommonUtils.isCustomSchemaEnabled()) {
-            return;
-        }
         try {
             if (userManager.getCustomUserSchemaExtension() != null) {
                 if (log.isDebugEnabled()) {
@@ -150,18 +147,8 @@ public class SupportUtils {
                 return;
             }
 
-            try {
-                SCIMCustomSchemaProcessor scimCustomSchemaProcessor = new SCIMCustomSchemaProcessor();
-                List<SCIMCustomAttribute> attributes =
-                        scimCustomSchemaProcessor.getCustomAttributes(IdentityTenantUtil.getTenantDomain(tenantId),
-                                getCustomSchemaURI());
-                AttributeSchema attributeSchema = SCIMCustomSchemaExtensionBuilder.getInstance()
-                        .buildUserCustomSchemaExtension(attributes);
-                SCIMCustomAttributeSchemaCache.getInstance().addSCIMCustomAttributeSchema(tenantId, attributeSchema);
-            } catch (InternalErrorException e) {
-                throw new CharonException("Error while building scim custom schema", e);
-            }
-        } catch (NotImplementedException | BadRequestException | IdentitySCIMException e) {
+            SCIMCommonUtils.buildCustomSchema(tenantId);
+        } catch (NotImplementedException | BadRequestException e) {
             throw new CharonException("Error while building scim custom schema", e);
         }
     }


### PR DESCRIPTION
Fix SCIM bulk import with the ask password option fails where custom schema is set to null in the bulk user addition flow.