### PR TITLE
Revert "Refactor the users list limit to a common method"

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -605,10 +605,6 @@ public class SCIMUserManager implements UserManager {
                                          String sortOrder, String domainName, Map<String, Boolean> requiredAttributes)
             throws CharonException, NotImplementedException, BadRequestException {
 
-        // Validates the count parameter if exists.
-        if (count != null && IdentityUtil.isSCIM2UserMaxItemsPerPageEnabled()) {
-            count = validateCountParameter(count);
-        }
         // Validate NULL value for startIndex.
         startIndex = handleStartIndexEqualsNULL(startIndex);
         if (sortBy != null || sortOrder != null) {
@@ -6440,25 +6436,5 @@ public class SCIMUserManager implements UserManager {
     private String maskIfRequired(String value) {
 
         return LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(value) : value;
-    }
-
-    /**
-     * Validate the count query parameter.
-     *
-     * @param count Requested item count.
-     * @return Validated count parameter.
-     */
-    private int validateCountParameter(Integer count) {
-
-        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
-        if (count > maximumItemsPerPage) {
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("Given limit exceeds the maximum limit. Therefore the limit is set to %s.",
-                        maximumItemsPerPage));
-            }
-            return maximumItemsPerPage;
-        }
-
-        return count;
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -532,8 +532,8 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
 
     @Test(dataProvider = "userInfoForFiltering")
     public void testFilteringUsersWithGET(List<org.wso2.carbon.user.core.common.User> users, String filter,
-                                          Integer count, int expectedResultCount,
-                                          List<org.wso2.carbon.user.core.common.User> filteredUsers) throws Exception {
+                                          int expectedResultCount, List<org.wso2.carbon.user.core.common.User>
+                                                  filteredUsers) throws Exception {
 
         Map<String, String> scimToLocalClaimMap = new HashMap<>();
         scimToLocalClaimMap.put("urn:ietf:params:scim:schemas:core:2.0:User:userName",
@@ -570,8 +570,6 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         when(mockRealmService.getBootstrapRealmConfiguration()).thenReturn(mockedRealmConfig);
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled()).thenReturn(false);
-        when(IdentityUtil.getMaximumItemPerPage()).thenReturn(2);
-        when(IdentityUtil.isSCIM2UserMaxItemsPerPageEnabled()).thenReturn(true);
 
         ClaimMapping[] claimMappings = getTestClaimMappings();
         when(mockedClaimManager.getAllClaimMappings(anyString())).thenReturn(claimMappings);
@@ -587,7 +585,7 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
             node = filterTreeManager.buildTree();
         }
 
-        UsersGetResponse result = scimUserManager.listUsersWithGET(node, Integer.valueOf(1), count, null, null, null,
+        UsersGetResponse result = scimUserManager.listUsersWithGET(node, 1, null, null, null, null,
                 requiredClaimsMap);
         assertEquals(result.getUsers().size(), expectedResultCount);
     }
@@ -615,30 +613,16 @@ public class SCIMUserManagerTest extends PowerMockTestCase {
         testUser2.setUserStoreDomain("PRIMARY");
         users.add(testUser2);
 
-        org.wso2.carbon.user.core.common.User testUser3 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
-                .toString(), "testUser3", "testUser3");
-        Map<String, String> testUser3Attributes = new HashMap<>();
-        testUser3Attributes.put("http://wso2.org/claims/givenname", "testUser");
-        testUser3Attributes.put("http://wso2.org/claims/emailaddress", "testUser3@wso2.com");
-        testUser3.setAttributes(testUser1Attributes);
-        testUser3.setUserStoreDomain("PRIMARY");
-        users.add(testUser3);
-
         return new Object[][]{
 
-                {users, "name.givenName eq testUser", null, 2,
+                {users, "name.givenName eq testUser", 2,
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
                             add(testUser2);
                         }}},
-                {users, "name.givenName eq testUser and emails eq testUser1@wso2.com", null, 1,
+                {users, "name.givenName eq testUser and emails eq testUser1@wso2.com", 1,
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
-                        }}},
-                {users, "name.givenName eq testUser", 3, 2,
-                        new ArrayList<org.wso2.carbon.user.core.common.User>() {{
-                            add(testUser1);
-                            add(testUser2);
                         }}}
         };
     }

--- a/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
+++ b/components/org.wso2.carbon.identity.scim2.provider/src/main/java/org/wso2/carbon/identity/scim2/provider/resources/UserResource.java
@@ -199,6 +199,11 @@ public class UserResource extends AbstractResource {
                 throw  new FormatNotSupportedException(error);
             }
 
+            // Validates the count parameter if exists.
+            if (count != null && IdentityUtil.isSCIM2UserMaxItemsPerPageEnabled()) {
+                count = validateCountParameter(count);
+            }
+
             // obtain the user store manager
             UserManager userManager = IdentitySCIMManager.getInstance().getUserManager();
 
@@ -394,5 +399,25 @@ public class UserResource extends AbstractResource {
 
         IdentityUtil.threadLocalProperties.get()
                 .remove(IdentityRecoveryConstants.AP_CONFIRMATION_CODE_THREAD_LOCAL_PROPERTY);
+    }
+
+    /**
+     * Validate the count query parameter.
+     *
+     * @param count Requested item count.
+     * @return Validated count parameter.
+     */
+    private int validateCountParameter(Integer count) {
+
+        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (count > maximumItemsPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Given limit exceeds the maximum limit. Therefore the limit is set to %s.",
+                        maximumItemsPerPage));
+            }
+            return maximumItemsPerPage;
+        }
+
+        return count;
     }
 }


### PR DESCRIPTION
Reverts wso2-extensions/identity-inbound-provisioning-scim2#560

- This affects both /scim2/Users GET api and /scim2/Users/.search API and can be a behavioural change for either one, need to revisit the solution