### PR TITLE
Handle forbidden responses when updating roles with a patch request

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -546,7 +546,7 @@ public class SCIMRoleManager implements RoleManager {
 
     @Override
     public Role patchRole(String roleId, Map<String, List<PatchOperation>> patchOperations)
-            throws BadRequestException, CharonException, ConflictException, NotFoundException {
+            throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);
 
@@ -605,7 +605,7 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     private void updateUsers(String roleId, String currentRoleName, List<PatchOperation> memberOperations)
-            throws BadRequestException, CharonException {
+            throws BadRequestException, CharonException, ForbiddenException {
 
         Collections.sort(memberOperations);
         Set<String> addedUsers = new HashSet<>();
@@ -687,7 +687,7 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     private void doUpdateUsers(Set<String> newUserList, Set<String> deletedUserList, Set<Object> newlyAddedMemberIds,
-                               String roleId) throws CharonException, BadRequestException {
+                               String roleId) throws CharonException, BadRequestException, ForbiddenException {
 
         // Update the role with added users and deleted users.
         List<String> newUserIDList = getUserIDList(new ArrayList<>(newUserList), tenantDomain);
@@ -706,8 +706,7 @@ public class SCIMRoleManager implements RoleManager {
                     throw new BadRequestException(e.getMessage());
                 }
                 if (OPERATION_FORBIDDEN.getCode().equals(e.getErrorCode())) {
-                    throw new CharonException(String.format("%d--%s",
-                            ResponseCodeConstants.CODE_FORBIDDEN, e.getMessage()));
+                    throw new ForbiddenException(e.getMessage());
                 }
                 throw new CharonException(
                         String.format("Error occurred while updating users in the role: %s", roleId), e);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -546,7 +546,7 @@ public class SCIMRoleManager implements RoleManager {
 
     @Override
     public Role patchRole(String roleId, Map<String, List<PatchOperation>> patchOperations)
-            throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
+            throws BadRequestException, CharonException, ConflictException, NotFoundException {
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);
 
@@ -605,7 +605,7 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     private void updateUsers(String roleId, String currentRoleName, List<PatchOperation> memberOperations)
-            throws BadRequestException, CharonException, ForbiddenException {
+            throws BadRequestException, CharonException {
 
         Collections.sort(memberOperations);
         Set<String> addedUsers = new HashSet<>();
@@ -687,7 +687,7 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     private void doUpdateUsers(Set<String> newUserList, Set<String> deletedUserList, Set<Object> newlyAddedMemberIds,
-                               String roleId) throws CharonException, BadRequestException, ForbiddenException {
+                               String roleId) throws CharonException, BadRequestException {
 
         // Update the role with added users and deleted users.
         List<String> newUserIDList = getUserIDList(new ArrayList<>(newUserList), tenantDomain);
@@ -706,7 +706,8 @@ public class SCIMRoleManager implements RoleManager {
                     throw new BadRequestException(e.getMessage());
                 }
                 if (OPERATION_FORBIDDEN.getCode().equals(e.getErrorCode())) {
-                    throw new ForbiddenException(e.getMessage());
+                    throw new CharonException(String.format("%d--%s",
+                            ResponseCodeConstants.CODE_FORBIDDEN, e.getMessage()));
                 }
                 throw new CharonException(
                         String.format("Error occurred while updating users in the role: %s", roleId), e);

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>4.0.7</charon.version>
+        <charon.version>4.0.9</charon.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
## Purpose
Only the tenant owner is allowed to remove users from the Administrator role. Framework throws an error if the authorized user doesn't have the permissions when making the request. Previously a 500 error was thrown in this scenario. However 403 should be returned instead of 500.


## Related PR

- This PR should be merged first https://github.com/wso2/charon/pull/386