### PR TITLE
Fix Getting 500 error response for client errors in SCIM/Groups PATCH

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 11.0.19+7 ]
+        java-version: [ 11.0.19+7, 17.0.7+7 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Adopt JDK 11 and 17

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 11.0.19+7 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Adopt JDK 11 and 17

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3422,6 +3422,7 @@ public class SCIMUserManager implements UserManager {
             if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
                     .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode(),
                             ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
+                log.error(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getMessage(), e);
                 throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
             }
             throw resolveError(e, e.getMessage());

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3367,14 +3367,14 @@ public class SCIMUserManager implements UserManager {
                 temporaryMembers.clear();
 
                 for (String member : deletedMembers) {
-                    if (addedMembers.isEmpty() && (member == null || member.isEmpty())) {
+                    if (addedMembers.isEmpty() && StringUtils.isBlank(member)) {
                         throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
-                    } else if (!addedMembers.isEmpty() && (member == null || member.isEmpty()) )  {
-                        continue;
                     }
-                    String username = UserCoreUtil.addDomainToName(UserCoreUtil.removeDomainFromName(member),
-                            userStoreDomainForGroup);
-                    temporaryMembers.add(username);
+                    if (StringUtils.isNotBlank(member)) {
+                        String username = UserCoreUtil.addDomainToName(UserCoreUtil.removeDomainFromName(member),
+                                userStoreDomainForGroup);
+                        temporaryMembers.add(username);
+                    }
                 }
 
                 deletedMembers.clear();

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.constants.UserCoreClaimConstants;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager;
 import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionAttribute;
@@ -3366,6 +3367,11 @@ public class SCIMUserManager implements UserManager {
                 temporaryMembers.clear();
 
                 for (String member : deletedMembers) {
+                    if (addedMembers.isEmpty() && (member == null || member.isEmpty())) {
+                        throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
+                    } else if (!addedMembers.isEmpty() && (member == null || member.isEmpty()) )  {
+                        continue;
+                    }
                     String username = UserCoreUtil.addDomainToName(UserCoreUtil.removeDomainFromName(member),
                             userStoreDomainForGroup);
                     temporaryMembers.add(username);
@@ -3413,13 +3419,16 @@ public class SCIMUserManager implements UserManager {
             carbonUM.updateGroupName(currentGroupName, newGroupName);
 
         } catch (UserStoreException e) {
+            if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
+                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode(),
+                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
+                throw new BadRequestException(ResponseCodeConstants.INVALID_VALUE);
+            }
             throw resolveError(e, e.getMessage());
         } catch (IdentitySCIMException e) {
             throw new CharonException(e.getMessage(), e);
         } catch (IdentityApplicationManagementException e) {
             throw new CharonException("Error retrieving User Store name. ", e);
-        } catch (BadRequestException e) {
-            throw new CharonException("Error in updating the group", e);
         }
     }
 
@@ -3462,10 +3471,6 @@ public class SCIMUserManager implements UserManager {
                 SCIMConstants.OperationalConstants.REMOVE)) {
             addedMembers.remove(memberObject.get(SCIMConstants.GroupSchemaConstants.DISPLAY));
             removedMembers.add(memberObject.get(SCIMConstants.GroupSchemaConstants.DISPLAY));
-            String value = memberObject.get(SCIMConstants.GroupSchemaConstants.VALUE);
-            if (StringUtils.isNotBlank(value)) {
-                deletedMemberIds.add(value);
-            }
         }
     }
 
@@ -3660,7 +3665,7 @@ public class SCIMUserManager implements UserManager {
             if (StringUtils.isEmpty(userId)) {
                 String error = "User: " + userName + " doesn't exist in the user store. Hence can not update the " +
                         "group: " + displayName;
-                throw new BadRequestException(error);
+                throw new BadRequestException(error, ResponseCodeConstants.INVALID_VALUE);
             }
             memberUserIds.add(userId);
         }


### PR DESCRIPTION
## Purpose

This PR aims to address the issues mentioned in https://github.com/wso2/product-is/issues/16097.

## Goals

The goals of this PR are to:

- Change the error responses when adding a member to a group with invalid display name.
- Change the error responses when adding a member to a group with invalid id.
- Change the error responses when a user is added with mismatching id and display name.
- Change the error response when removing a non-existent user from a group
- Fix the issue of receiving a 400 error when attempting to `remove and add a user` scenario by using the user ID. However, this was working with the user display name.