### PR TITLE
Fix lack of exception when attempting to update a non-existent role name

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -284,7 +284,8 @@ public class SCIMGroupHandler {
         if (groupDAO.isExistingGroup(oldRoleName, this.tenantId)) {
             groupDAO.updateRoleName(this.tenantId, oldRoleName, newRoleName);
         } else {
-            logger.warn("Non-existent group: " + oldRoleName + " is trying to be updated..");
+            throw new IdentitySCIMException("Non-existent group: " + oldRoleName +
+                    " is trying to be updated..");
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -285,7 +285,7 @@ public class SCIMGroupHandler {
             groupDAO.updateRoleName(this.tenantId, oldRoleName, newRoleName);
         } else {
             throw new IdentitySCIMException("Non-existent group: " + oldRoleName +
-                    " is trying to be updated..");
+                    " is trying to be updated.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -301,7 +301,7 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
 
         SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
         scimGroupHandler.updateRoleName("NON_EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
-        // this method is for testing of throwing IdentitySCIMException, hence no assertion
+        // This method is to test the throwing of an IdentitySCIMException, hence no assertion.
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
+import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.charon3.core.objects.Group;
 
@@ -47,7 +48,6 @@ import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyMap;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -289,7 +289,7 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
         assertEquals(argumentCaptor.getValue(),"EXISTENT_ROLE_NAME");
     }
 
-    @Test
+    @Test(expectedExceptions = IdentitySCIMException.class)
     public void testUpdateRoleNameNonExistent() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
         mockStatic(IdentityDatabaseUtil.class);
@@ -301,7 +301,7 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
 
         SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
         scimGroupHandler.updateRoleName("NON_EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
-        verify(mockedGroupDAO, times(0)).updateRoleName(anyInt(),anyString(),anyString());
+        // this method is for testing of throwing IdentitySCIMException, hence no assertion
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Previously, when addressing https://github.com/wso2/product-is/issues/14095, the updateRoleName method's was changed to print a warn log instead of throwing an exception via https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/435, which was a temporary fix which had not been reverted even after a proper fix was added.

This PR reverts the temporary fix and allows an exception to be thrown instead of a warn log.

With this change, the SOAP API will be able to identify the failure of the operation and return the status as 500 Internal Server Error along with the error message.

## Related PRs

- https://github.com/wso2-extensions/identity-user-ws/pull/64

## Related Issues

- https://github.com/wso2/product-is/issues/19114