### PR TITLE
Fix user deletion issue in the sub organizations

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -925,6 +925,9 @@ public class SCIMCommonUtils {
      */
     public static String getLoggedInUserID() throws CharonException {
 
+        if (PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId() != null) {
+            return PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
+        }
         try {
             String loggedInUserName = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             String loggedInUserTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();


### PR DESCRIPTION
## Changes in this PR
- Return the user id from the carbon context if that exists. Otherwise the existing implementation will follow.