### PR TITLE
Fix unique key violation exception when concurrent group patch requests trying to add same users to the group

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -3391,6 +3391,16 @@ public class SCIMUserManager implements UserManager {
         try {
             doUpdateGroup(oldGroup, newGroup);
         } catch (UserStoreException e) {
+            if (e instanceof org.wso2.carbon.user.core.UserStoreException && (StringUtils
+                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE
+                            .getCode(), ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()) ||
+                    StringUtils.equals(UserCoreErrorConstants.ErrorMessages
+                                    .ERROR_CODE_DUPLICATE_WHILE_UPDATING_USER_OF_ROLE.getCode(),
+                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()))) {
+                // This handles the scenario where a unique key violation exception occurs when concurrent group
+                // patch requests try to add the same users to the group.
+                return;
+            }
             handleErrorsOnRoleNamePolicy(e);
             throw resolveError(e, e.getMessage());
         } catch (IdentitySCIMException e) {
@@ -3659,6 +3669,16 @@ public class SCIMUserManager implements UserManager {
                 return oldGroup;
             }
         } catch (UserStoreException e) {
+            if (e instanceof org.wso2.carbon.user.core.UserStoreException && (StringUtils
+                    .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE
+                            .getCode(), ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()) ||
+                    StringUtils.equals(UserCoreErrorConstants.ErrorMessages
+                                    .ERROR_CODE_DUPLICATE_WHILE_UPDATING_USER_OF_ROLE.getCode(),
+                            ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode()))) {
+                // This handles the scenario where a unique key violation exception occurs when concurrent group
+                // patch requests try to add the same users to the group.
+                return getGroup(newGroup.getId(), requiredAttributes);
+            }
             handleErrorsOnRoleNamePolicy(e);
             throw resolveError(e, e.getMessage());
         } catch (IdentitySCIMException e) {


### PR DESCRIPTION
## Purpose
$Subject

## Related Issue


## Related PRs
- https://github.com/wso2/carbon-kernel/pull/3997
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/552
