### PR TITLE
Add method override to fix method not allowed issue for users endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -31,6 +31,10 @@
             <ref bean="userBean"/>
         </jaxrs:serviceBeans>
 
+        <jaxrs:properties>
+            <entry key="org.apache.cxf.jaxrs.allow.http.method.override" value="true"/>
+        </jaxrs:properties>
+
     </jaxrs:server>
 
     <jaxrs:server id="userResourceOrgPerspective" address="/o/Users">


### PR DESCRIPTION
### Purpose
- Add allow http method override value as true for scim1/users endpoint
    - With CXF 3.2.11 onwards HTTP method overriding is disabled by default [1]
    - So, need to add this to scim2 provider

### Related issue
https://github.com/wso2/product-is/issues/17565

[1] https://issues.apache.org/jira/browse/CXF-8133