### PR TITLE
Add a new check for maximum items per page param

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6451,7 +6451,7 @@ public class SCIMUserManager implements UserManager {
     private int validateCountParameter(Integer count) {
 
         int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
-        if (count > maximumItemsPerPage) {
+        if (maximumItemsPerPage != -1 && count > maximumItemsPerPage) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Given limit exceeds the maximum limit. Therefore the limit is set to %s.",
                         maximumItemsPerPage));


### PR DESCRIPTION
## Changes from this PR
- Added a newly check for maxmium items per page configuration
- We added this to revert this change. If the maximum items per page = -1, we return the total number of uses from the API