### PR TITLE
Add support for federated IDP groups to role assignments

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -132,6 +132,10 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.password.policy</artifactId>
         </dependency>
@@ -244,6 +248,7 @@
                             version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.*;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.idp.mgt.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.scim2.common.internal,

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -56,6 +56,7 @@ import org.wso2.charon3.core.config.SCIMCustomSchemaExtensionBuilder;
 import org.wso2.charon3.core.config.SCIMUserSchemaExtensionBuilder;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
+import org.wso2.carbon.idp.mgt.IdpManager;
 
 import java.io.File;
 import java.util.concurrent.ExecutorService;
@@ -294,6 +295,34 @@ public class SCIMCommonComponent {
 
         SCIMCommonComponentHolder.setRoleManagementServiceV2(null);
         logger.debug("RoleManagementServiceV2 unset in SCIMCommonComponent bundle.");
+    }
+
+    /**
+     * Set idp manager service implementation.
+     *
+     * @param idpManager Idp manager service.
+     */
+    @Reference(
+            name = "org.wso2.carbon.idp.mgt.IdpManager",
+            service = org.wso2.carbon.idp.mgt.IdpManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdPManagerService")
+    protected void setIdPManagerService(IdpManager idpManager) {
+
+        SCIMCommonComponentHolder.setIdpManagerService(idpManager);
+        logger.debug("IdPManagerService set in SCIMCommonComponent bundle.");
+    }
+
+    /**
+     * Unset idp manager service implementation.
+     *
+     * @param idpManager Idp manager service.
+     */
+    protected void unsetIdPManagerService(IdpManager idpManager) {
+
+        SCIMCommonComponentHolder.setIdpManagerService(null);
+        logger.debug("IdPManagerService unset in SCIMCommonComponent bundle.");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.scim2.common.internal;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
@@ -41,6 +42,7 @@ public class SCIMCommonComponentHolder {
     private static RoleManagementService roleManagementService;
     private static org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService roleManagementServiceV2;
     private static OrganizationManager organizationManager;
+    private static IdpManager idpManager;
     private static final List<SCIMUserStoreErrorResolver> scimUserStoreErrorResolvers = new ArrayList<>();
 
     /**
@@ -168,6 +170,26 @@ public class SCIMCommonComponentHolder {
     public static List<SCIMUserStoreErrorResolver> getScimUserStoreErrorResolverList() {
 
         return scimUserStoreErrorResolvers;
+    }
+
+    /**
+     * Set IdpManager service.
+     *
+     * @param idpManager Idp Manager.
+     */
+    public static void setIdpManagerService(IdpManager idpManager) {
+
+        SCIMCommonComponentHolder.idpManager = idpManager;
+    }
+
+    /**
+     * Get IdpManager service.
+     *
+     * @return Idp Manager.
+     */
+    public static IdpManager getIdpManagerService() {
+
+        return idpManager;
     }
 
     public static void addScimUserStoreErrorResolver(SCIMUserStoreErrorResolver scimUserStoreErrorResolver) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -154,6 +154,29 @@ public class SCIMCommonUtils {
         }
     }
 
+    public static String getIdpGroupURL(String idpId, String groupId) {
+
+        String idpGroupURL;
+        String path = "/api/server/v1/identity-providers";
+        try {
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                idpGroupURL = ServiceURLBuilder.create().addPath(path).build()
+                        .getAbsolutePublicURL();
+            } else {
+                idpGroupURL = getURLIfTenantQualifiedURLDisabled(path);
+            }
+            return StringUtils.isNotBlank(idpId) && StringUtils.isNotBlank(groupId) ?
+                    new StringBuilder().append(idpGroupURL).append(SCIMCommonConstants.URL_SEPERATOR).append(idpId)
+                            .append(SCIMCommonConstants.URL_SEPERATOR).append(groupId).toString() : null;
+        } catch (URLBuilderException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error occurred while building the identity provider's group endpoint with " +
+                                "tenant/organization qualified URL.", e);
+            }
+            return null;
+        }
+    }
+
     public static String getPermissionRefURL(String apiId, String permissionName) {
 
         String apiResourceURL;

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+                <version>${identity.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.9.15</carbon.kernel.version>
-        <identity.framework.version>5.25.462</identity.framework.version>
+        <identity.framework.version>5.25.509</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
This PR adds the support for federated IDP groups to role assignments.

Related issue - https://github.com/wso2/product-is/issues/17429

Need to merged after - https://github.com/wso2/carbon-identity-framework/pull/5143