### PR TITLE
Improve domain qualified username handling when filter users by group with PRIMARY domain

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1481,9 +1481,11 @@ public class SCIMUserManager implements UserManager {
             // Check that total user count matching the client query needs to be calculated.
             if (isJDBCUSerStore(domainName) || isAllConfiguredUserStoresJDBC()
                     || SCIMCommonUtils.isConsiderTotalRecordsForTotalResultOfLDAPEnabled()) {
-                int maxLimit = getMaxLimit(domainName);
+                int maxLimit;
                 if (!SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
                     maxLimit = Integer.MAX_VALUE;
+                } else {
+                    maxLimit = getMaxLimit(domainName);
                 }
                 // Get total users based on the filter query without depending on pagination params.
                 if (SCIMCommonUtils.isGroupBasedUserFilteringImprovementsEnabled() &&

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -1791,7 +1791,10 @@ public class SCIMUserManager implements UserManager {
         If there is a domain and if the domain separator is not found in the attribute value, append the domain
         with the domain separator in front of the new attribute value.
         */
-        attributeValue = UserCoreUtil.addDomainToName(((ExpressionNode) node).getValue(), domainName);
+        if (StringUtils.isNotEmpty(domainName) && StringUtils
+                .containsNone(attributeValue, CarbonConstants.DOMAIN_SEPARATOR)) {
+            attributeValue = domainName.toUpperCase() + CarbonConstants.DOMAIN_SEPARATOR + attributeValue;
+        }
 
         try {
             List<String> roleNames = getRoleNames(attributeName, filterOperation, attributeValue);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -629,8 +629,13 @@ public class SCIMUserManagerTest {
 
         org.wso2.carbon.user.core.common.User testUser1 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
                 .toString(), "testUser1", "testUser1");
+        testUser1.setUserStoreDomain("PRIMARY");
         List<org.wso2.carbon.user.core.common.User> filteredUsers = new ArrayList<>();
         filteredUsers.add(testUser1);
+
+        scimCommonUtils.when(() -> SCIMCommonUtils.convertLocalToSCIMDialect(anyMap(), anyMap())).thenReturn(new HashMap<String, String>() {{
+            put(SCIMConstants.CommonSchemaConstants.ID_URI, "1f70378a-69bb-49cf-aa51-a0493c09110c");
+        }});
 
         when(mockedUserStoreManager.getSecondaryUserStoreManager(domain)).thenReturn(mockedJDBCUserStoreManager);
         when(mockedJDBCUserStoreManager.isSCIMEnabled()).thenReturn(true);
@@ -641,8 +646,10 @@ public class SCIMUserManagerTest {
         when(mockedUserStoreManager.getUserListOfGroupWithID(anyString())).thenReturn(filteredUsers);
 
         UniqueIDUserClaimSearchEntry uniqueIDUserClaimSearchEntry = new UniqueIDUserClaimSearchEntry();
-        when(mockedUserStoreManager.getUsersClaimValuesWithID(any(), any(), nullable(String.class))).thenReturn(
-                Collections.singletonList(uniqueIDUserClaimSearchEntry));
+        List<UniqueIDUserClaimSearchEntry> uniqueIDUserClaimSearchEntries = new ArrayList<>();
+        uniqueIDUserClaimSearchEntries.add(uniqueIDUserClaimSearchEntry);
+        when(mockedUserStoreManager.getUsersClaimValuesWithID(any(), any(), nullable(String.class)))
+                .thenReturn(uniqueIDUserClaimSearchEntries);
 
         UsersGetResponse result = scimUserManager.listUsersWithGET(node, 1, null, null, null, domain, new HashMap<>());
         assertEquals(result.getUsers().size(), filteredUsers.size());


### PR DESCRIPTION
The PRIMARY domain has to be appended when filtering the groups by name. If domain is not specified, all the groups from all the user stores will be listed where the filtering condition is matched.

Here is a similar place[1] where same logic is followed, where domain is appended to the group(role) name instead of using the `UserCoreUtil.addDomainToName` method which skip adding "PRIMARY" domain for the groups. 

[1] https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/blob/master/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java#L2091~L2098

### Related Issues
- https://github.com/wso2/product-is/issues/22189