### PR TITLE
Add managedOrg attribute

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -705,6 +705,21 @@
 "referenceTypes":[]
 },
 {
+"attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:managedOrg",
+"attributeName":"managedOrg",
+"dataType":"string",
+"multiValued":"false",
+"description":"Organization where the user is managed",
+"required":"false",
+"caseExact":"false",
+"mutability":"readwrite",
+"returned":"default",
+"uniqueness":"none",
+"subAttributes":"null",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
 "attributeURI":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "attributeName":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 "dataType":"complex",
@@ -715,7 +730,7 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile country userSourceId totpEnabled backupCodeEnabled enabledAuthenticators failedBackupCodeAttempts",
+"subAttributes":"verifyEmail askPassword employeeNumber costCenter organization division department manager pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile country userSourceId totpEnabled backupCodeEnabled enabledAuthenticators failedBackupCodeAttempts managedOrg",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }


### PR DESCRIPTION
### Purpose

This PR adds the managedOrg attribute to `scim2-schema-extension.config` file. This will return the organization id which manages the invited users in `GET /t/<tenant_name>/o/scim2/Users` response.

### Related Issues
- https://github.com/wso2/product-is/issues/17492