### PR TITLE
Update scim2 documentation_uri

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/org.wso2.carbon.identity.scim2.common.feature.default.json
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/org.wso2.carbon.identity.scim2.common.feature.default.json
@@ -4,7 +4,7 @@
   "scim2.custom_user_schema_uri": "urn:scim:wso2:schema",
   "scim2.max_bulk_operations": "1000",
   "scim2.max_bulk_payload": "1048576",
-  "scim2.documentation_uri": "https://docs.wso2.com/display/IS580/Using+the+SCIM+2.0+REST+APIs",
+  "scim2.documentation_uri": "https://is.docs.wso2.com/en/latest/apis/scim2-users-rest-apis/",
   "scim2.oauth_bearer.primary": true,
   "scim2.http_basic.primary": false,
   "scim2.basic_auth_documentation_uri": "$ref{scim2.documentation_uri}",

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/org.wso2.carbon.identity.scim2.common.feature.default.json
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/org.wso2.carbon.identity.scim2.common.feature.default.json
@@ -4,7 +4,7 @@
   "scim2.custom_user_schema_uri": "urn:scim:wso2:schema",
   "scim2.max_bulk_operations": "1000",
   "scim2.max_bulk_payload": "1048576",
-  "scim2.documentation_uri": "https://is.docs.wso2.com/en/latest/apis/scim2-users-rest-apis/",
+  "scim2.documentation_uri": "https://is.docs.wso2.com/en/latest/apis/scim2/",
   "scim2.oauth_bearer.primary": true,
   "scim2.http_basic.primary": false,
   "scim2.basic_auth_documentation_uri": "$ref{scim2.documentation_uri}",


### PR DESCRIPTION
## Purpose
To update the SCIM2 `documentation_uri` in the `/ServiceProviderConfig` endpoint response.

## Approach
Updating the `documentation_uri` to https://is.docs.wso2.com/en/latest/apis/scim2-users-rest-apis/ to ensure compatibility with future releases. The new URL does not include specific release versions, allowing it to rely on the latest updates.

## Related Issues
Resolves [#20738](https://github.com/wso2/product-is/issues/20738)

