### PR TITLE
Enable role management in organization level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.24</carbon.kernel.version>
-        <identity.framework.version>7.5.109</identity.framework.version>
+        <identity.framework.version>7.7.15</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
## Proposed changes in this PR
- $subject
- Allow to create, update and delete the roles in the sub organization level.
- Restricting the shared role permission update and delete shared roles in the sub organization level.
- Related to https://github.com/wso2/product-is/issues/21208

## Dependant tasks
- Update the framework version after merging the following framework PRs.
   - https://github.com/wso2/carbon-identity-framework/pull/6002
   - https://github.com/wso2/carbon-identity-framework/pull/6010