### PR TITLE
Fix error while retrieving system role in super tenant

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -149,6 +149,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -238,6 +242,8 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.*;
                             version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.*;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.scim2.common.internal,

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -125,6 +125,7 @@ public class SCIMCommonComponent {
             AdminAttributeUtil.updateAdminUser(MultitenantConstants.SUPER_TENANT_ID, true);
             AdminAttributeUtil.updateAdminGroup(MultitenantConstants.SUPER_TENANT_ID);
             SCIMCommonUtils.updateEveryOneRoleV2MetaData(MultitenantConstants.SUPER_TENANT_ID);
+            SCIMCommonUtils.updateSystemRoleV2MetaData(MultitenantConstants.SUPER_TENANT_ID);
             if (logger.isDebugEnabled()) {
                 logger.debug("SCIM Common component activated successfully.");
             }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
 import org.wso2.carbon.identity.scim2.common.cache.SCIMCustomAttributeSchemaCache;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
@@ -865,6 +866,29 @@ public class SCIMCommonUtils {
                 String everyoneRoleNameWithDomain =
                         UserCoreUtil.addDomainToName(everyoneRoleName, domainName);
                 scimGroupHandler.addRoleV2MandatoryAttributes(everyoneRoleNameWithDomain);
+            } catch (org.wso2.carbon.user.api.UserStoreException | IdentitySCIMException e) {
+                log.error(e);
+            }
+        }
+    }
+
+    /**
+     * Update system role meta data.
+     *
+     * @param tenantId Tenant Id.
+     */
+    public static void updateSystemRoleV2MetaData(int tenantId) {
+
+        // Handle system role creation also here if legacy runtime is disabled.
+        if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
+            try {
+                UserStoreManager userStoreManager = (UserStoreManager) SCIMCommonComponentHolder.getRealmService().
+                        getTenantUserRealm(tenantId).getUserStoreManager();
+                String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+                SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(userStoreManager.getTenantId());
+                String systemRoleNameWithDomain =
+                        UserCoreUtil.addDomainToName(AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE, domainName);
+                scimGroupHandler.addRoleV2MandatoryAttributes(systemRoleNameWithDomain);
             } catch (org.wso2.carbon.user.api.UserStoreException | IdentitySCIMException e) {
                 log.error(e);
             }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -860,12 +860,9 @@ public class SCIMCommonUtils {
             try {
                 UserStoreManager userStoreManager = (UserStoreManager) SCIMCommonComponentHolder.getRealmService().
                         getTenantUserRealm(tenantId).getUserStoreManager();
-                String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
                 SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(userStoreManager.getTenantId());
                 String everyoneRoleName = userStoreManager.getRealmConfiguration().getEveryOneRoleName();
-                String everyoneRoleNameWithDomain =
-                        UserCoreUtil.addDomainToName(everyoneRoleName, domainName);
-                scimGroupHandler.addRoleV2MandatoryAttributes(everyoneRoleNameWithDomain);
+                scimGroupHandler.addRoleV2MandatoryAttributes(everyoneRoleName);
             } catch (org.wso2.carbon.user.api.UserStoreException | IdentitySCIMException e) {
                 log.error(e);
             }
@@ -884,11 +881,8 @@ public class SCIMCommonUtils {
             try {
                 UserStoreManager userStoreManager = (UserStoreManager) SCIMCommonComponentHolder.getRealmService().
                         getTenantUserRealm(tenantId).getUserStoreManager();
-                String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
                 SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(userStoreManager.getTenantId());
-                String systemRoleNameWithDomain =
-                        UserCoreUtil.addDomainToName(AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE, domainName);
-                scimGroupHandler.addRoleV2MandatoryAttributes(systemRoleNameWithDomain);
+                scimGroupHandler.addRoleV2MandatoryAttributes(AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE);
             } catch (org.wso2.carbon.user.api.UserStoreException | IdentitySCIMException e) {
                 log.error(e);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,12 @@
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                <version>${org.wso2.carbon.identity.handler.event.account.lock.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
                 <artifactId>org.wso2.carbon.identity.scim2.common</artifactId>
                 <version>${project.version}</version>
@@ -280,6 +286,8 @@
         <charon.version>4.0.14</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.76
         </org.wso2.carbon.identity.organization.management.core.version>
+        <org.wso2.carbon.identity.handler.event.account.lock.version>1.8.13
+        </org.wso2.carbon.identity.handler.event.account.lock.version>
 
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
@@ -310,6 +318,8 @@
         </carbon.identity.framework.imp.pkg.version.range>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        </carbon.identity.account.lock.handler.imp.pkg.version.range>
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
When trying to access scim2/v2/Roles endpoint for system role, getting 404 error.
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Role id: c65e5d2a-f65a-4ed6-a2b6-cacaa34fbced does not exist in the tenant: carbon.super",
    "status": "404"
}
```

This is due to not updating scim attribute metadata for system role in super tenant. With this fix, system role metadata is updated when activating the SCIMCommonComponent.

Issue - https://github.com/wso2/product-is/issues/17350 