### PR TITLE
Return 404 response when changing a non-existing role

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -714,7 +714,7 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
         }
     }
 
-    private String getCurrentRoleName(String roleId, String tenantDomain) throws CharonException, BadRequestException {
+    private String getCurrentRoleName(String roleId, String tenantDomain) throws CharonException, NotFoundException {
 
         String currentRoleName;
         try {
@@ -724,7 +724,7 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             }
         } catch (IdentityRoleManagementException e) {
             if ((ROLE_NOT_FOUND.getCode()).equals(e.getErrorCode())) {
-                throw new BadRequestException(e.getMessage());
+                throw new NotFoundException(e.getMessage());
             }
             throw new CharonException(String.format("Error occurred while getting the role name by " +
                     "the role id: %s", roleId), e);


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/19092

The following response will be given now for the PATCH /scim2/v2/Roles/invalidRole request

```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "A role doesn't exist with id: invalidRole in the tenantDomain: carbon.super",
    "status": "404"
}
```