### PR TITLE
Add hard limit for scim2/Users/.search API response

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -157,6 +157,10 @@
             <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -249,6 +253,7 @@
                             org.wso2.carbon.identity.handler.event.account.lock.*;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.idp.mgt.*;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.scim2.common.internal,

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -633,12 +633,13 @@ public class SCIMUserManager implements UserManager {
             if (!IdentityUtil.isConsiderServerWideUserEndpointMaxLimitEnabled()) {
                 Resource maxLimitResource = getResourceByTenantId(carbonUM.getTenantId());
                 if (maxLimitResource != null) {
-                    count = maxLimitResource.getAttributes().stream()
+                    int maxLimit = maxLimitResource.getAttributes().stream()
                             .filter(item -> "userResponseMaxLimit".equals(item.getKey()))
                             .map(org.wso2.carbon.identity.configuration.mgt.core.model.Attribute::getValue)
                             .findFirst()
                             .map(Integer::parseInt)
                             .orElse(count);  // Use the local count variable
+                    count = Math.min(count, maxLimit);
                 }
             } else {
                 count = SCIMCommonUtils.validateCountParameter(count);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -630,7 +630,7 @@ public class SCIMUserManager implements UserManager {
         int count = searchRequest.getCount();
 
         try {
-            if (!IdentityUtil.isConsiderServerWideUserEndpointMaxLimitEnabled()) {
+            if (!SCIMCommonUtils.isConsiderServerWideUserEndpointMaxLimitEnabled()) {
                 Resource maxLimitResource = getResourceByTenantId(carbonUM.getTenantId());
                 if (maxLimitResource != null) {
                     int maxLimit = maxLimitResource.getAttributes().stream()

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
@@ -386,6 +387,34 @@ public class SCIMCommonComponent {
     protected void setIdentityEventService(IdentityEventService identityEventService) {
 
         SCIMCommonComponentHolder.setIdentityEventService(identityEventService);
+    }
+
+    @Reference(
+            name = "resource.configuration.manager",
+            service = ConfigurationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConfigurationManager"
+    )
+
+    /**
+     * This method is used to set the Configuration manager Service.
+     *
+     * @param configurationManager The Realm Service which needs to be set.
+     */
+    protected void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        SCIMCommonComponentHolder.setConfigurationManager(configurationManager);
+    }
+
+    /**
+     * This method is used to unset the Configuration manager Service.
+     *
+     * @param configurationManager The Configuration manager Service which needs to unset.
+     */
+    protected void unsetConfigurationManager(ConfigurationManager configurationManager) {
+
+        SCIMCommonComponentHolder.setConfigurationManager(null);
     }
 
     @Deactivate

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/SCIMCommonComponentHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.scim2.common.internal;
 
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
@@ -45,6 +46,7 @@ public class SCIMCommonComponentHolder {
     private static OrganizationManager organizationManager;
     private static IdpManager idpManager;
     private static IdentityEventService identityEventService;
+    private static ConfigurationManager configurationManager;
     private static final List<SCIMUserStoreErrorResolver> scimUserStoreErrorResolvers = new ArrayList<>();
 
     /**
@@ -224,5 +226,25 @@ public class SCIMCommonComponentHolder {
     public static void setIdentityEventService(IdentityEventService identityEventService) {
 
         SCIMCommonComponentHolder.identityEventService = identityEventService;
+    }
+
+    /**
+     * Get Configuration Manager.
+     *
+     * @return ConfigurationManager.
+     */
+    public static ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
+
+    /**
+     * Set Configuration manager.
+     *
+     * @param configurationManager Configuration Manager.
+     */
+    public static void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        SCIMCommonComponentHolder.configurationManager = configurationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -114,6 +114,8 @@ public class SCIMCommonConstants {
             "SCIM2.RemoveDuplicateUsersInUsersResponse";
     public static final String SCIM2_COMPLEX_MULTI_ATTRIBUTE_FILTERING_ENABLED =
             "SCIM2MultiAttributeFiltering.UsePagination";
+    public static final String CONSIDER_SERVER_WIDE_MAX_LIMIT_ENABLED=
+            "SCIM2.ConsiderServerWideUserEndpointMaxLimit";
 
     public static final String URL_SEPERATOR = "/";
     public static final String TENANT_URL_SEPERATOR = "/t/";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -966,4 +966,24 @@ public class SCIMCommonUtils {
             throw new CharonException("Error occurred while checking the organization state.", e);
         }
     }
+
+    /**
+     * Validate the count query parameter.
+     *
+     * @param count Requested item count.
+     * @return Validated count parameter.
+     */
+    public static int validateCountParameter(Integer count) {
+
+        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (count > maximumItemsPerPage) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Given limit exceeds the maximum limit. Therefore the limit is set to %s.",
+                        maximumItemsPerPage));
+            }
+            return maximumItemsPerPage;
+        }
+
+        return count;
+    }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -986,4 +986,20 @@ public class SCIMCommonUtils {
 
         return count;
     }
+
+    /**
+     * Read the SCIM User Endpoint Consider Server Wide config and returns it.
+     *
+     * @return If SCIM User Endpoint Consider Server Wise Config is enabled.
+     */
+    public static boolean isConsiderServerWideUserEndpointMaxLimitEnabled() {
+
+        String considerServerWideUserEndpointMaxLimitProperty =
+                IdentityUtil.getProperty(SCIMCommonConstants.CONSIDER_SERVER_WIDE_MAX_LIMIT_ENABLED);
+
+        if (StringUtils.isBlank(considerServerWideUserEndpointMaxLimitProperty)) {
+            return true;
+        }
+        return Boolean.parseBoolean(considerServerWideUserEndpointMaxLimitProperty);
+    }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
 
 public class SCIMCommonUtilsTest {
 
@@ -267,4 +269,26 @@ public class SCIMCommonUtilsTest {
         };
     }
 
+    @DataProvider
+    public Object[][] getServerWideUserEndpointMaxLimitEnabledData() {
+        return new Object[][]{
+                {"", true},
+                {null, true},
+                {"true", true},
+                {"false", false},
+        };
+    }
+
+    @Test(dataProvider = "getServerWideUserEndpointMaxLimitEnabledData")
+    public void testIsConsiderServerWideUserEndpointMaxLimitEnabled(Object value, boolean isExpectedResultTrue) {
+
+        identityUtil.when(() -> IdentityUtil.getProperty(SCIMCommonConstants.CONSIDER_SERVER_WIDE_MAX_LIMIT_ENABLED))
+                .thenReturn(value);
+        if (isExpectedResultTrue) {
+            assertTrue(SCIMCommonUtils.isConsiderServerWideUserEndpointMaxLimitEnabled());
+        } else {
+            assertFalse(SCIMCommonUtils.isConsiderServerWideUserEndpointMaxLimitEnabled());
+        }
+
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
                 <version>${identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
@@ -285,7 +290,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.16</carbon.kernel.version>
-        <identity.framework.version>7.0.112</identity.framework.version>
+        <identity.framework.version>7.3.59</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.16</carbon.kernel.version>
-        <identity.framework.version>7.3.59</identity.framework.version>
+        <identity.framework.version>7.5.69</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.16</carbon.kernel.version>
-        <identity.framework.version>7.5.69</identity.framework.version>
+        <identity.framework.version>7.0.112</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
### Purpose
- $subject
- Read the tenant wise configuration to set the hard limit for scm2/Users/.search API response

### Merge after
- https://github.com/wso2/carbon-identity-framework/pull/5839
 