### PR TITLE
Fix invalid warn log being printed in the console

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -683,6 +683,14 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             if (!isEnable() || userStoreManager == null || !userStoreManager.isSCIMEnabled()) {
                 return true;
             }
+            if (userStoreManager instanceof AbstractUserStoreManager &&
+                    ((AbstractUserStoreManager) userStoreManager).isUniqueGroupIdEnabled()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("UniqueGroupId is enabled. Skipping doPostUpdateRoleName in " +
+                            "SCIMUserOperationListener");
+                }
+                return true;
+            }
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Error while reading isScimEnabled from userstore manager", e);
         }


### PR DESCRIPTION
## Purpose 
Fix the following invalid warn log being printed in the console when updating a group name of the group uuid enabled userstore.

```
"Non-existent group: " + oldRoleName + " is trying to be updated.."
```