### PR TITLE
Fix admin role mandatory attribute update

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -18,11 +18,18 @@
 
 package org.wso2.carbon.identity.scim2.common.group;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
+import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.objects.Group;
@@ -74,6 +81,59 @@ public class SCIMGroupHandler {
         attributes.put(SCIMConstants.CommonSchemaConstants.LOCATION_URI, SCIMCommonUtils.getSCIMGroupURL(id));
         GroupDAO groupDAO = new GroupDAO();
         groupDAO.addSCIMGroupAttributes(tenantId, groupName, attributes);
+    }
+
+    /**
+     * Add admin role attributes.
+     *
+     * @param roleName Role name.
+     * @throws IdentitySCIMException if any error occurs while adding admin role attributes.
+     */
+    public void addAdminRoleMandatoryAttributes(String roleName)
+            throws IdentitySCIMException {
+        Map<String, String> attributes = new HashMap<>();
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(1);
+        String id;
+        try {
+            id = SCIMCommonComponentHolder.getRoleManagementServiceV2().getRoleIdByName(
+                    UserCoreUtil.removeDomainFromName(roleName), RoleConstants.ORGANIZATION,
+                    getOrganizationId(tenantDomain), tenantDomain);
+        } catch (IdentityRoleManagementException e) {
+            throw new IdentitySCIMException("Error while resolving admin role id", e);
+        }
+        if (StringUtils.isBlank(id)) {
+            id = UUID.randomUUID().toString();
+        }
+        attributes.put(SCIMConstants.CommonSchemaConstants.ID_URI, id);
+
+        String createdDate = AttributeUtil.formatDateTime(Instant.now());
+        attributes.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, createdDate);
+
+        attributes.put(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI, createdDate);
+        attributes.put(SCIMConstants.CommonSchemaConstants.LOCATION_URI, SCIMCommonUtils.getSCIMGroupURL(id));
+        GroupDAO groupDAO = new GroupDAO();
+        groupDAO.addSCIMGroupAttributes(tenantId, roleName, attributes);
+    }
+
+    /**
+     * Get the organization id of the tenant.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Organization id.
+     * @throws IdentitySCIMException if any error occurs while resolving organization id.
+     */
+    private String getOrganizationId(String tenantDomain) throws IdentitySCIMException {
+
+        String orgId;
+        try {
+            orgId = SCIMCommonComponentHolder.getOrganizationManager().resolveOrganizationId(tenantDomain);
+        } catch (OrganizationManagementException e) {
+            throw new IdentitySCIMException("Error while resolving org id of tenant : " + tenantDomain, e);
+        }
+        if (StringUtils.isBlank(orgId)) {
+            throw new IdentitySCIMException("Organization id not found for tenant : " + tenantDomain);
+        }
+        return orgId;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -91,8 +91,9 @@ public class SCIMGroupHandler {
      */
     public void addAdminRoleMandatoryAttributes(String roleName)
             throws IdentitySCIMException {
+
         Map<String, String> attributes = new HashMap<>();
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(1);
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
         String id;
         try {
             id = SCIMCommonComponentHolder.getRoleManagementServiceV2().getRoleIdByName(

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -89,8 +89,7 @@ public class SCIMGroupHandler {
      * @param roleName Role name.
      * @throws IdentitySCIMException if any error occurs while adding admin role attributes.
      */
-    public void addAdminRoleMandatoryAttributes(String roleName)
-            throws IdentitySCIMException {
+    public void addAdminRoleMandatoryAttributes(String roleName) throws IdentitySCIMException {
 
         Map<String, String> attributes = new HashMap<>();
         String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.handlers.SCIMClaimOperationEventHandler;
@@ -313,6 +314,21 @@ public class SCIMCommonComponent {
     protected void unsetScimUserStoreErrorResolver(SCIMUserStoreErrorResolver scimUserStoreErrorResolver) {
 
         SCIMCommonComponentHolder.removeScimUserStoreErrorResolver(scimUserStoreErrorResolver);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        SCIMCommonComponentHolder.setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        SCIMCommonComponentHolder.setOrganizationManager(null);
     }
 
     @Deactivate

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.scim2.common.internal;
 
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
@@ -39,6 +40,7 @@ public class SCIMCommonComponentHolder {
     private static RolePermissionManagementService rolePermissionManagementService;
     private static RoleManagementService roleManagementService;
     private static org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService roleManagementServiceV2;
+    private static OrganizationManager organizationManager;
     private static final List<SCIMUserStoreErrorResolver> scimUserStoreErrorResolvers = new ArrayList<>();
 
     /**
@@ -140,6 +142,27 @@ public class SCIMCommonComponentHolder {
     public static org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService getRoleManagementServiceV2() {
 
         return roleManagementServiceV2;
+    }
+
+
+    /**
+     * Get {@link OrganizationManager}.
+     *
+     * @return organization manager instance {@link OrganizationManager}.
+     */
+    public static OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set {@link OrganizationManager}.
+     *
+     * @param organizationManager Instance of {@link OrganizationManager}.
+     */
+    public static void setOrganizationManager(OrganizationManager organizationManager) {
+
+        SCIMCommonComponentHolder.organizationManager = organizationManager;
     }
 
     public static List<SCIMUserStoreErrorResolver> getScimUserStoreErrorResolverList() {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtil.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtil.java
@@ -134,7 +134,7 @@ public class AdminAttributeUtil {
                             log.debug(
                                     "Group does not exist, setting scim attribute group value: " + roleNameWithDomain);
                         }
-                        scimGroupHandler.addMandatoryAttributes(roleNameWithDomain);
+                        scimGroupHandler.addAdminRoleMandatoryAttributes(roleNameWithDomain);
                     }
 
                     // Adding the SCIM attributes for admin group

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
@@ -152,7 +152,7 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
 
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         adminAttributeUtil.updateAdminGroup(1);
-        verify(scimGroupHandler).addMandatoryAttributes(argument.capture());
+        verify(scimGroupHandler).addAdminRoleMandatoryAttributes(argument.capture());
 
         assertEquals(argument.getValue(), roleNameWithDomain);
     }


### PR DESCRIPTION
Previously, the mandatory id attribute of admin role was update using a random UUID. However, in the current role v2 implementation, we set the UUID from the kernel to the UM_HYBRID_ROLE table. Instead of updating the ID attribute of the role with a random UUID, we set the role id attribute by retrieving the UUID from the UM_HYBRID_ROLE table.