### PR TITLE
Fix unique key violation exception when concurrent group patch requests trying to add same users to the group

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3535,9 +3535,12 @@ public class SCIMUserManager implements UserManager {
             // Update the group name in UM_HYBRID_GROUP_ROLE table.
             carbonUM.updateGroupName(currentGroupName, newGroupName);
         } catch (UserStoreException e) {
-            if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
-                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE.getCode(),
-                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
+            if (e instanceof org.wso2.carbon.user.core.UserStoreException && (StringUtils
+                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE
+                            .getCode(), ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()) ||
+                    StringUtils.equals(UserCoreErrorConstants.ErrorMessages
+                                    .ERROR_CODE_DUPLICATE_WHILE_UPDATING_USER_OF_ROLE.getCode(),
+                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()))) {
                 // This handles the scenario where a unique key violation exception occurs when concurrent group
                 // patch requests try to add the same users to the group.
                 return;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3536,6 +3536,13 @@ public class SCIMUserManager implements UserManager {
             carbonUM.updateGroupName(currentGroupName, newGroupName);
         } catch (UserStoreException e) {
             if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
+                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE.getCode(),
+                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
+                // This handles the scenario where a unique key violation exception occurs when concurrent group
+                // patch requests try to add the same users to the group.
+                return;
+            }
+            if (e instanceof org.wso2.carbon.user.core.UserStoreException && StringUtils
                     .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode(),
                             ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode())) {
                 log.error(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getMessage(), e);

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.10.12</carbon.kernel.version>
+        <carbon.kernel.version>4.10.16</carbon.kernel.version>
         <identity.framework.version>7.0.112</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
## Purpose
$subject

## Related Issues 

## Merge after
- https://github.com/wso2/carbon-kernel/pull/3997