### PR TITLE
Provide Group UUID support for write operations

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/DAO/GroupDAO.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/DAO/GroupDAO.java
@@ -195,7 +195,6 @@ public class GroupDAO {
                 }
                 prepStmt.executeBatch();
                 connection.commit();
-
             } catch (SQLException e) {
                 throw new IdentitySCIMException("Error when adding SCIM attributes for the group: "
                         + roleName, e);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -615,15 +615,15 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                             !CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
                         scimGroupHandler.addRoleV2MandatoryAttributes(roleNameWithDomain);
                     } else {
-                        scimGroupHandler.addMandatoryAttributes(roleNameWithDomain);
+                        if (!((AbstractUserStoreManager) userStoreManager).isUniqueGroupIdEnabled()) {
+                            scimGroupHandler.addMandatoryAttributes(roleNameWithDomain);
+                        }
                     }
                 }
             } catch (IdentitySCIMException e) {
                 throw new UserStoreException("Error retrieving group information from SCIM Tables.", e);
             }
-
             return true;
-
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.9.18</carbon.kernel.version>
+        <carbon.kernel.version>4.9.24</carbon.kernel.version>
         <identity.framework.version>5.25.612</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.9.24</carbon.kernel.version>
+        <carbon.kernel.version>4.10.1</carbon.kernel.version>
         <identity.framework.version>5.25.612</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
## Purpose
Implement Group UUID support for ReadWrite LDAP and AD. 
- Resolves 2nd Todo in https://github.com/wso2/product-is/issues/7913
- Resolves https://github.com/wso2/product-is/issues/7915
- Part of https://github.com/wso2/product-is/issues/16368

## Approach
- Use the UM APIs and improve the SCIM implementation.
- Improve the listeners in SCIM to read meta attributes from user core events

## Before Merging
- https://github.com/wso2/carbon-kernel/pull/3812 has to be merged and a new kernel version to be released.
- Use the new kernel version in product-is and bump in this repo.