### PR TITLE
Improve tenant qualified URL feature.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -385,7 +385,7 @@ public class SCIMCommonUtils {
 
         String tenantDomain;
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            tenantDomain = getTenantDomainFromContext();
         } else {
             tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/SchemaResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/SchemaResource.java
@@ -37,6 +37,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.getTenantDomainFromContext;
+
 public class SchemaResource extends AbstractResource {
 
     private static final Log logger = LogFactory.getLog(SchemaResource.class);
@@ -68,7 +70,7 @@ public class SchemaResource extends AbstractResource {
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
 
             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+                String tenantDomain = getTenantDomainFromContext();
             }
 
             // create charon-SCIM schemas endpoint and hand-over the request.

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/util/SupportUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/util/SupportUtils.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.getCustomSchemaURI;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.getTenantDomainFromContext;
 
 /**
  * This class contains the common utils used at HTTP level
@@ -161,7 +162,7 @@ public class SupportUtils {
     public static String getTenantDomain() {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            return IdentityTenantUtil.getTenantDomainFromContext();
+            return getTenantDomainFromContext();
         }
         return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
     }


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/16906

Improve resolving tenant domain when tenant qualified URL feature is enabled. If the tenant domain is available in the context retrieve it otherwise retrieve tenant domain from the privileged carbon context.