### PR TITLE
Fix: SCIM error handling for group display name (fixes #20344)

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -776,7 +776,7 @@ public class SCIMRoleManager implements RoleManager {
 
         String value = groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE);
 
-        if (value == null) {
+        if (StringUtils.isBlank(value)) {
             throw new BadRequestException(
                     "Updating groups of the role by display name is not supported. Update using group id instead.",
                     ResponseCodeConstants.INVALID_SYNTAX);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -775,11 +775,11 @@ public class SCIMRoleManager implements RoleManager {
             throws BadRequestException {
 
         String value = groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE);
-        String errorMessage =
-                "Updating groups of the role by display name is not supported. Update using group id instead.";
 
         if (value == null) {
-            throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_SYNTAX);
+            throw new BadRequestException(
+                    "Updating groups of the role by display name is not supported. Update using group id instead.",
+                    ResponseCodeConstants.INVALID_SYNTAX);
         }
 
         switch (groupOperation.getOperation()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -771,21 +771,30 @@ public class SCIMRoleManager implements RoleManager {
 
     private void prepareAddedRemovedGroupLists(Set<String> addedGroupsIds, Set<String> removedGroupsIds,
                                                Set<String> replacedGroupsIds, PatchOperation groupOperation,
-                                               Map<String, String> groupObject, List<GroupBasicInfo> groupListOfRole) {
+                                               Map<String, String> groupObject, List<GroupBasicInfo> groupListOfRole)
+            throws BadRequestException {
+
+        String value = groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE);
+        String errorMessage =
+                "Updating groups of the role by display name is not supported. Update using group id instead.";
+
+        if (value == null) {
+            throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_SYNTAX);
+        }
 
         switch (groupOperation.getOperation()) {
             case (SCIMConstants.OperationalConstants.ADD):
-                removedGroupsIds.remove(groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE));
-                if (!isGroupExist(groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE), groupListOfRole)) {
-                    addedGroupsIds.add(groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE));
+                removedGroupsIds.remove(value);
+                if (!isGroupExist(value, groupListOfRole)) {
+                    addedGroupsIds.add(value);
                 }
                 break;
             case (SCIMConstants.OperationalConstants.REMOVE):
-                addedGroupsIds.remove(groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE));
-                removedGroupsIds.add(groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE));
+                addedGroupsIds.remove(value);
+                removedGroupsIds.add(value);
                 break;
             case (SCIMConstants.OperationalConstants.REPLACE):
-                replacedGroupsIds.add(groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE));
+                replacedGroupsIds.add(value);
                 break;
         }
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1125,8 +1125,9 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
                         new ArrayList<>(deleteGroupIDList), tenantDomain);
             } catch (IdentityRoleManagementException e) {
                 if (RoleConstants.Error.INVALID_REQUEST.getCode().equals(e.getErrorCode())) {
-                    // Custom error message and SCIM type
-                    String errorMessage = "Invalid request: The provided value is not supported. Please use the group ID instead.";
+                    // Error message and SCIM type
+                    String errorMessage = "Updating groups of the role by display name is not supported. "
+                            + "Update using group id instead.";
                     String scimType = "invalidSyntax"; // From RFC 7644 Table 9
 
                     // Throw BadRequestException with custom message and scimType

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1126,11 +1126,11 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             } catch (IdentityRoleManagementException e) {
                 if (RoleConstants.Error.INVALID_REQUEST.getCode().equals(e.getErrorCode())) {
                     // Custom error message and SCIM type
-                    String customMessage = "Invalid request: Group display name is not supported. Please use the group ID instead.";
+                    String errorMessage = "Invalid request: The provided value is not supported. Please use the group ID instead.";
                     String scimType = "invalidSyntax"; // From RFC 7644 Table 9
 
                     // Throw BadRequestException with custom message and scimType
-                    throw new BadRequestException(customMessage, scimType);
+                    throw new BadRequestException(errorMessage, scimType);
                 }
                 throw new CharonException(
                         String.format("Error occurred while updating groups in the role with ID: %s", roleId), e);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1217,11 +1217,11 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
                                           Map<String, String> groupObject) throws BadRequestException {
 
         String value = groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE);
-        String errorMessage =
-                "Updating groups of the role by display name is not supported. Update using group id instead.";
 
         if (value == null) {
-            throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_SYNTAX);
+            throw new BadRequestException(
+                    "Updating groups of the role by display name is not supported. Update using group id instead.",
+                    ResponseCodeConstants.INVALID_SYNTAX);
         }
 
         switch (groupOperation.getOperation()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1218,7 +1218,7 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
 
         String value = groupObject.get(SCIMConstants.CommonSchemaConstants.VALUE);
 
-        if (value == null) {
+        if (StringUtils.isBlank(value)) {
             throw new BadRequestException(
                     "Updating groups of the role by display name is not supported. Update using group id instead.",
                     ResponseCodeConstants.INVALID_SYNTAX);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1125,7 +1125,12 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
                         new ArrayList<>(deleteGroupIDList), tenantDomain);
             } catch (IdentityRoleManagementException e) {
                 if (RoleConstants.Error.INVALID_REQUEST.getCode().equals(e.getErrorCode())) {
-                    throw new BadRequestException(e.getMessage());
+                    // Custom error message and SCIM type
+                    String customMessage = "Invalid request: Group display name is not supported. Please use the group ID instead.";
+                    String scimType = "invalidSyntax"; // From RFC 7644 Table 9
+
+                    // Throw BadRequestException with custom message and scimType
+                    throw new BadRequestException(customMessage, scimType);
                 }
                 throw new CharonException(
                         String.format("Error occurred while updating groups in the role with ID: %s", roleId), e);


### PR DESCRIPTION
## Purpose
Fix SCIM error handling to provide appropriate messages when a group display name is used instead of a group ID.

## Goals
To ensure compliance with RFC 7644 and provide clear, actionable error messages to users when an invalid request is made with a group display name.

## Approach
- Implemented error response with `scimType` set to `invalidSyntax` for requests using a group display name instead of a group ID.
- Provided a clear and concise error message in the `detail` field.
- Handled the fix for both V1 and V2 roles.
- Ensured the error response adhered to the SCIM specification.

## Issue
Resolves [#20334](https://github.com/wso2/product-is/issues/20334)
