### PR TITLE
Add empty check before updating IDP groups

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -163,8 +163,10 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             RoleBasicInfo roleBasicInfo =
                     roleManagementService.addRole(role.getDisplayName(), role.getUsers(), localGroupIds,
                             permissionList, audienceType, role.getAudienceValue(), tenantDomain);
-            roleManagementService.updateIdpGroupListOfRole(roleBasicInfo.getId(), idpGroupList, new ArrayList<>(),
-                    tenantDomain);
+            if (isNotEmpty(idpGroupList)) {
+                roleManagementService.updateIdpGroupListOfRole(roleBasicInfo.getId(), idpGroupList, new ArrayList<>(),
+                        tenantDomain);
+            }
             RoleV2 createdRole = new RoleV2();
             createdRole.setId(roleBasicInfo.getId());
             String locationURI = SCIMCommonUtils.getSCIMRoleV2URL(roleBasicInfo.getId());


### PR DESCRIPTION
> Currently we do not have an empty check before updating IDP groups during role creation. Due to this IDP group update event is triggered unnecessarily. This PR add an additional empty check before updating IDP groups