### PR TITLE
Get totalResults value by user count

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1481,7 +1481,7 @@ public class SCIMUserManager implements UserManager {
                              String sortOrder, String domainName) throws BadRequestException, CharonException {
 
         if (SCIMConstants.UserSchemaConstants.GROUP_URI.equals(((ExpressionNode) node).getAttributeValue())) {
-            getUserCountByGroup(node, domainName);
+            return getUserCountByGroup(node, domainName);
         }
 
         return filterUsers(node, 1, limit, sortBy, sortOrder, domainName).size();

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1447,7 +1447,7 @@ public class SCIMUserManager implements UserManager {
                     maxLimit = Math.max(maxLimit, limit);
                 }
                 // Get total users based on the filter query without depending on pagination params.
-                if(SCIMCommonUtils.isRetrieveTotalResultsByUserCountEnabled()) {
+                if (SCIMCommonUtils.isRetrieveTotalResultsByUserCountEnabled()) {
                     //Get the total user count by the filter query.
                     totalResults += getUserCountByAttribute(node, 1, maxLimit, sortBy, sortOrder, domainName);
                 } else {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -102,6 +102,8 @@ public class SCIMCommonConstants {
             "SCIM2.ConsiderMaxLimitForTotalResult";
     public static final String SCIM_ENABLE_CONSIDER_TOTAL_RECORDS_FOR_TOTAL_RESULT_OF_LDAP =
             "SCIM2.ConsiderTotalRecordsForTotalResultOfLDAP";
+    public static final String SCIM_ENABLE_RETRIEVE_TOTAL_RESULTS_BY_User_Count =
+            "SCIM2.EnableRetrieveTotalResultsByUserCount";
     public static final String SCIM_ENABLE_MANDATE_DOMAIN_FOR_GROUPNAMES_IN_GROUPS_RESPONSE =
             "SCIM2.MandateDomainForGroupNamesInGroupsResponse";
     public static final String SCIM_ENABLE_MANDATE_DOMAIN_FOR_USERNAMES_AND_GROUPNAMES_IN_RESPONSE =

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -102,7 +102,7 @@ public class SCIMCommonConstants {
             "SCIM2.ConsiderMaxLimitForTotalResult";
     public static final String SCIM_ENABLE_CONSIDER_TOTAL_RECORDS_FOR_TOTAL_RESULT_OF_LDAP =
             "SCIM2.ConsiderTotalRecordsForTotalResultOfLDAP";
-    public static final String SCIM_ENABLE_RETRIEVE_TOTAL_RESULTS_BY_User_Count =
+    public static final String SCIM_ENABLE_RETRIEVE_TOTAL_RESULTS_BY_USER_COUNT =
             "SCIM2.EnableRetrieveTotalResultsByUserCount";
     public static final String SCIM_ENABLE_MANDATE_DOMAIN_FOR_GROUPNAMES_IN_GROUPS_RESPONSE =
             "SCIM2.MandateDomainForGroupNamesInGroupsResponse";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -620,6 +620,17 @@ public class SCIMCommonUtils {
     }
 
     /**
+     * Checks whether the identity.xml config is available to retrieve totalResults by user count.
+     *
+     * @return whether 'RetrieveTotalResultsByUserCount' property is enabled in identity.xml.
+     */
+    public static boolean isRetrieveTotalResultsByUserCountEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(
+                SCIMCommonConstants.SCIM_ENABLE_RETRIEVE_TOTAL_RESULTS_BY_User_Count));
+    }
+
+    /**
      * Checks whether the identity.xml config is available to notify userstore availability.
      *
      * @return whether 'NotifyUserstoreStatus' property is enabled in the identity.xml.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -627,7 +627,7 @@ public class SCIMCommonUtils {
     public static boolean isRetrieveTotalResultsByUserCountEnabled() {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty(
-                SCIMCommonConstants.SCIM_ENABLE_RETRIEVE_TOTAL_RESULTS_BY_User_Count));
+                SCIMCommonConstants.SCIM_ENABLE_RETRIEVE_TOTAL_RESULTS_BY_USER_COUNT));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.10.2</carbon.kernel.version>
+        <carbon.kernel.version>4.10.10</carbon.kernel.version>
         <identity.framework.version>7.0.89</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
Resolve the issue: https://github.com/wso2/product-is/issues/12813

When the SCIM API is invoked with a filter, the current behavior involves returning a predefined value for the totalResults parameter based on the MaxUserNameListLength, rather than reflecting the actual results that match the filter criteria. This fix addresses the issue by accurately determining the user count that corresponds to the given filter.  To enable this fix, the following config should be added 

```
[scim2]
enable_retrieve_totalresults_By_user_count = true
```
Related PRs; https://github.com/wso2/carbon-kernel/pull/3906, https://github.com/wso2/carbon-identity-framework/pull/5533

Merge https://github.com/wso2/carbon-kernel/pull/3906 PR, before merging this PR.

