### PR TITLE
Improve password history violation error response

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -416,7 +416,8 @@ public class SCIMUserManager implements UserManager {
             }
             if ((e instanceof IdentityEventException) && StringUtils
                     .equals(ERROR_CODE_PASSWORD_HISTORY_VIOLATION, ((IdentityEventException) e).getErrorCode())) {
-                throw new BadRequestException(e.getMessage(), ResponseCodeConstants.INVALID_VALUE);
+                throw new BadRequestException(ERROR_CODE_PASSWORD_HISTORY_VIOLATION + " - " +e.getMessage(),
+                        ResponseCodeConstants.INVALID_VALUE);
             }
             e = e.getCause();
             i++;


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/11107
Since we already filtering password violation exceptions to add appropriate  error message, we are improving the error message by adding error code.

Response after the fix
```
{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"scimType":"invalidValue","detail":"22001 - This password has been used in recent history. Please choose a different password","status":"400"}
```