### PR TITLE
Allow SCIM PATCH API to work when members array is provided only with display attribute for its elements

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3467,7 +3467,9 @@ public class SCIMUserManager implements UserManager {
         if (StringUtils.equals(memberOperation.getOperation(), SCIMConstants.OperationalConstants.ADD)) {
             removedMembers.remove(memberObject.get(SCIMConstants.GroupSchemaConstants.DISPLAY));
             addedMembers.add(memberObject.get(SCIMConstants.GroupSchemaConstants.DISPLAY));
-            newlyAddedMemberIds.add(memberObject.get(SCIMConstants.GroupSchemaConstants.VALUE));
+            if (StringUtils.isNotBlank(memberObject.get(SCIMConstants.GroupSchemaConstants.VALUE))) {
+                newlyAddedMemberIds.add(memberObject.get(SCIMConstants.GroupSchemaConstants.VALUE));
+            }
         } else if (StringUtils.equals(memberOperation.getOperation(),
                 SCIMConstants.OperationalConstants.REMOVE)) {
             addedMembers.remove(memberObject.get(SCIMConstants.GroupSchemaConstants.DISPLAY));


### PR DESCRIPTION
Currently we are checking for both display and value attributes during a PATCH API call. The userId from the value of the value attribute and the userId derived from the username provided in display attribute is cross validated. This throws a null pointer exception if the value for the value attribute is provided. Adding this condition will restrict populating null as a element of userIds retrieved from the API body.