### PR TITLE
Fix ADD operation replacing permissions of the role

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -75,6 +75,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -953,8 +954,11 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
                                 permissionOperation, permissionObject, permissionListOfRole);
                     }
                 }
-                prepareReplacedPermissionLists(permissionListOfRole, addedPermissions, deletedPermissions,
-                        replacedPermissions);
+                if (SCIMConstants.OperationalConstants.REPLACE.equals(
+                        permissionOperation.getOperation().toLowerCase(Locale.ENGLISH))) {
+                    prepareReplacedPermissionLists(permissionListOfRole, addedPermissions, deletedPermissions,
+                            replacedPermissions);
+                }
             }
             if (isNotEmpty(addedPermissions) || isNotEmpty(deletedPermissions)) {
                 doUpdatePermissions(roleId, addedPermissions, deletedPermissions);


### PR DESCRIPTION
### Problem
When performing an ADD operation on a role's permissions via the SCIM2 API, the existing permissions are incorrectly replaced instead of appending the new permissions.

### Root Cause
The issue was caused by the `prepareReplacedPermissionLists` method being executed for every patch operation. This method clears the existing permissions, which is appropriate for the REPLACE operation but not for ADD or REMOVE.

### Solution
- The fix ensures that `prepareReplacedPermissionLists` is only executed for the REPLACE operation, preventing unintended clearing of permissions during ADD or REMOVE operations.

- Added unit tests scenarios to cover the permission update operations

### Issue

https://github.com/wso2/product-is/issues/21628