### PR TITLE
Add validation for the count parameter

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -403,9 +403,8 @@ public class UserResource extends AbstractResource {
      *
      * @param count Requested item count.
      * @return Validated count parameter.
-     * @throws CharonException If the count is negative.
      */
-    private int validateCountParameter(Integer count) throws CharonException {
+    private int validateCountParameter(Integer count) {
 
         int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
         if (count > maximumItemsPerPage) {

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -198,7 +198,7 @@ public class UserResource extends AbstractResource {
             }
 
             // Validates the count parameter if exists.
-            if (count != null && IdentityUtil.isSCIM2UserEndpointPaginationEnabled()) {
+            if (count != null && IdentityUtil.isSCIM2UserMaxItemsPerPageEnabled()) {
                 count = validateCountParameter(count);
             }
 

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -197,6 +197,11 @@ public class UserResource extends AbstractResource {
                 throw  new FormatNotSupportedException(error);
             }
 
+            // Validates the count parameter if exists.
+            if (count != null && IdentityUtil.isSCIM2UserEndpointPaginationEnabled()) {
+                count = validateCountParameter(count);
+            }
+
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
 
@@ -391,5 +396,26 @@ public class UserResource extends AbstractResource {
 
         IdentityUtil.threadLocalProperties.get()
                 .remove(IdentityRecoveryConstants.AP_CONFIRMATION_CODE_THREAD_LOCAL_PROPERTY);
+    }
+
+    /**
+     * Validate the count query parameter.
+     *
+     * @param count Requested item count.
+     * @return Validated count parameter.
+     * @throws CharonException If the count is negative.
+     */
+    private int validateCountParameter(Integer count) throws CharonException {
+
+        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (count > maximumItemsPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Given limit exceeds the maximum limit. Therefore the limit is set to %s.",
+                        maximumItemsPerPage));
+            }
+            return maximumItemsPerPage;
+        }
+
+        return count;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.2</carbon.kernel.version>
-        <identity.framework.version>7.0.105</identity.framework.version>
+        <identity.framework.version>7.0.112</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
### Describe
This PR will fix the `default maximum number of records per request`(100) is not being honored by SCIM GET Users API. As the fix, added a validation for the count parameter which check whether the count is exceeding the configured `default maximum number of records per request` parameter. If yes, then sets the count value to 100.

### When this PR need to be merged
1. Merge and Release https://github.com/wso2/carbon-identity-framework/pull/5599 PR.
2. Bump framework version with the released version.
3. Run the PR builder.

Related issues:
- https://github.com/wso2/product-is/issues/20030