### PR TITLE
Add application roles for Users and Groups roles

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -168,6 +168,11 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.role.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -216,6 +221,8 @@
                             org.wso2.carbon.identity.claim.metadata.mgt.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.role.mgt.core.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.role.mgt.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.mgt.*;version="${carbon.identity.framework.imp.pkg.version.range}"
                         </Import-Package>

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -4243,7 +4243,7 @@ public class SCIMUserManager implements UserManager {
         // Add application roles of the user
         try {
             List<ApplicationRole> applicationRoles = SCIMCommonComponentHolder.getApplicationRoleManager()
-                    .getApplicationRolesByUserId(scimUser.getId());
+                    .getApplicationRolesByUserId(scimUser.getId(), tenantDomain);
             for(ApplicationRole applicationRole: applicationRoles) {
                 Role role = new Role();
                 role.setDisplayName(applicationRole.getRoleName());
@@ -4483,7 +4483,7 @@ public class SCIMUserManager implements UserManager {
         // Add application roles of the group
         try {
             List<ApplicationRole> applicationRoles = SCIMCommonComponentHolder.getApplicationRoleManager()
-                    .getApplicationRolesByGroupId(group.getId());
+                    .getApplicationRolesByGroupId(group.getId(), tenantDomain);
             for(ApplicationRole applicationRole: applicationRoles) {
                 Role role = new Role();
                 role.setDisplayName(applicationRole.getRoleName());

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.application.role.mgt.ApplicationRoleManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -267,6 +268,36 @@ public class SCIMCommonComponent {
     }
 
     /**
+     * Set application role manager implementation.
+     *
+     * @param applicationRoleManager ApplicationRoleManager
+     */
+    @Reference(
+            name = "identity.application.role.mgt.component",
+            service = org.wso2.carbon.identity.application.role.mgt.ApplicationRoleManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationRoleManager")
+    protected void setApplicationRoleManager(ApplicationRoleManager applicationRoleManager) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("ApplicationRoleManager set in SCIMCommonComponent bundle.");
+        }
+        SCIMCommonComponentHolder.setApplicationRoleManager(applicationRoleManager);
+    }
+
+    /**
+     * Unset application role manager implementation.
+     */
+    protected void unsetApplicationRoleManager(ApplicationRoleManager applicationRoleManager) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("ApplicationRoleManager unset in SCIMCommonComponent bundle.");
+        }
+        SCIMCommonComponentHolder.setApplicationRoleManager(null);
+    }
+
+    /**
      * Set SCIMUserStoreErrorResolver implementation
      *
      * @param scimUserStoreErrorResolver SCIMUserStoreErrorResolver
@@ -286,6 +317,7 @@ public class SCIMCommonComponent {
 
         SCIMCommonComponentHolder.removeScimUserStoreErrorResolver(scimUserStoreErrorResolver);
     }
+
 
     @Deactivate
     protected void deactivate(ComponentContext context) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.scim2.common.internal;
 
+import org.wso2.carbon.identity.application.role.mgt.ApplicationRoleManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -38,6 +39,7 @@ public class SCIMCommonComponentHolder {
     private static ClaimMetadataManagementService claimManagementService;
     private static RolePermissionManagementService rolePermissionManagementService;
     private static RoleManagementService roleManagementService;
+    private static ApplicationRoleManager applicationRoleManager;
     private static final List<SCIMUserStoreErrorResolver> scimUserStoreErrorResolvers = new ArrayList<>();
 
     /**
@@ -118,6 +120,26 @@ public class SCIMCommonComponentHolder {
     public static RoleManagementService getRoleManagementService() {
 
         return roleManagementService;
+    }
+
+    /**
+     * Set application role management service.
+     *
+     * @param applicationRoleManager ApplicationRoleManager.
+     */
+    public static void setApplicationRoleManager(ApplicationRoleManager applicationRoleManager) {
+
+        SCIMCommonComponentHolder.applicationRoleManager = applicationRoleManager;
+    }
+
+    /**
+     * Get role management service.
+     *
+     * @return RoleManagementService.
+     */
+    public static ApplicationRoleManager getApplicationRoleManager() {
+
+        return applicationRoleManager;
     }
 
     public static List<SCIMUserStoreErrorResolver> getScimUserStoreErrorResolverList() {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -141,6 +141,8 @@ public class SCIMCommonConstants {
     public static final String MIN_LENGTH = "minLength";
     public static final String MAX_LENGTH = "maxLength";
     public static final String REQUIRED = "required";
+    public static final String DEFAULT_ROLE_TYPE = "default";
+    public static final String APP_ROLE_TYPE = "default";
 
 
     private static final Map<String, String> groupAttributeSchemaMap = new HashMap<>();

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -142,7 +142,7 @@ public class SCIMCommonConstants {
     public static final String MAX_LENGTH = "maxLength";
     public static final String REQUIRED = "required";
     public static final String DEFAULT_ROLE_TYPE = "default";
-    public static final String APP_ROLE_TYPE = "default";
+    public static final String APP_ROLE_TYPE = "application";
 
 
     private static final Map<String, String> groupAttributeSchemaMap = new HashMap<>();

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.InboundProvisioningConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.role.mgt.ApplicationRoleManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.AttributeMapping;
@@ -195,6 +196,9 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
     @Mock
     private RolePermissionManagementService mockedRolePermissionManagementService;
 
+    @Mock
+    private ApplicationRoleManager mockApplicationRoleManager;
+
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -314,6 +318,11 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(IdentityUtil.extractDomainFromName(anyString())).thenReturn(userStoreDomain);
         when(mockedUserStoreManager.getGroup(groupId, null)).
                 thenReturn(buildUserCoreGroupResponse(roleName, groupId, userStoreDomain));
+        mockStatic(SCIMCommonComponentHolder.class);
+        when(SCIMCommonComponentHolder.getApplicationRoleManager())
+                .thenReturn(mockApplicationRoleManager);
+        when(mockApplicationRoleManager.getApplicationRolesByGroupId(anyString(), anyString()))
+                .thenReturn(new ArrayList<>());
         mockStatic(SCIMCommonUtils.class);
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/scim2/Groups");
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
@@ -399,6 +408,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedGroupDAO.isExistingGroup("testRole", 0)).thenReturn(true);
         when(mockedGroupDAO.getSCIMGroupAttributes(0, "testRole")).thenReturn(attributes);
         when(IdentityUtil.extractDomainFromName(anyString())).thenReturn(userStoreDomain);
+
+        mockStatic(SCIMCommonComponentHolder.class);
+        when(SCIMCommonComponentHolder.getApplicationRoleManager())
+                .thenReturn(mockApplicationRoleManager);
+        when(mockApplicationRoleManager.getApplicationRolesByGroupId(anyString(), anyString()))
+                .thenReturn(new ArrayList<>());
 
         mockedUserStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
 
@@ -956,6 +971,13 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
             when(abstractUserStoreManager.getGroupByGroupName(role, null)).
                     thenReturn(buildUserCoreGroupResponse(role, "123456789", null));
         }
+
+        mockStatic(SCIMCommonComponentHolder.class);
+        when(SCIMCommonComponentHolder.getApplicationRoleManager())
+                .thenReturn(mockApplicationRoleManager);
+        when(mockApplicationRoleManager.getApplicationRolesByGroupId(anyString(), anyString()))
+                .thenReturn(new ArrayList<>());
+
         whenNew(GroupDAO.class).withAnyArguments().thenReturn(mockedGroupDAO);
         when(mockedGroupDAO.isExistingGroup(anyString(), anyInt())).thenReturn(true);
         when(mockedGroupDAO.getSCIMGroupAttributes(anyInt(), anyString())).thenReturn(attributes);
@@ -1020,6 +1042,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockedGroupDAO.getSCIMGroupAttributes(anyInt(), anyString())).thenReturn(attributes);
         mockStatic(SCIMCommonUtils.class);
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/scim2/Groups");
+
+        mockStatic(SCIMCommonComponentHolder.class);
+        when(SCIMCommonComponentHolder.getApplicationRoleManager())
+                .thenReturn(mockApplicationRoleManager);
+        when(mockApplicationRoleManager.getApplicationRolesByGroupId(anyString(), anyString()))
+                .thenReturn(new ArrayList<>());
 
         SCIMUserManager scimUserManager = new SCIMUserManager(abstractUserStoreManager, mockedClaimManager);
         GroupsGetResponse groupsResponse = scimUserManager
@@ -1369,6 +1397,12 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
                 .thenReturn(USERNAME_LOCAL_CLAIM);
         when(IdentityUtil.getProperty(SCIMCommonConstants.ENABLE_LOGIN_IDENTIFIERS)).thenReturn(enableLoginIdentifiers);
         when(IdentityUtil.extractDomainFromName(anyString())).thenReturn("Internal");
+
+        mockStatic(SCIMCommonComponentHolder.class);
+        when(SCIMCommonComponentHolder.getApplicationRoleManager())
+                .thenReturn(mockApplicationRoleManager);
+        when(mockApplicationRoleManager.getApplicationRolesByGroupId(anyString(), anyString()))
+                .thenReturn(new ArrayList<>());
 
         PowerMockito.whenNew(SCIMGroupHandler.class).withArguments(anyInt()).thenReturn(mockedSCIMGroupHandler);
         when(mockedSCIMGroupHandler.listSCIMRoles()).thenReturn(scimRoles);

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.role.mgt</artifactId>
+                <version>${identity.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
                 <scope>test</scope>
                 <version>${identity.framework.version}</version>
@@ -258,7 +264,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.9.4</carbon.kernel.version>
-        <identity.framework.version>5.25.143</identity.framework.version>
+        <identity.framework.version>5.25.287-SNAPSHOT</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
With the support of application role in the Identity Server (https://github.com/wso2/product-is/issues/16363), We need to add application roles to Users and Groups roles .

Related PR
- https://github.com/wso2/carbon-identity-framework/pull/4873