### PR TITLE
Add ExcludedUserStoreDomains Property to schema

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -174,7 +174,7 @@ public class SCIMUserManager implements UserManager {
     private static final String DISPLAY_NAME_PROPERTY = "displayName";
     private static final String DISPLAY_ORDER_PROPERTY = "displayOrder";
     private static final String REGULAR_EXPRESSION_PROPERTY = "regEx";
-    private static final String EXCLUDED_USER_STORE_DOMAINS_PROPERTY = "excludedUserStoreDomains";
+    private static final String EXCLUDED_USER_STORES_PROPERTY = "excludedUserStores";
     private static final String LOCATION_CLAIM = "http://wso2.org/claims/location";
     private static final String LAST_MODIFIED_CLAIM = "http://wso2.org/claims/modified";
     private static final String RESOURCE_TYPE_CLAIM = "http://wso2.org/claims/resourceType";
@@ -5952,9 +5952,9 @@ public class SCIMUserManager implements UserManager {
                 attribute.addAttributeProperty(ClaimConstants.MAX_LENGTH,
                         mappedLocalClaim.getClaimProperty(ClaimConstants.MAX_LENGTH));
             }
-            if (mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORE_DOMAINS_PROPERTY) != null) {
-                attribute.addAttributeProperty(EXCLUDED_USER_STORE_DOMAINS_PROPERTY,
-                        mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORE_DOMAINS_PROPERTY));
+            if (mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY) != null) {
+                attribute.addAttributeProperty(EXCLUDED_USER_STORES_PROPERTY,
+                        mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY));
             }
         }
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -174,6 +174,7 @@ public class SCIMUserManager implements UserManager {
     private static final String DISPLAY_NAME_PROPERTY = "displayName";
     private static final String DISPLAY_ORDER_PROPERTY = "displayOrder";
     private static final String REGULAR_EXPRESSION_PROPERTY = "regEx";
+    private static final String EXCLUDED_USER_STORE_DOMAINS_PROPERTY = "excludedUserStoreDomains";
     private static final String LOCATION_CLAIM = "http://wso2.org/claims/location";
     private static final String LAST_MODIFIED_CLAIM = "http://wso2.org/claims/modified";
     private static final String RESOURCE_TYPE_CLAIM = "http://wso2.org/claims/resourceType";
@@ -5950,6 +5951,10 @@ public class SCIMUserManager implements UserManager {
             if (mappedLocalClaim.getClaimProperty(ClaimConstants.MAX_LENGTH) != null) {
                 attribute.addAttributeProperty(ClaimConstants.MAX_LENGTH,
                         mappedLocalClaim.getClaimProperty(ClaimConstants.MAX_LENGTH));
+            }
+            if (mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORE_DOMAINS_PROPERTY) != null) {
+                attribute.addAttributeProperty(EXCLUDED_USER_STORE_DOMAINS_PROPERTY,
+                        mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORE_DOMAINS_PROPERTY));
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.16</carbon.kernel.version>
-        <identity.framework.version>7.0.112</identity.framework.version>
+        <identity.framework.version>7.5.109</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
Add ExcludedUserStoreDomains claim property to schemas.

### Relevant Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/22601

### Relevant PRs
- https://github.com/wso2/carbon-identity-framework/pull/6096
- https://github.com/wso2/carbon-kernel/pull/4110
- https://github.com/wso2-extensions/identity-governance/pull/872