### PR TITLE
Remove powermock usage

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -173,12 +173,14 @@
             <artifactId>testng</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-testng</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolverTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolverTest.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.apache.http.HttpStatus;
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreException;
@@ -31,7 +30,7 @@ import static org.testng.Assert.assertNull;
 /**
  * Contains the unit test cases for DefaultSCIMUserStoreErrorResolver.
  */
-public class DefaultSCIMUserStoreErrorResolverTest extends PowerMockTestCase {
+public class DefaultSCIMUserStoreErrorResolverTest {
 
     @Test
     public void testGetOrder() {

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
@@ -19,8 +19,8 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -33,17 +33,16 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Contains the unit test cases for IdentityResourceURLBuilder.
  */
-@PrepareForTest({IdentityTenantUtil.class, ServiceURLBuilder.class})
-public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
+public class IdentityResourceURLBuilderTest {
 
     private static final Map<String, String> DUMMY_ENDPOINT_URI_MAP = new HashMap<String, String>() {{
         put("Users", "https://localhost:9444/scim2/Users");
@@ -56,14 +55,17 @@ public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
     @Mock
     ServiceURL mockServiceUrl;
 
+    private MockedStatic<ServiceURLBuilder> serviceURLBuilder;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+
     @BeforeMethod
     public void setUpMethod() {
 
         initMocks(this);
-        mockStatic(ServiceURLBuilder.class);
-        when(ServiceURLBuilder.create()).thenReturn(mockServiceURLBuilder);
+        serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+        serviceURLBuilder.when(() -> ServiceURLBuilder.create()).thenReturn(mockServiceURLBuilder);
         when(mockServiceURLBuilder.addPath(anyString())).thenReturn(mockServiceURLBuilder);
-        mockStatic(IdentityTenantUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
     }
 
     @DataProvider(name = "dataProviderForBuild")
@@ -82,7 +84,7 @@ public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
     public void testBuild(boolean isTenantQualifiedUrlsEnabled, String url, String resource, boolean throwError,
                           String expected) throws NotFoundException, URLBuilderException {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
         when(mockServiceURLBuilder.build()).thenAnswer(invocationOnMock -> {
             if (throwError) {
                 throw new URLBuilderException("Protocol of service URL is not available.");
@@ -109,7 +111,7 @@ public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
     public void testBuildThrowingNotFoundException(boolean isTenantQualifiedUrlsEnabled, String resource)
             throws URLBuilderException, NotFoundException {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
         when(mockServiceURLBuilder.build()).thenThrow(
                 new URLBuilderException("Protocol of service URL is not available."));
         IdentityResourceURLBuilder identityResourceURLBuilder = new IdentityResourceURLBuilder();

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
@@ -19,13 +19,11 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.testng.annotations.Listeners;
+import org.mockito.testng.MockitoTestNGListener;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
@@ -44,19 +42,18 @@ import org.wso2.charon3.core.extensions.UserManager;
 
 import java.nio.file.Paths;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
 
 /**
  * Contains the unit test cases for IdentitySCIMManager.
  */
-@PrepareForTest({SCIMCommonUtils.class, PrivilegedCarbonContext.class, SCIMCommonComponentHolder.class,CharonConfiguration.class})
-@PowerMockIgnore({"javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
-public class IdentitySCIMManagerTest extends PowerMockTestCase {
+@Listeners(MockitoTestNGListener.class)
+public class IdentitySCIMManagerTest {
 
     @Mock
     RealmService realmService;
@@ -76,14 +73,17 @@ public class IdentitySCIMManagerTest extends PowerMockTestCase {
     private SCIMConfigProcessor scimConfigProcessor;
     private IdentitySCIMManager identitySCIMManager;
 
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
+    private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
+
     @BeforeMethod
     public void setUp() throws Exception {
 
-        mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonUtils.getSCIMUserURL()).thenReturn("http://scimUserUrl:9443");
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMUserURL()).thenReturn("http://scimUserUrl:9443");
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
 
         scimConfigProcessor = SCIMConfigProcessor.getInstance();
         String filePath = Paths
@@ -91,7 +91,7 @@ public class IdentitySCIMManagerTest extends PowerMockTestCase {
         scimConfigProcessor.buildConfigFromFile(filePath);
         identitySCIMManager = IdentitySCIMManager.getInstance();
 
-        mockStatic(SCIMCommonComponentHolder.class);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
 
         when(realmService.getTenantManager()).thenReturn(mockedTenantManager);
         when(mockedTenantManager.getTenantId(anyString())).thenReturn(-1234);
@@ -100,12 +100,6 @@ public class IdentitySCIMManagerTest extends PowerMockTestCase {
         when(mockedUserRealm.getClaimManager()).thenReturn(mockedClaimManager);
         when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
         CommonTestUtils.initPrivilegedCarbonContext();
-    }
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
@@ -19,13 +19,12 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
@@ -43,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
@@ -50,8 +50,7 @@ import static org.testng.Assert.assertEquals;
 /**
  * Contains the unit test cases for SCIMRoleManagerV2.
  */
-@PrepareForTest({IdentityUtil.class})
-public class SCIMRoleManagerV2Test extends PowerMockTestCase {
+public class SCIMRoleManagerV2Test {
 
     private static final String SAMPLE_TENANT_DOMAIN = "carbon.super";
     private static final String SAMPLE_VALID_ROLE_ID = "595f5508-f286-446a-86c4-5071e07b98fc";
@@ -64,6 +63,8 @@ public class SCIMRoleManagerV2Test extends PowerMockTestCase {
 
     private SCIMRoleManagerV2 scimRoleManagerV2;
 
+    private MockedStatic<IdentityUtil> identityUtil;
+
     @BeforeClass
     public void setUpClass() {
 
@@ -73,7 +74,7 @@ public class SCIMRoleManagerV2Test extends PowerMockTestCase {
     @BeforeMethod
     public void setUpMethod() {
 
-        PowerMockito.mockStatic(IdentityUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
         scimRoleManagerV2 = new SCIMRoleManagerV2(roleManagementService, SAMPLE_TENANT_DOMAIN);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -19,12 +19,9 @@
 package org.wso2.carbon.identity.scim2.common.listener;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
@@ -49,22 +46,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-@PrepareForTest({UserCoreUtil.class, SCIMGroupHandler.class, SCIMCommonUtils.class, IdentityUtil.class,
-        IdentityTenantUtil.class})
-public class SCIMUserOperationListenerTest extends PowerMockTestCase {
+
+public class SCIMUserOperationListenerTest {
 
     private final String CARBON_SUPER = "carbon.super";
     private String userName = "testUser";
@@ -93,22 +81,21 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
     @Mock
     GroupDAO groupDAO;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<IdentityUtil> identityUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
         scimUserOperationListener = spy(new SCIMUserOperationListener());
-        mockStatic(UserCoreUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-        mockStatic(IdentityTenantUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
         SCIMCommonComponentHolder.setClaimManagementService(claimMetadataManagementService);
         when(userStoreManager.getTenantId()).thenReturn(-1234);
-        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(CARBON_SUPER);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(CARBON_SUPER);
     }
 
     @DataProvider(name = "testGetExecutionOrderIdData")
@@ -234,8 +221,8 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         when(scimUserOperationListener.isEnable()).thenReturn(isEnabled);
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
 
-        mockStatic(IdentityUtil.class);
-        when(IdentityUtil.getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE)).thenReturn("false");
+        identityUtil = mockStatic(IdentityUtil.class);
+        identityUtil.when(() -> IdentityUtil.getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE)).thenReturn("false");
 
         assertTrue(scimUserOperationListener.
                 doPreSetUserClaimValuesWithID(userId, claims, profile, userStoreManager));
@@ -426,7 +413,7 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
 
     @Test(dataProvider = "testSCIMAttributesData")
     public void testGetSCIMAttributes(Map<String, String> claimsMap) throws Exception {
-        mockStatic(SCIMCommonUtils.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, "http://wso2.org/claims/userid");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, "http://wso2.org/claims/created");
@@ -435,13 +422,13 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         scimToLocalClaimsMap.put(SCIMConstants.UserSchemaConstants.USER_NAME_URI, "http://wso2.org/claims/username");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI,
                 "http://wso2.org/claims/resourceType");
-        when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
         assertNotNull(scimUserOperationListener.getSCIMAttributes(userName, claimsMap));
     }
 
     @Test(dataProvider = "testSCIMAttributesData")
     public void testPopulateSCIMAttributes(Map<String, String> claimsMap) throws Exception {
-        mockStatic(SCIMCommonUtils.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, "http://wso2.org/claims/userid");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, "http://wso2.org/claims/created");
@@ -450,16 +437,15 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         scimToLocalClaimsMap.put(SCIMConstants.UserSchemaConstants.USER_NAME_URI, "http://wso2.org/claims/username");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI,
                 "http://wso2.org/claims/resourceType");
-        when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
         assertNotNull(scimUserOperationListener.populateSCIMAttributes(userName, claimsMap));
     }
 
     private void mockTestEnvironment(boolean isEnabled, boolean isSCIMEnabled, String domainName) throws Exception {
         when(scimUserOperationListener.isEnable()).thenReturn(isEnabled);
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(groupDAO);
-        when(UserCoreUtil.getDomainName((RealmConfiguration) anyObject())).thenReturn(domainName);
-        when(UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn("testRoleNameWithDomain");
-        when(SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn("testRoleNameWithDomain");
+        userCoreUtil.when(() -> UserCoreUtil.getDomainName((RealmConfiguration) any())).thenReturn(domainName);
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn("testRoleNameWithDomain");
+        scimCommonUtils.when(() ->SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn("testRoleNameWithDomain");
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
@@ -20,8 +20,7 @@ package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -37,16 +36,9 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.Map;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.*;
 
-@PrepareForTest({SCIMCommonComponentHolder.class, ClaimsMgtUtil.class, IdentityTenantUtil.class, UserCoreUtil.class,
-        IdentityUtil.class, SCIMCommonUtils.class, AdminAttributeUtil.class})
-public class AdminAttributeUtilTest extends PowerMockTestCase {
+public class AdminAttributeUtilTest {
 
     @Mock
     RealmService realmService;
@@ -58,6 +50,11 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
     UserStoreManager userStoreManager;
 
     AdminAttributeUtil adminAttributeUtil;
+
+    private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
+    private MockedStatic<ClaimsMgtUtil> claimsMgtUtil;
+
+private MockedStatic<IdentityTenantUtil> identityTenantUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -76,15 +73,15 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
     public void testUpdateAdminUser(boolean validateSCIMID) throws Exception {
         String adminUsername = "admin";
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenReturn(true);
-        when(ClaimsMgtUtil.getAdminUserNameFromTenantId(eq(realmService), anyInt())).thenReturn(adminUsername);
-        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
+        claimsMgtUtil.when(() -> ClaimsMgtUtil.getAdminUserNameFromTenantId(eq(realmService), anyInt())).thenReturn(adminUsername);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(userStoreManager.getUserClaimValue(anyString(), anyString(), anyString())).thenReturn("");
 
         ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
@@ -94,10 +91,10 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
 
     @Test(expectedExceptions = UserStoreException.class)
     public void testUpdateAdminUser1() throws Exception {
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenThrow(new UserStoreException());

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTestForGroup.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTestForGroup.java
@@ -20,8 +20,7 @@ package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -38,18 +37,12 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
 import static org.testng.Assert.assertEquals;
 
-@PrepareForTest({SCIMCommonComponentHolder.class, ClaimsMgtUtil.class, IdentityTenantUtil.class, UserCoreUtil.class,
-        IdentityUtil.class, SCIMCommonUtils.class, AdminAttributeUtil.class})
-public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
+public class AdminAttributeUtilTestForGroup {
 
     @Mock
     RealmService realmService;
@@ -67,6 +60,13 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
     SCIMGroupHandler scimGroupHandler;
 
     AdminAttributeUtil adminAttributeUtil;
+
+    private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
+    private MockedStatic<ClaimsMgtUtil> claimsMgtUtil;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<IdentityUtil> identityUtil;
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -93,13 +93,13 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
     public void testUpdateAdminGroup(String domainName) throws Exception {
         String roleNameWithDomain = "TESTDOMAIN/admin";
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(UserCoreUtil.class);
-        mockStatic(IdentityUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenReturn(true);
@@ -107,11 +107,10 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
         when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
         when(userStoreManager.isRoleAndGroupSeparationEnabled()).thenReturn(true);
         when(realmConfiguration.getAdminRoleName()).thenReturn("admin");
-        when(UserCoreUtil.getDomainName((RealmConfiguration) anyObject())).thenReturn(domainName);
-        when(IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
-        when(UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
-        when(SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
-        whenNew(SCIMGroupHandler.class).withAnyArguments().thenReturn(scimGroupHandler);
+        userCoreUtil.when(() -> UserCoreUtil.getDomainName((RealmConfiguration) any())).thenReturn(domainName);
+        identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
 
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
@@ -125,24 +124,23 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
     public void testUpdateAdminGroup1() throws Exception {
         String roleNameWithDomain = "TESTDOMAIN/admin";
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(UserCoreUtil.class);
-        mockStatic(IdentityUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenReturn(true);
         when(userStoreManager.getTenantId()).thenReturn(1);
         when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
         when(realmConfiguration.getAdminRoleName()).thenReturn("admin");
-        when(UserCoreUtil.getDomainName((RealmConfiguration) anyObject())).thenReturn("testDomain");
-        when(IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
-        when(UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
-        when(SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
-        whenNew(SCIMGroupHandler.class).withAnyArguments().thenReturn(scimGroupHandler);
+        userCoreUtil.when(() -> UserCoreUtil.getDomainName((RealmConfiguration) any())).thenReturn("testDomain");
+        identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
         when(scimGroupHandler.isGroupExisting(anyString())).thenThrow(new IdentitySCIMException("testException"));
 
         adminAttributeUtil.updateAdminGroup(1);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -19,14 +19,10 @@
 package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.CarbonBaseConstants;
@@ -41,16 +37,13 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
-
-@PrepareForTest({IdentityUtil.class, UserCoreUtil.class, IdentityTenantUtil.class, ServiceURLBuilder.class})
-@PowerMockIgnore({"javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
-public class SCIMCommonUtilsTest extends PowerMockTestCase {
+public class SCIMCommonUtilsTest {
 
     private static final String ID = "8a439cf6-3c6b-47d2-94bf-34d072495af3";
     private static final String SCIM_URL = "https://localhost:9443/scim2";
@@ -71,28 +64,28 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Mock
     DefaultServiceURLBuilder defaultServiceURLBuilder1;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<ServiceURLBuilder> serviceURLBuilder;
+    private MockedStatic<IdentityUtil> identityUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
         initMocks(this);
-        mockStatic(IdentityUtil.class);
-        mockStatic(UserCoreUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(ServiceURLBuilder.class);
-        when(IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(SCIM_URL);
-        when(IdentityUtil.getPrimaryDomainName()).thenReturn(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
-        when(ServiceURLBuilder.create()).thenReturn(defaultServiceURLBuilder);
+        identityUtil = mockStatic(IdentityUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+        identityUtil.when(() -> IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(SCIM_URL);
+        identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
+        serviceURLBuilder.when(() -> ServiceURLBuilder.create()).thenReturn(defaultServiceURLBuilder);
         when(defaultServiceURLBuilder.build()).thenReturn(serviceURL);
         when(defaultServiceURLBuilder.addPath(SCIMCommonConstants.SCIM2_ENDPOINT)).thenReturn
                 (defaultServiceURLBuilder1);
         when(defaultServiceURLBuilder1.build()).thenReturn(serviceURL1);
         when(serviceURL1.getAbsolutePublicURL()).thenReturn("https://localhost:9443/scim2");
         when(serviceURL.getAbsolutePublicURL()).thenReturn("https://localhost:9443");
-        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn("carbon.super");
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomainFromContext()).thenReturn("carbon.super");
     }
 
     @AfterMethod
@@ -103,7 +96,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMUserURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimUserURL = SCIMCommonUtils.getSCIMUserURL(ID);
         assertEquals(scimUserURL, scimUserLocation + "/" + ID);
     }
@@ -111,7 +104,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMUserURLForNullId(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimUserURL = SCIMCommonUtils.getSCIMUserURL(null);
         assertEquals(scimUserURL, null);
     }
@@ -119,7 +112,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMGroupURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimGroupURL = SCIMCommonUtils.getSCIMGroupURL(ID);
         assertEquals(scimGroupURL, scimGroupLocation + "/" + ID);
     }
@@ -127,7 +120,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMGroupURLForNullId(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimGroupURL = SCIMCommonUtils.getSCIMGroupURL(null);
         assertEquals(scimGroupURL, null);
     }
@@ -135,7 +128,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMServiceProviderConfigURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimServiceProviderConfigURL = SCIMCommonUtils.getSCIMServiceProviderConfigURL(ID);
         assertEquals(scimServiceProviderConfigURL, scimServiceProviderConfig);
     }
@@ -143,7 +136,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMUserURL1(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimUsersURL = SCIMCommonUtils.getSCIMUserURL();
         assertEquals(scimUsersURL, scimUserLocation);
     }
@@ -151,7 +144,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMGroupURL1(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimGroupsURL = SCIMCommonUtils.getSCIMGroupURL();
         assertEquals(scimGroupsURL, scimGroupLocation);
     }
@@ -159,7 +152,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMServiceProviderConfigURL1(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimServiceProviderConfigURL = SCIMCommonUtils.getSCIMServiceProviderConfigURL();
         assertEquals(scimServiceProviderConfigURL, scimServiceProviderConfig);
     }
@@ -167,7 +160,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMResourceTypeURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimResourceTypeURL = SCIMCommonUtils.getSCIMResourceTypeURL();
         assertEquals(scimResourceTypeURL, scimResourceType);
     }
@@ -249,7 +242,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     public void testGetGlobalConsumerId() throws Exception {
         String tenantDomain = "testTenantDomain";
         CommonTestUtils.initPrivilegedCarbonContext(tenantDomain);
-        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
         assertEquals(SCIMCommonUtils.getGlobalConsumerId(), tenantDomain);
     }
 
@@ -257,7 +250,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     public void testGetUserConsumerId() throws Exception {
         String userConsumerId = "testConsumerId";
         CommonTestUtils.initPrivilegedCarbonContext();
-        when(UserCoreUtil.addTenantDomainToEntry(anyString(), anyString())).thenReturn(userConsumerId);
+        userCoreUtil.when(() -> UserCoreUtil.addTenantDomainToEntry(anyString(), anyString())).thenReturn(userConsumerId);
 
         assertEquals(SCIMCommonUtils.getUserConsumerId(), userConsumerId);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -230,15 +230,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-testng</artifactId>
+                <version>${mockito-testng.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -328,12 +322,12 @@
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
-        <testng.version>6.9.10</testng.version>
+        <testng.version>7.10.1</testng.version>
         <jacoco.version>0.8.4</jacoco.version>
         <!-- Mockito Versions are Updated  -->
-        <mockito.version>2.23.4</mockito.version>
-        <powermock.version>2.0.2</powermock.version>
-        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <mockito.version>5.3.1</mockito.version>
+        <mockito-testng.version>0.5.2</mockito-testng.version>
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Remove the usage of the powermock library from the test cases.
- Powermock library is becoming dead and it is so far has not supported Java 21. With our effort to provide support Identity Server product compiling with Java 21, this becomes a blocker.