### PR TITLE
Add superAdmin validation for patch and delete operations

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtil.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtil.java
@@ -211,8 +211,7 @@ public class AdminAttributeUtil {
             return adminUserID;
 
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            String error = "Error obtaining user realm.";
-            throw new CharonException(error, e);
+            throw new CharonException("Error obtaining user realm.", e);
         } catch (IdentityRoleManagementException e) {
             throw new CharonException("Error occurred while retrieving super admin ID.", e);
         }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtil.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtil.java
@@ -195,8 +195,7 @@ public class AdminAttributeUtil {
      *
      * @return Super admin ID.
      */
-    public static String getSuperAdminID()
-            throws CharonException {
+    public static String getSuperAdminID() throws CharonException {
 
         try {
             String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -34,6 +34,8 @@ import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
+import org.wso2.carbon.identity.role.mgt.core.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.mgt.core.util.UserIDResolver;
 import org.wso2.carbon.identity.scim2.common.cache.SCIMCustomAttributeSchemaCache;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
@@ -913,6 +915,23 @@ public class SCIMCommonUtils {
             } catch (org.wso2.carbon.user.api.UserStoreException | IdentitySCIMException e) {
                 log.error(e);
             }
+        }
+    }
+
+    /**
+     * Get the request initiating (logged in) user ID.
+     *
+     * @return logged in user ID.
+     */
+    public static String getLoggedInUserID() throws CharonException {
+
+        try {
+            String loggedInUserName = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+            String loggedInUserTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            UserIDResolver userIDResolver = new UserIDResolver();
+            return userIDResolver.getIDByName(loggedInUserName, loggedInUserTenantDomain);
+        } catch (IdentityRoleManagementException e) {
+            throw new CharonException("Error occurred while retrieving super admin ID.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.scim2.provider.resources;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.jaxrs.designator.PATCH;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
@@ -42,6 +44,8 @@ import static org.wso2.carbon.identity.scim2.provider.util.SupportUtils.getTenan
 
 @Path("/")
 public class UserResource extends AbstractResource {
+
+    private static final Log LOG = LogFactory.getLog(UserResource.class);
 
     @GET
     @Path("{id}")
@@ -150,6 +154,9 @@ public class UserResource extends AbstractResource {
             String superAdminID = AdminAttributeUtil.getSuperAdminID();
             String loggedInUser = SCIMCommonUtils.getLoggedInUserID();
             if ((superAdminID.equals(id)) && (!loggedInUser.equals(id))) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Do not have permission to delete SuperAdmin user.");
+                }
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
 
@@ -339,6 +346,9 @@ public class UserResource extends AbstractResource {
             String superAdminID = AdminAttributeUtil.getSuperAdminID();
             String loggedInUser = SCIMCommonUtils.getLoggedInUserID();
             if ((superAdminID.equals(id)) && (!loggedInUser.equals(id))) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Do not have permission to patch SuperAdmin user.");
+                }
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
 

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -22,6 +22,8 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.jaxrs.designator.PATCH;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.scim2.common.impl.IdentitySCIMManager;
+import org.wso2.carbon.identity.scim2.common.utils.AdminAttributeUtil;
+import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.carbon.identity.scim2.provider.util.SCIMProviderConstants;
 import org.wso2.carbon.identity.scim2.provider.util.SupportUtils;
 import org.wso2.charon3.core.exceptions.CharonException;
@@ -144,6 +146,12 @@ public class UserResource extends AbstractResource {
             }
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
+
+            String superAdminID = AdminAttributeUtil.getSuperAdminID();
+            String loggedInUser = SCIMCommonUtils.getLoggedInUserID();
+            if ((superAdminID.equals(id)) && (!loggedInUser.equals(id))) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
 
             // create charon-SCIM user resource manager and hand-over the request.
             UserResourceManager userResourceManager = new UserResourceManager();
@@ -327,6 +335,12 @@ public class UserResource extends AbstractResource {
             }
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
+
+            String superAdminID = AdminAttributeUtil.getSuperAdminID();
+            String loggedInUser = SCIMCommonUtils.getLoggedInUserID();
+            if ((superAdminID.equals(id)) && (!loggedInUser.equals(id))) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
 
             // Build Custom schema
             buildCustomSchema(userManager, getTenantId());


### PR DESCRIPTION
With this update superAdmin related patch and delete scim operations will only be allowed to be performed by the superAdmin themselves. 