### PR TITLE
Resolve user ID from username when user ID is not provided

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1297,10 +1297,19 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
                         ResponseCodeConstants.INVALID_VALUE);
             }
 
+            String userID = memberObject.get(SCIMConstants.RoleSchemaConstants.VALUE);
+            if (StringUtils.isEmpty(userID)) {
+                userID = userStoreManager.getUserIDFromUserName(
+                        memberObject.get(SCIMConstants.RoleSchemaConstants.DISPLAY));
+                if (StringUtils.isEmpty(userID)) {
+                    throw new BadRequestException("User can't be resolved from the given username.",
+                            ResponseCodeConstants.NO_TARGET);
+                }
+            }
+
             List<String> roleList;
             try {
-                roleList = roleManagementService.getRoleIdListOfUser(
-                        memberObject.get(SCIMConstants.RoleSchemaConstants.VALUE), tenantDomain);
+                roleList = roleManagementService.getRoleIdListOfUser(userID, tenantDomain);
             } catch (IdentityRoleManagementException e) {
                 throw new CharonException("Error occurred while retrieving the role list of user.");
             }


### PR DESCRIPTION
### Purpose
In SCIM2 Roles V2 api, patch operation will fail when trying to remove a user from a role if the request only contains the `display` property of the user. This PR fixes this issue