### PR TITLE
Fix scim2/me delete issue

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -138,6 +138,7 @@ import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.prependDomain;
 import static org.wso2.carbon.user.core.UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_ROLES_CLAIM;
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER;
 
 public class SCIMUserManager implements UserManager {
 
@@ -145,7 +146,6 @@ public class SCIMUserManager implements UserManager {
     private static final String SQL_FILTERING_DELIMITER = "%";
     private static final String ERROR_CODE_INVALID_USERNAME = "31301";
     private static final String ERROR_CODE_INVALID_CREDENTIAL = "30003";
-    private static final String ERROR_CODE_NON_EXISTING_USER = "30007";
     private static final String ERROR_CODE_INVALID_CREDENTIAL_DURING_UPDATE = "36001";
     private static final String ERROR_CODE_PASSWORD_HISTORY_VIOLATION = "22001";
     private static final String ERROR_CODE_INVALID_ROLE_NAME = "30011";
@@ -542,7 +542,7 @@ public class SCIMUserManager implements UserManager {
             }
             throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_VALUE);
         } catch (org.wso2.carbon.user.core.UserStoreException e) {
-            if (e.getMessage().contains(ERROR_CODE_NON_EXISTING_USER)) {
+            if (e.getMessage().contains(ERROR_CODE_NON_EXISTING_USER.getMessage())) {
                 throwUserNotFoundError(userId);
             }
             String errorMessage;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -542,7 +542,7 @@ public class SCIMUserManager implements UserManager {
             }
             throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_VALUE);
         } catch (org.wso2.carbon.user.core.UserStoreException e) {
-            if (e.getMessage().contains(ERROR_CODE_NON_EXISTING_USER.getMessage())) {
+            if (e.getMessage().contains(ERROR_CODE_NON_EXISTING_USER.getCode())) {
                 throwUserNotFoundError(userId);
             }
             String errorMessage;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1494,13 +1494,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         coreUser.setUserID(userId);
         coreUser.setUsername("coreUser");
         coreUser.setUserStoreDomain("DomainName");
-        List<org.wso2.carbon.user.core.common.User> coreUsers = new ArrayList<>();
-        coreUsers.add(coreUser);
 
         mockStatic(SCIMCommonUtils.class);
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
         AbstractUserStoreManager mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
-        when(mockedUserStoreManager.getUserListWithID(anyString(), anyString(), anyString())).thenReturn(coreUsers);
+        when(mockedUserStoreManager.getUserWithID(anyString(), any(), anyString())).thenReturn(coreUser);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("DomainName")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(false);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
@@ -1521,13 +1519,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         coreUser.setUserID(userId);
         coreUser.setUsername("coreUser");
         coreUser.setUserStoreDomain("PRIMARY");
-        List<org.wso2.carbon.user.core.common.User> coreUsers = new ArrayList<>();
-        coreUsers.add(coreUser);
 
         mockStatic(SCIMCommonUtils.class);
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
         AbstractUserStoreManager mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
-        when(mockedUserStoreManager.getUserListWithID(anyString(), anyString(), anyString())).thenReturn(coreUsers);
+        when(mockedUserStoreManager.getUserWithID(anyString(), any(), anyString())).thenReturn(coreUser);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         InboundProvisioningConfig inboundProvisioningConfig = new InboundProvisioningConfig();

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.9.1</carbon.kernel.version>
+        <carbon.kernel.version>4.9.4</carbon.kernel.version>
         <identity.framework.version>5.25.143</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
## Purpose

- Use `getUserWithID` method instead of `getUserListWithID` method to fetch the user in `scim2/Me` delete endpoint.
- Improved `getUserWithID` method (https://github.com/wso2/carbon-kernel/pull/3559) will fetch the user using the userstore domain instead of iterating through all userstores.

## Related Issues
- Fixes - https://github.com/wso2/product-is/issues/15656