### PR TITLE
Remove powermock usage from unit tests

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -173,12 +173,14 @@
             <artifactId>testng</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-testng</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.scim2.common.group;
 
-import org.apache.commons.lang.StringUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -75,7 +74,6 @@ public class SCIMGroupHandlerTest {
     private MockedStatic<SCIMCommonUtils> scimCommonUtils;
     private MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil;
     private MockedStatic<IdentityTenantUtil> identityTenantUtil;
-    private MockedStatic<StringUtils> stringUtils;
 
     @BeforeMethod
     public void setUp() {
@@ -84,7 +82,6 @@ public class SCIMGroupHandlerTest {
         scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
-        stringUtils = mockStatic(StringUtils.class);
     }
 
     @AfterMethod
@@ -92,7 +89,6 @@ public class SCIMGroupHandlerTest {
         scimCommonUtils.close();
         identityDatabaseUtil.close();
         identityTenantUtil.close();
-        stringUtils.close();
     }
 
     @Test
@@ -181,13 +177,12 @@ public class SCIMGroupHandlerTest {
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
         when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
-        when(StringUtils.isNotEmpty(nullable(String.class))).thenReturn(true);
         when(SCIMCommonUtils.getPrimaryFreeGroupName(nullable(String.class))).thenReturn("directors");
         when(mockedPreparedStatement.executeQuery()).thenReturn(resultSet);
         when(mockedGroupDAO.getGroupNameById(1, "5")).thenReturn("directors");
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+        when(resultSet.getString(1)).thenReturn("roleName");
         assertEquals(new SCIMGroupHandler(1).getGroupName("5"), "directors", "asserting for existance");
-
-        when(StringUtils.isNotEmpty(nullable(String.class))).thenReturn(false);
         assertNull(new SCIMGroupHandler(1).getGroupName("NON_EXISITNG_GROUP_NAME"), "asserting for non existance");
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -21,22 +21,26 @@ package org.wso2.carbon.identity.scim2.common.group;
 import org.apache.commons.lang.StringUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.charon3.core.objects.Group;
+import org.wso2.charon3.core.utils.AttributeUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,25 +48,21 @@ import java.util.Calendar;
 import java.util.Set;
 import java.util.HashSet;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
-@PrepareForTest({IdentityDatabaseUtil.class, StringUtils.class, SCIMCommonUtils.class, SCIMGroupHandler.class,
-                 IdentityTenantUtil.class})
-@PowerMockIgnore("java.sql.*")
-public class SCIMGroupHandlerTest extends PowerMockTestCase {
+public class SCIMGroupHandlerTest {
 
     @Mock
     private GroupDAO mockedGroupDAO;
@@ -73,16 +73,32 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
     @Mock
     private PreparedStatement mockedPreparedStatement;
 
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
+    private MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<StringUtils> stringUtils;
+
     @BeforeMethod
     public void setUp() throws Exception {
         initMocks(this);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        stringUtils = mockStatic(StringUtils.class);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        scimCommonUtils.close();
+        identityDatabaseUtil.close();
+        identityTenantUtil.close();
+        stringUtils.close();
+        System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
     @Test
     public void testAddMandatoryAttributes() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(SCIMCommonUtils.class);
-        mockStatic(IdentityDatabaseUtil.class);
 
         when(SCIMCommonUtils.getSCIMGroupURL(anyString())).thenReturn("ID");
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
@@ -110,8 +126,6 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
     @Test
     public void testCreateSCIMAttributes() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(SCIMCommonUtils.class);
 
         Group group = new Group();
         Date date = new Date();
@@ -132,8 +146,6 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
 
     @Test
     public void testCreateSCIMAttributesExceptions() throws Exception {
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(SCIMCommonUtils.class);
         ResultSet resultSet = mock(ResultSet.class);
 
         Group group = new Group();
@@ -147,22 +159,26 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
         when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
         when(mockedPreparedStatement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.isExistingGroup(SCIMCommonUtils.getGroupNameWithDomain("ALREADY_EXISTANT_GROUP_NAME"), 1)).thenReturn(false);
 
-        SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-        scimGroupHandler.createSCIMAttributes(group);
-        verify(mockedGroupDAO).addSCIMGroupAttributes(anyInt(), argumentCaptor.capture(), anyMap());
-        assertEquals("testDisplayName", argumentCaptor.getValue());
+        try (MockedConstruction<GroupDAO> mockedConstruction = Mockito.mockConstruction(
+                GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(SCIMCommonUtils.getGroupNameWithDomain("ALREADY_EXISTANT_GROUP_NAME"), 1))
+                            .thenReturn(false);
+                })) {
+
+            SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
+            ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+            scimGroupHandler.createSCIMAttributes(group);
+            verify(mockedConstruction.constructed().get(0))
+                    .addSCIMGroupAttributes(anyInt(), argumentCaptor.capture(), anyMap());
+            assertEquals("testDisplayName", argumentCaptor.getValue());
+        }
     }
 
     @Test
     public void testGetGroupName() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(StringUtils.class);
-        mockStatic(SCIMCommonUtils.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
         when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
@@ -185,9 +201,6 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
     public void testGetGroupWithAttributes() throws Exception {
         Group group = new Group();
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(SCIMCommonUtils.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(StringUtils.class);
 
         Date date = new Date(2017, 10, 10, 10, 10, 10);
         Map<String, String> attributes = new HashMap<String, String>();
@@ -208,9 +221,6 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
     public void testGetGroupWithAttributesSecondScenario() throws Exception {
         Group group = new Group();
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(SCIMCommonUtils.class);
 
         Date today = Calendar.getInstance().getTime();
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
@@ -226,18 +236,28 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
         when(resultSet.next()).thenReturn(true);
         when(mockedPreparedStatement.executeQuery()).thenReturn(resultSet);
         when(mockedGroupDAO.isExistingGroup("EXISTING_GROUP_NAME", 1)).thenReturn(true);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.getSCIMGroupAttributes(anyInt(), anyString())).thenReturn(attributes);
         when(IdentityTenantUtil.getTenantDomain(1)).thenReturn("TENANT_DOMAIN");
         when(SCIMCommonUtils.getSCIMGroupURL()).thenReturn("https://localhost:9443/t/TENANT_DOMAIN/Groups");
-        assertEquals(new SCIMGroupHandler(1).getGroupWithAttributes(group, "EXISTING_GROUP_NAME"), group);
+
+        Instant mockInstant = Instant.now();
+        try (MockedStatic<AttributeUtil> mockedAttributeUtil = Mockito.mockStatic(AttributeUtil.class)) {
+            mockedAttributeUtil.when(() -> AttributeUtil.parseDateTime(anyString())).thenReturn(mockInstant);
+
+            try (MockedConstruction<GroupDAO> mockedConstruction = Mockito.mockConstruction(
+                    GroupDAO.class,
+                    (mock, context) -> {
+                        when(mock.getSCIMGroupAttributes(anyInt(), anyString())).thenReturn(attributes);
+                    })) {
+
+                SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
+                assertEquals(scimGroupHandler.getGroupWithAttributes(group, "EXISTING_GROUP_NAME"), group);
+            }
+        }
     }
 
     @Test
     public void testIsGroupExisting() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(SCIMCommonUtils.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
         when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
@@ -254,61 +274,66 @@ public class SCIMGroupHandlerTest extends PowerMockTestCase {
     @Test
     public void testDeleteGroupAttributes() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
         when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);
         when(mockedPreparedStatement.executeQuery()).thenReturn(resultSet);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(mockedGroupDAO);
         when(resultSet.next()).thenReturn(true);
-        when(mockedGroupDAO.isExistingGroup(anyString(), anyInt())).thenReturn(true);
 
-        SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-        scimGroupHandler.deleteGroupAttributes("GROUP_DELETABLE");
-        verify(mockedGroupDAO).removeSCIMGroup(anyInt(), argumentCaptor.capture());
-        assertEquals(argumentCaptor.getValue(),"GROUP_DELETABLE");
+        try (MockedConstruction<GroupDAO> mockedConstruction = Mockito.mockConstruction(
+                GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(anyString(), anyInt())).thenReturn(true);
+                })) {
 
+            SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
+            ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+            scimGroupHandler.deleteGroupAttributes("GROUP_DELETABLE");
+            verify(mockedConstruction.constructed().get(0)).removeSCIMGroup(anyInt(), argumentCaptor.capture());
+            assertEquals(argumentCaptor.getValue(), "GROUP_DELETABLE");
+        }
     }
 
     @Test
     public void testUpdateRoleName() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(SCIMCommonUtils.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.isExistingGroup(anyString(), anyInt())).thenReturn(true);
 
-        SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-        scimGroupHandler.updateRoleName("EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
-        verify(mockedGroupDAO).updateRoleName(anyInt(),argumentCaptor.capture(),anyString());
-        assertEquals(argumentCaptor.getValue(),"EXISTENT_ROLE_NAME");
+        try (MockedConstruction<GroupDAO> mockedConstruction = Mockito.mockConstruction(
+                GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(anyString(), anyInt())).thenReturn(true);
+                })) {
+
+            SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
+            ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+            scimGroupHandler.updateRoleName("EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
+            verify(mockedConstruction.constructed().get(0)).updateRoleName(anyInt(), argumentCaptor.capture(), anyString());
+            assertEquals(argumentCaptor.getValue(), "EXISTENT_ROLE_NAME");
+        }
     }
 
     @Test(expectedExceptions = IdentitySCIMException.class)
     public void testUpdateRoleNameNonExistent() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(SCIMCommonUtils.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(mockedGroupDAO);
-        when(mockedGroupDAO.isExistingGroup("NON_EXISTENT_ROLE_NAME", 1)).thenReturn(false);
 
-        SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
-        scimGroupHandler.updateRoleName("NON_EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
-        // This method is to test the throwing of an IdentitySCIMException, hence no assertion.
+        try (MockedConstruction<GroupDAO> mockedConstruction = Mockito.mockConstruction(
+                GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup("NON_EXISTENT_ROLE_NAME", 1)).thenReturn(false);
+                })) {
+
+            SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
+            scimGroupHandler.updateRoleName("NON_EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
+        }
     }
 
     @Test
     public void testListSCIMRoles() throws Exception {
         Set<String> groups = mock(HashSet.class);
         ResultSet resultSet = mock(ResultSet.class);
-        mockStatic(IdentityDatabaseUtil.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
         when(connection.prepareStatement(anyString())).thenReturn(mockedPreparedStatement);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,7 +27,6 @@ import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
@@ -79,7 +78,8 @@ public class SCIMGroupHandlerTest {
     private MockedStatic<StringUtils> stringUtils;
 
     @BeforeMethod
-    public void setUp() throws Exception {
+    public void setUp() {
+
         initMocks(this);
         scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
@@ -93,7 +93,6 @@ public class SCIMGroupHandlerTest {
         identityDatabaseUtil.close();
         identityTenantUtil.close();
         stringUtils.close();
-        System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
     @Test
@@ -315,7 +314,6 @@ public class SCIMGroupHandlerTest {
 
     @Test(expectedExceptions = IdentitySCIMException.class)
     public void testUpdateRoleNameNonExistent() throws Exception {
-        ResultSet resultSet = mock(ResultSet.class);
 
         when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
 
@@ -327,6 +325,7 @@ public class SCIMGroupHandlerTest {
 
             SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(1);
             scimGroupHandler.updateRoleName("NON_EXISTENT_ROLE_NAME", "NEW_ROLE_NAME");
+            // This method is to test the throwing of an IdentitySCIMException, hence no assertion.
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolverTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolverTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolverTest.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.apache.http.HttpStatus;
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreException;
@@ -31,7 +30,7 @@ import static org.testng.Assert.assertNull;
 /**
  * Contains the unit test cases for DefaultSCIMUserStoreErrorResolver.
  */
-public class DefaultSCIMUserStoreErrorResolverTest extends PowerMockTestCase {
+public class DefaultSCIMUserStoreErrorResolverTest {
 
     @Test
     public void testGetOrder() {

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.scim2.common.impl;
 import org.mockito.Mock;
 
 import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -66,6 +67,12 @@ public class IdentityResourceURLBuilderTest {
         serviceURLBuilder.when(() -> ServiceURLBuilder.create()).thenReturn(mockServiceURLBuilder);
         when(mockServiceURLBuilder.addPath(anyString())).thenReturn(mockServiceURLBuilder);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+    }
+
+    @AfterMethod
+    public void tearDownMethod() {
+        serviceURLBuilder.close();
+        identityTenantUtil.close();
     }
 
     @DataProvider(name = "dataProviderForBuild")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
@@ -19,8 +19,8 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -33,17 +33,16 @@ import org.wso2.charon3.core.exceptions.NotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Contains the unit test cases for IdentityResourceURLBuilder.
  */
-@PrepareForTest({IdentityTenantUtil.class, ServiceURLBuilder.class})
-public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
+public class IdentityResourceURLBuilderTest {
 
     private static final Map<String, String> DUMMY_ENDPOINT_URI_MAP = new HashMap<String, String>() {{
         put("Users", "https://localhost:9444/scim2/Users");
@@ -56,14 +55,17 @@ public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
     @Mock
     ServiceURL mockServiceUrl;
 
+    private MockedStatic<ServiceURLBuilder> serviceURLBuilder;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+
     @BeforeMethod
     public void setUpMethod() {
 
         initMocks(this);
-        mockStatic(ServiceURLBuilder.class);
-        when(ServiceURLBuilder.create()).thenReturn(mockServiceURLBuilder);
+        serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+        serviceURLBuilder.when(() -> ServiceURLBuilder.create()).thenReturn(mockServiceURLBuilder);
         when(mockServiceURLBuilder.addPath(anyString())).thenReturn(mockServiceURLBuilder);
-        mockStatic(IdentityTenantUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
     }
 
     @DataProvider(name = "dataProviderForBuild")
@@ -82,7 +84,7 @@ public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
     public void testBuild(boolean isTenantQualifiedUrlsEnabled, String url, String resource, boolean throwError,
                           String expected) throws NotFoundException, URLBuilderException {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
         when(mockServiceURLBuilder.build()).thenAnswer(invocationOnMock -> {
             if (throwError) {
                 throw new URLBuilderException("Protocol of service URL is not available.");
@@ -109,7 +111,7 @@ public class IdentityResourceURLBuilderTest extends PowerMockTestCase {
     public void testBuildThrowingNotFoundException(boolean isTenantQualifiedUrlsEnabled, String resource)
             throws URLBuilderException, NotFoundException {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedUrlsEnabled);
         when(mockServiceURLBuilder.build()).thenThrow(
                 new URLBuilderException("Protocol of service URL is not available."));
         IdentityResourceURLBuilder identityResourceURLBuilder = new IdentityResourceURLBuilder();

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentityResourceURLBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
@@ -19,13 +19,11 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.testng.annotations.Listeners;
+import org.mockito.testng.MockitoTestNGListener;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
@@ -44,19 +42,18 @@ import org.wso2.charon3.core.extensions.UserManager;
 
 import java.nio.file.Paths;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
 
 /**
  * Contains the unit test cases for IdentitySCIMManager.
  */
-@PrepareForTest({SCIMCommonUtils.class, PrivilegedCarbonContext.class, SCIMCommonComponentHolder.class,CharonConfiguration.class})
-@PowerMockIgnore({"javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
-public class IdentitySCIMManagerTest extends PowerMockTestCase {
+@Listeners(MockitoTestNGListener.class)
+public class IdentitySCIMManagerTest {
 
     @Mock
     RealmService realmService;
@@ -76,14 +73,17 @@ public class IdentitySCIMManagerTest extends PowerMockTestCase {
     private SCIMConfigProcessor scimConfigProcessor;
     private IdentitySCIMManager identitySCIMManager;
 
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
+    private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
+
     @BeforeMethod
     public void setUp() throws Exception {
 
-        mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonUtils.getSCIMUserURL()).thenReturn("http://scimUserUrl:9443");
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMUserURL()).thenReturn("http://scimUserUrl:9443");
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
 
         scimConfigProcessor = SCIMConfigProcessor.getInstance();
         String filePath = Paths
@@ -91,7 +91,7 @@ public class IdentitySCIMManagerTest extends PowerMockTestCase {
         scimConfigProcessor.buildConfigFromFile(filePath);
         identitySCIMManager = IdentitySCIMManager.getInstance();
 
-        mockStatic(SCIMCommonComponentHolder.class);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
 
         when(realmService.getTenantManager()).thenReturn(mockedTenantManager);
         when(mockedTenantManager.getTenantId(anyString())).thenReturn(-1234);
@@ -100,12 +100,6 @@ public class IdentitySCIMManagerTest extends PowerMockTestCase {
         when(mockedUserRealm.getClaimManager()).thenReturn(mockedClaimManager);
         when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
         CommonTestUtils.initPrivilegedCarbonContext();
-    }
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/IdentitySCIMManagerTest.java
@@ -20,23 +20,24 @@ package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.quality.Strictness;
+import org.mockito.testng.MockitoSettings;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.annotations.Listeners;
 import org.mockito.testng.MockitoTestNGListener;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMConfigProcessor;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
-import org.wso2.charon3.core.config.CharonConfiguration;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.extensions.UserManager;
 
@@ -53,6 +54,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
  * Contains the unit test cases for IdentitySCIMManager.
  */
 @Listeners(MockitoTestNGListener.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class IdentitySCIMManagerTest {
 
     @Mock
@@ -78,7 +80,6 @@ public class IdentitySCIMManagerTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-
         scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMUserURL()).thenReturn("http://scimUserUrl:9443");
 
@@ -91,8 +92,6 @@ public class IdentitySCIMManagerTest {
         scimConfigProcessor.buildConfigFromFile(filePath);
         identitySCIMManager = IdentitySCIMManager.getInstance();
 
-        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
-
         when(realmService.getTenantManager()).thenReturn(mockedTenantManager);
         when(mockedTenantManager.getTenantId(anyString())).thenReturn(-1234);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(mockedUserRealm);
@@ -100,6 +99,13 @@ public class IdentitySCIMManagerTest {
         when(mockedUserRealm.getClaimManager()).thenReturn(mockedClaimManager);
         when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
         CommonTestUtils.initPrivilegedCarbonContext();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        scimCommonComponentHolder.close();
+        scimCommonUtils.close();
+        System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
@@ -20,11 +20,12 @@ package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
@@ -76,6 +77,12 @@ public class SCIMRoleManagerV2Test {
 
         identityUtil = mockStatic(IdentityUtil.class);
         scimRoleManagerV2 = new SCIMRoleManagerV2(roleManagementService, SAMPLE_TENANT_DOMAIN);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        identityUtil.close();
+        System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
     @DataProvider(name = "scimOperations")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
@@ -82,7 +82,6 @@ public class SCIMRoleManagerV2Test {
     @AfterMethod
     public void tearDown() {
         identityUtil.close();
-        System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
     @DataProvider(name = "scimOperations")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2Test.java
@@ -19,13 +19,12 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
@@ -43,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
@@ -50,8 +50,7 @@ import static org.testng.Assert.assertEquals;
 /**
  * Contains the unit test cases for SCIMRoleManagerV2.
  */
-@PrepareForTest({IdentityUtil.class})
-public class SCIMRoleManagerV2Test extends PowerMockTestCase {
+public class SCIMRoleManagerV2Test {
 
     private static final String SAMPLE_TENANT_DOMAIN = "carbon.super";
     private static final String SAMPLE_VALID_ROLE_ID = "595f5508-f286-446a-86c4-5071e07b98fc";
@@ -64,6 +63,8 @@ public class SCIMRoleManagerV2Test extends PowerMockTestCase {
 
     private SCIMRoleManagerV2 scimRoleManagerV2;
 
+    private MockedStatic<IdentityUtil> identityUtil;
+
     @BeforeClass
     public void setUpClass() {
 
@@ -73,7 +74,7 @@ public class SCIMRoleManagerV2Test extends PowerMockTestCase {
     @BeforeMethod
     public void setUpMethod() {
 
-        PowerMockito.mockStatic(IdentityUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
         scimRoleManagerV2 = new SCIMRoleManagerV2(roleManagementService, SAMPLE_TENANT_DOMAIN);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -226,7 +226,6 @@ public class SCIMUserManagerTest {
         scimUserSchemaExtensionBuilder.close();
         claimMetadataHandler.close();
         resourceManagerUtil.close();
-        System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
     @DataProvider(name = "ClaimData")

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -110,7 +110,14 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -362,7 +369,7 @@ public class SCIMUserManagerTest {
     @Test(dataProvider = "getGroupException")
     public void testGetGroupWithExceptions(String roleName, String userStoreDomain) throws Exception {
 
-        AbstractUserStoreManager mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        AbstractUserStoreManager mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         Field field = AbstractUserStoreManager.class.getDeclaredField("userStoreManagerHolder");
         field.setAccessible(true);
         field.set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
@@ -423,7 +430,7 @@ public class SCIMUserManagerTest {
 
         mockedUserStoreManager = mock(AbstractUserStoreManager.class);
 
-        AbstractUserStoreManager mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        AbstractUserStoreManager mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         Field field = AbstractUserStoreManager.class.getDeclaredField("userStoreManagerHolder");
         field.setAccessible(true);
         field.set(mockedUserStoreManager, new HashMap<String, UserStoreManager>());
@@ -1450,7 +1457,7 @@ public class SCIMUserManagerTest {
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, USERID_LOCAL_CLAIM);
 
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
-        mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         org.wso2.carbon.user.core.common.User user = mock(org.wso2.carbon.user.core.common.User.class);
@@ -1485,7 +1492,7 @@ public class SCIMUserManagerTest {
         List<org.wso2.carbon.user.core.common.User> coreUsers = new ArrayList<>();
 
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
-        AbstractUserStoreManager mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        AbstractUserStoreManager mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getUserListWithID(anyString(), anyString(), anyString())).thenReturn(coreUsers);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
@@ -1507,7 +1514,7 @@ public class SCIMUserManagerTest {
         coreUser.setUserStoreDomain("DomainName");
 
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
-        AbstractUserStoreManager mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        AbstractUserStoreManager mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getUserWithID(anyString(), any(), anyString())).thenReturn(coreUser);
         when(mockedUserStoreManager.getSecondaryUserStoreManager("DomainName")).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(false);
@@ -1530,7 +1537,7 @@ public class SCIMUserManagerTest {
         coreUser.setUserStoreDomain("PRIMARY");
 
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
-        AbstractUserStoreManager mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        AbstractUserStoreManager mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getUserWithID(anyString(), any(), anyString())).thenReturn(coreUser);
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
@@ -1585,7 +1592,7 @@ public class SCIMUserManagerTest {
         SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
                 mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         doThrow(new NotImplementedException()).when(mockedUser).setSchemas(Mockito.any(UserManager.class));
-        mockedUser.setSchemas(Mockito.mock(UserManager.class));
+        mockedUser.setSchemas(mock(UserManager.class));
         scimUserManager.createUser(user, null);
         // This method is for testing of throwing CharonException, hence no assertion.
     }
@@ -1616,7 +1623,7 @@ public class SCIMUserManagerTest {
         when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
         when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
 
-        mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.isExistingUserWithID(anyString())).thenReturn(true);
         when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(true);
         when(mockedUserStoreManager.getUserList(anyString(), anyString(), nullable(String.class))).thenReturn(existingUserList);
@@ -1650,7 +1657,7 @@ public class SCIMUserManagerTest {
         when(SCIMCommonUtils.convertSCIMtoLocalDialect(anyMap())).thenCallRealMethod();
         when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimMappings);
 
-        mockedUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        mockedUserStoreManager = mock(AbstractUserStoreManager.class);
         when(mockedUserStoreManager.getUserList(anyString(), anyString(), anyString())).thenReturn(null);
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString()))
                 .thenReturn(secondaryUserStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -19,12 +19,9 @@
 package org.wso2.carbon.identity.scim2.common.listener;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
@@ -49,22 +46,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-@PrepareForTest({UserCoreUtil.class, SCIMGroupHandler.class, SCIMCommonUtils.class, IdentityUtil.class,
-        IdentityTenantUtil.class})
-public class SCIMUserOperationListenerTest extends PowerMockTestCase {
+
+public class SCIMUserOperationListenerTest {
 
     private final String CARBON_SUPER = "carbon.super";
     private String userName = "testUser";
@@ -93,22 +81,21 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
     @Mock
     GroupDAO groupDAO;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<IdentityUtil> identityUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
         scimUserOperationListener = spy(new SCIMUserOperationListener());
-        mockStatic(UserCoreUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-        mockStatic(IdentityTenantUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
         SCIMCommonComponentHolder.setClaimManagementService(claimMetadataManagementService);
         when(userStoreManager.getTenantId()).thenReturn(-1234);
-        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(CARBON_SUPER);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(CARBON_SUPER);
     }
 
     @DataProvider(name = "testGetExecutionOrderIdData")
@@ -234,8 +221,8 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         when(scimUserOperationListener.isEnable()).thenReturn(isEnabled);
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
 
-        mockStatic(IdentityUtil.class);
-        when(IdentityUtil.getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE)).thenReturn("false");
+        identityUtil = mockStatic(IdentityUtil.class);
+        identityUtil.when(() -> IdentityUtil.getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE)).thenReturn("false");
 
         assertTrue(scimUserOperationListener.
                 doPreSetUserClaimValuesWithID(userId, claims, profile, userStoreManager));
@@ -426,7 +413,7 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
 
     @Test(dataProvider = "testSCIMAttributesData")
     public void testGetSCIMAttributes(Map<String, String> claimsMap) throws Exception {
-        mockStatic(SCIMCommonUtils.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, "http://wso2.org/claims/userid");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, "http://wso2.org/claims/created");
@@ -435,13 +422,13 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         scimToLocalClaimsMap.put(SCIMConstants.UserSchemaConstants.USER_NAME_URI, "http://wso2.org/claims/username");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI,
                 "http://wso2.org/claims/resourceType");
-        when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
         assertNotNull(scimUserOperationListener.getSCIMAttributes(userName, claimsMap));
     }
 
     @Test(dataProvider = "testSCIMAttributesData")
     public void testPopulateSCIMAttributes(Map<String, String> claimsMap) throws Exception {
-        mockStatic(SCIMCommonUtils.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, "http://wso2.org/claims/userid");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, "http://wso2.org/claims/created");
@@ -450,16 +437,15 @@ public class SCIMUserOperationListenerTest extends PowerMockTestCase {
         scimToLocalClaimsMap.put(SCIMConstants.UserSchemaConstants.USER_NAME_URI, "http://wso2.org/claims/username");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI,
                 "http://wso2.org/claims/resourceType");
-        when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
         assertNotNull(scimUserOperationListener.populateSCIMAttributes(userName, claimsMap));
     }
 
     private void mockTestEnvironment(boolean isEnabled, boolean isSCIMEnabled, String domainName) throws Exception {
         when(scimUserOperationListener.isEnable()).thenReturn(isEnabled);
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
-        whenNew(GroupDAO.class).withNoArguments().thenReturn(groupDAO);
-        when(UserCoreUtil.getDomainName((RealmConfiguration) anyObject())).thenReturn(domainName);
-        when(UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn("testRoleNameWithDomain");
-        when(SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn("testRoleNameWithDomain");
+        userCoreUtil.when(() -> UserCoreUtil.getDomainName((RealmConfiguration) any())).thenReturn(domainName);
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn("testRoleNameWithDomain");
+        scimCommonUtils.when(() ->SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn("testRoleNameWithDomain");
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -48,7 +48,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -19,7 +19,10 @@
 package org.wso2.carbon.identity.scim2.common.listener;
 
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +33,6 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
-import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.carbon.user.api.Permission;
@@ -47,6 +49,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -88,14 +91,23 @@ public class SCIMUserOperationListenerTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-
+        initMocks(this);
         scimUserOperationListener = spy(new SCIMUserOperationListener());
         userCoreUtil = mockStatic(UserCoreUtil.class);
         scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
         SCIMCommonComponentHolder.setClaimManagementService(claimMetadataManagementService);
         when(userStoreManager.getTenantId()).thenReturn(-1234);
         identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(CARBON_SUPER);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        userCoreUtil.close();
+        scimCommonUtils.close();
+        identityTenantUtil.close();
+        identityUtil.close();
     }
 
     @DataProvider(name = "testGetExecutionOrderIdData")
@@ -221,7 +233,6 @@ public class SCIMUserOperationListenerTest {
         when(scimUserOperationListener.isEnable()).thenReturn(isEnabled);
         when(userStoreManager.isSCIMEnabled()).thenReturn(isSCIMEnabled);
 
-        identityUtil = mockStatic(IdentityUtil.class);
         identityUtil.when(() -> IdentityUtil.getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE)).thenReturn("false");
 
         assertTrue(scimUserOperationListener.
@@ -294,19 +305,13 @@ public class SCIMUserOperationListenerTest {
     @Test(expectedExceptions = UserStoreException.class)
     public void testDoPostAddRole2() throws Exception {
         mockTestEnvironment(true, true, "testDomain");
-        when(groupDAO.isExistingGroup(anyString(), anyInt())).thenThrow(new IdentitySCIMException
-                ("IdentitySCIMException"));
-
-        scimUserOperationListener.doPostAddRoleWithID(roleName, userList, permissions, userStoreManager);
-    }
-
-    @Test(dataProvider = "testDoPostAddRoleData")
-    public void testDoPreDeleteRole(boolean isEnabled, boolean isSCIMEnabled, boolean isGroupExisting,
-                                    String domainName) throws Exception {
-        mockTestEnvironment(isEnabled, isSCIMEnabled, domainName);
-        when(groupDAO.isExistingGroup(anyString(), anyInt())).thenReturn(isGroupExisting);
-
-        assertTrue(scimUserOperationListener.doPreDeleteRole(roleName, userStoreManager));
+        try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(anyString(), anyInt()))
+                            .thenThrow(new IdentitySCIMException("IdentitySCIMException"));
+                })) {
+            scimUserOperationListener.doPostAddRoleWithID(roleName, userList, permissions, userStoreManager);
+        }
     }
 
     @Test(expectedExceptions = UserStoreException.class)
@@ -320,10 +325,13 @@ public class SCIMUserOperationListenerTest {
     @Test(expectedExceptions = UserStoreException.class)
     public void testDoPreDeleteRole2() throws Exception {
         mockTestEnvironment(true, true, "testDomain");
-        when(groupDAO.isExistingGroup(anyString(), anyInt())).thenThrow(new IdentitySCIMException
-                ("IdentitySCIMException"));
-
-        scimUserOperationListener.doPreDeleteRole(roleName, userStoreManager);
+        try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(nullable(String.class), anyInt()))
+                            .thenThrow(new IdentitySCIMException("IdentitySCIMException"));
+                })) {
+            scimUserOperationListener.doPreDeleteRole(roleName, userStoreManager);
+        }
     }
 
     @Test
@@ -350,9 +358,12 @@ public class SCIMUserOperationListenerTest {
     @Test(dataProvider = "testDoPostUpdateRoleNameData")
     public void testDoPostUpdateRoleName(boolean isEnabled, boolean isSCIMEnabled, String domainName) throws Exception {
         mockTestEnvironment(isEnabled, isSCIMEnabled, domainName);
-        when(groupDAO.isExistingGroup(anyString(), anyInt())).thenReturn(true);
-
-        assertTrue(scimUserOperationListener.doPostUpdateRoleName(roleName, roleName, userStoreManager));
+        try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(anyString(), anyInt())).thenReturn(true);
+                })) {
+            assertTrue(scimUserOperationListener.doPostUpdateRoleName(roleName, roleName, userStoreManager));
+        }
     }
 
     @Test(expectedExceptions = UserStoreException.class)
@@ -366,10 +377,13 @@ public class SCIMUserOperationListenerTest {
     @Test(expectedExceptions = UserStoreException.class)
     public void testDoPostUpdateRoleName2() throws Exception {
         mockTestEnvironment(true, true, "testDomain");
-        when(groupDAO.isExistingGroup(anyString(), anyInt()))
-                .thenThrow(new IdentitySCIMException("IdentitySCIMException"));
-
-        scimUserOperationListener.doPostUpdateRoleName(roleName, roleName, userStoreManager);
+        try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(anyString(), anyInt()))
+                            .thenThrow(new IdentitySCIMException("IdentitySCIMException"));
+                })) {
+            scimUserOperationListener.doPostUpdateRoleName(roleName, roleName, userStoreManager);
+        }
     }
 
     @Test
@@ -413,7 +427,6 @@ public class SCIMUserOperationListenerTest {
 
     @Test(dataProvider = "testSCIMAttributesData")
     public void testGetSCIMAttributes(Map<String, String> claimsMap) throws Exception {
-        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, "http://wso2.org/claims/userid");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, "http://wso2.org/claims/created");
@@ -428,7 +441,6 @@ public class SCIMUserOperationListenerTest {
 
     @Test(dataProvider = "testSCIMAttributesData")
     public void testPopulateSCIMAttributes(Map<String, String> claimsMap) throws Exception {
-        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, "http://wso2.org/claims/userid");
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.CREATED_URI, "http://wso2.org/claims/created");

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/test/utils/CommonTestUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/test/utils/CommonTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
@@ -21,22 +21,22 @@ package org.wso2.carbon.identity.scim2.common.utils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.stratos.common.util.ClaimsMgtUtil;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.Map;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AdminAttributeUtilTest {
 
@@ -53,12 +53,22 @@ public class AdminAttributeUtilTest {
 
     private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
     private MockedStatic<ClaimsMgtUtil> claimsMgtUtil;
-
-private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
+        initMocks(this);
         adminAttributeUtil = new AdminAttributeUtil();
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        scimCommonComponentHolder.close();
+        claimsMgtUtil.close();
+        identityTenantUtil.close();
     }
 
     @DataProvider(name = "testUpdateAdminUserData")
@@ -73,9 +83,6 @@ private MockedStatic<IdentityTenantUtil> identityTenantUtil;
     public void testUpdateAdminUser(boolean validateSCIMID) throws Exception {
         String adminUsername = "admin";
 
-        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
-        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
-        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
         scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
@@ -91,9 +98,6 @@ private MockedStatic<IdentityTenantUtil> identityTenantUtil;
 
     @Test(expectedExceptions = UserStoreException.class)
     public void testUpdateAdminUser1() throws Exception {
-        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
-        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
-        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
         scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
@@ -20,8 +20,7 @@ package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -37,16 +36,9 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.Map;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.*;
 
-@PrepareForTest({SCIMCommonComponentHolder.class, ClaimsMgtUtil.class, IdentityTenantUtil.class, UserCoreUtil.class,
-        IdentityUtil.class, SCIMCommonUtils.class, AdminAttributeUtil.class})
-public class AdminAttributeUtilTest extends PowerMockTestCase {
+public class AdminAttributeUtilTest {
 
     @Mock
     RealmService realmService;
@@ -58,6 +50,11 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
     UserStoreManager userStoreManager;
 
     AdminAttributeUtil adminAttributeUtil;
+
+    private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
+    private MockedStatic<ClaimsMgtUtil> claimsMgtUtil;
+
+private MockedStatic<IdentityTenantUtil> identityTenantUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -76,15 +73,15 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
     public void testUpdateAdminUser(boolean validateSCIMID) throws Exception {
         String adminUsername = "admin";
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenReturn(true);
-        when(ClaimsMgtUtil.getAdminUserNameFromTenantId(eq(realmService), anyInt())).thenReturn(adminUsername);
-        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
+        claimsMgtUtil.when(() -> ClaimsMgtUtil.getAdminUserNameFromTenantId(eq(realmService), anyInt())).thenReturn(adminUsername);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(userStoreManager.getUserClaimValue(anyString(), anyString(), anyString())).thenReturn("");
 
         ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
@@ -94,10 +91,10 @@ public class AdminAttributeUtilTest extends PowerMockTestCase {
 
     @Test(expectedExceptions = UserStoreException.class)
     public void testUpdateAdminUser1() throws Exception {
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenThrow(new UserStoreException());

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTest.java
@@ -35,7 +35,12 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AdminAttributeUtilTest {

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTestForGroup.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTestForGroup.java
@@ -20,8 +20,7 @@ package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -38,18 +37,12 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
 import static org.testng.Assert.assertEquals;
 
-@PrepareForTest({SCIMCommonComponentHolder.class, ClaimsMgtUtil.class, IdentityTenantUtil.class, UserCoreUtil.class,
-        IdentityUtil.class, SCIMCommonUtils.class, AdminAttributeUtil.class})
-public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
+public class AdminAttributeUtilTestForGroup {
 
     @Mock
     RealmService realmService;
@@ -67,6 +60,13 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
     SCIMGroupHandler scimGroupHandler;
 
     AdminAttributeUtil adminAttributeUtil;
+
+    private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
+    private MockedStatic<ClaimsMgtUtil> claimsMgtUtil;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<IdentityUtil> identityUtil;
+    private MockedStatic<SCIMCommonUtils> scimCommonUtils;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -93,13 +93,13 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
     public void testUpdateAdminGroup(String domainName) throws Exception {
         String roleNameWithDomain = "TESTDOMAIN/admin";
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(UserCoreUtil.class);
-        mockStatic(IdentityUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenReturn(true);
@@ -107,11 +107,10 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
         when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
         when(userStoreManager.isRoleAndGroupSeparationEnabled()).thenReturn(true);
         when(realmConfiguration.getAdminRoleName()).thenReturn("admin");
-        when(UserCoreUtil.getDomainName((RealmConfiguration) anyObject())).thenReturn(domainName);
-        when(IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
-        when(UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
-        when(SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
-        whenNew(SCIMGroupHandler.class).withAnyArguments().thenReturn(scimGroupHandler);
+        userCoreUtil.when(() -> UserCoreUtil.getDomainName((RealmConfiguration) any())).thenReturn(domainName);
+        identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
 
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
@@ -125,24 +124,23 @@ public class AdminAttributeUtilTestForGroup extends PowerMockTestCase {
     public void testUpdateAdminGroup1() throws Exception {
         String roleNameWithDomain = "TESTDOMAIN/admin";
 
-        mockStatic(SCIMCommonComponentHolder.class);
-        mockStatic(ClaimsMgtUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(UserCoreUtil.class);
-        mockStatic(IdentityUtil.class);
-        mockStatic(SCIMCommonUtils.class);
-        when(SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
+        scimCommonComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
+        claimsMgtUtil = mockStatic(ClaimsMgtUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        identityUtil = mockStatic(IdentityUtil.class);
+        scimCommonUtils = mockStatic(SCIMCommonUtils.class);
+        scimCommonComponentHolder.when(() -> SCIMCommonComponentHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.isSCIMEnabled()).thenReturn(true);
         when(userStoreManager.getTenantId()).thenReturn(1);
         when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
         when(realmConfiguration.getAdminRoleName()).thenReturn("admin");
-        when(UserCoreUtil.getDomainName((RealmConfiguration) anyObject())).thenReturn("testDomain");
-        when(IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
-        when(UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
-        when(SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
-        whenNew(SCIMGroupHandler.class).withAnyArguments().thenReturn(scimGroupHandler);
+        userCoreUtil.when(() -> UserCoreUtil.getDomainName((RealmConfiguration) any())).thenReturn("testDomain");
+        identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn("TESTDOMAIN");
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenReturn(roleNameWithDomain);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getGroupNameWithDomain(anyString())).thenReturn(roleNameWithDomain);
         when(scimGroupHandler.isGroupExisting(anyString())).thenThrow(new IdentitySCIMException("testException"));
 
         adminAttributeUtil.updateAdminGroup(1);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTestForGroup.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AdminAttributeUtilTestForGroup.java
@@ -39,9 +39,14 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
-import static org.mockito.Mockito.*;
 import static org.mockito.ArgumentMatchers.any;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapperTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AttributeMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AuthenticationSchemaTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/AuthenticationSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -89,7 +89,11 @@ public class SCIMCommonUtilsTest {
     }
 
     @AfterMethod
-    public void tearDown() throws Exception {
+    public void tearDown() {
+        identityUtil.close();
+        userCoreUtil.close();
+        identityTenantUtil.close();
+        serviceURLBuilder.close();
         System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -19,14 +19,10 @@
 package org.wso2.carbon.identity.scim2.common.utils;
 
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.CarbonBaseConstants;
@@ -41,16 +37,13 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
-
-@PrepareForTest({IdentityUtil.class, UserCoreUtil.class, IdentityTenantUtil.class, ServiceURLBuilder.class})
-@PowerMockIgnore({"javax.xml.*","org.w3c.dom.*","org.xml.sax.*"})
-public class SCIMCommonUtilsTest extends PowerMockTestCase {
+public class SCIMCommonUtilsTest {
 
     private static final String ID = "8a439cf6-3c6b-47d2-94bf-34d072495af3";
     private static final String SCIM_URL = "https://localhost:9443/scim2";
@@ -71,28 +64,28 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Mock
     DefaultServiceURLBuilder defaultServiceURLBuilder1;
 
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
-    }
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<ServiceURLBuilder> serviceURLBuilder;
+    private MockedStatic<IdentityUtil> identityUtil;
 
     @BeforeMethod
     public void setUp() throws Exception {
         initMocks(this);
-        mockStatic(IdentityUtil.class);
-        mockStatic(UserCoreUtil.class);
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(ServiceURLBuilder.class);
-        when(IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(SCIM_URL);
-        when(IdentityUtil.getPrimaryDomainName()).thenReturn(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
-        when(ServiceURLBuilder.create()).thenReturn(defaultServiceURLBuilder);
+        identityUtil = mockStatic(IdentityUtil.class);
+        userCoreUtil = mockStatic(UserCoreUtil.class);
+        identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+        identityUtil.when(() -> IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(SCIM_URL);
+        identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
+        serviceURLBuilder.when(() -> ServiceURLBuilder.create()).thenReturn(defaultServiceURLBuilder);
         when(defaultServiceURLBuilder.build()).thenReturn(serviceURL);
         when(defaultServiceURLBuilder.addPath(SCIMCommonConstants.SCIM2_ENDPOINT)).thenReturn
                 (defaultServiceURLBuilder1);
         when(defaultServiceURLBuilder1.build()).thenReturn(serviceURL1);
         when(serviceURL1.getAbsolutePublicURL()).thenReturn("https://localhost:9443/scim2");
         when(serviceURL.getAbsolutePublicURL()).thenReturn("https://localhost:9443");
-        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn("carbon.super");
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomainFromContext()).thenReturn("carbon.super");
     }
 
     @AfterMethod
@@ -103,7 +96,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMUserURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimUserURL = SCIMCommonUtils.getSCIMUserURL(ID);
         assertEquals(scimUserURL, scimUserLocation + "/" + ID);
     }
@@ -111,7 +104,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMUserURLForNullId(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimUserURL = SCIMCommonUtils.getSCIMUserURL(null);
         assertEquals(scimUserURL, null);
     }
@@ -119,7 +112,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMGroupURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimGroupURL = SCIMCommonUtils.getSCIMGroupURL(ID);
         assertEquals(scimGroupURL, scimGroupLocation + "/" + ID);
     }
@@ -127,7 +120,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMGroupURLForNullId(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimGroupURL = SCIMCommonUtils.getSCIMGroupURL(null);
         assertEquals(scimGroupURL, null);
     }
@@ -135,7 +128,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMServiceProviderConfigURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimServiceProviderConfigURL = SCIMCommonUtils.getSCIMServiceProviderConfigURL(ID);
         assertEquals(scimServiceProviderConfigURL, scimServiceProviderConfig);
     }
@@ -143,7 +136,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMUserURL1(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimUsersURL = SCIMCommonUtils.getSCIMUserURL();
         assertEquals(scimUsersURL, scimUserLocation);
     }
@@ -151,7 +144,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMGroupURL1(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimGroupsURL = SCIMCommonUtils.getSCIMGroupURL();
         assertEquals(scimGroupsURL, scimGroupLocation);
     }
@@ -159,7 +152,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMServiceProviderConfigURL1(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimServiceProviderConfigURL = SCIMCommonUtils.getSCIMServiceProviderConfigURL();
         assertEquals(scimServiceProviderConfigURL, scimServiceProviderConfig);
     }
@@ -167,7 +160,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     @Test(dataProvider = "tenantURLQualifyData")
     public void testGetSCIMResourceTypeURL(boolean isTenantQualifyURLEnabled) throws Exception {
 
-        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
+        identityTenantUtil.when(() -> IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifyURLEnabled);
         String scimResourceTypeURL = SCIMCommonUtils.getSCIMResourceTypeURL();
         assertEquals(scimResourceTypeURL, scimResourceType);
     }
@@ -249,7 +242,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     public void testGetGlobalConsumerId() throws Exception {
         String tenantDomain = "testTenantDomain";
         CommonTestUtils.initPrivilegedCarbonContext(tenantDomain);
-        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
         assertEquals(SCIMCommonUtils.getGlobalConsumerId(), tenantDomain);
     }
 
@@ -257,7 +250,7 @@ public class SCIMCommonUtilsTest extends PowerMockTestCase {
     public void testGetUserConsumerId() throws Exception {
         String userConsumerId = "testConsumerId";
         CommonTestUtils.initPrivilegedCarbonContext();
-        when(UserCoreUtil.addTenantDomainToEntry(anyString(), anyString())).thenReturn(userConsumerId);
+        userCoreUtil.when(() -> UserCoreUtil.addTenantDomainToEntry(anyString(), anyString())).thenReturn(userConsumerId);
 
         assertEquals(SCIMCommonUtils.getUserConsumerId(), userConsumerId);
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMConfigProcessorTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMConfigProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/pom.xml
+++ b/pom.xml
@@ -230,15 +230,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-testng</artifactId>
+                <version>${mockito-testng.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -328,12 +322,12 @@
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
 
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
-        <testng.version>6.9.10</testng.version>
+        <testng.version>7.10.1</testng.version>
         <jacoco.version>0.8.4</jacoco.version>
         <!-- Mockito Versions are Updated  -->
-        <mockito.version>2.23.4</mockito.version>
-        <powermock.version>2.0.2</powermock.version>
-        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <mockito.version>5.3.1</mockito.version>
+        <mockito-testng.version>0.5.2</mockito-testng.version>
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Remove the usage of the powermock library from the test cases.
- Powermock library is becoming dead and it is so far has not supported Java 21. With our effort to provide support Identity Server product compiling with Java 21, this becomes a blocker.