### PR TITLE
Return SharedProfileValueResolvingMethod property value for each claim in /scim2/Schemas API 

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -179,6 +179,7 @@ public class SCIMUserManager implements UserManager {
     private static final String DISPLAY_ORDER_PROPERTY = "displayOrder";
     private static final String REGULAR_EXPRESSION_PROPERTY = "regEx";
     private static final String EXCLUDED_USER_STORES_PROPERTY = "excludedUserStores";
+    private static final String SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY = "sharedProfileValueResolvingMethod";
     private static final String LOCATION_CLAIM = "http://wso2.org/claims/location";
     private static final String LAST_MODIFIED_CLAIM = "http://wso2.org/claims/modified";
     private static final String RESOURCE_TYPE_CLAIM = "http://wso2.org/claims/resourceType";
@@ -6030,6 +6031,10 @@ public class SCIMUserManager implements UserManager {
             if (mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY) != null) {
                 attribute.addAttributeProperty(EXCLUDED_USER_STORES_PROPERTY,
                         mappedLocalClaim.getClaimProperty(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY));
+            }
+            if (mappedLocalClaim.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD) != null) {
+                attribute.addAttributeProperty(SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY,
+                        mappedLocalClaim.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD));
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.24</carbon.kernel.version>
-        <identity.framework.version>7.7.40</identity.framework.version>
+        <identity.framework.version>7.7.85</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
$Subject when there is a value for SharedProfileValueResolvingMethod claim property/ resolved by the system.

eg:

```
[
    {
        "name": "Core",
        "description": "Core",
        "attributes": [],
        "id": "urn:ietf:params:scim:schemas:core:2.0"
    },
    {
        "name": "User",
        "description": "User Account",
        "attributes": [
            {
                "uniqueness": "NONE",
                "displayName": "URL",
                "name": "profileUrl",
                "displayOrder": "10",
                "description": "URL",
                "mutability": "READ_WRITE",
                "type": "STRING",
                "multiValued": false,
                "caseExact": false,
                "returned": "DEFAULT",
                "required": false,
                "sharedProfileValueResolvingMethod": "FromOrigin"
            },
            {
                "displayName": "Email",
                "displayOrder": "6",
                "description": "Email Address",
                "type": "COMPLEX",
                "required": true,
                "subAttributes": [],
                "regEx": "^([a-zA-Z0-9!#$'\\+=^_\\.{|}~\\-&])+\\@(([a-zA-Z0-9\\-])+\\.)+([a-zA-Z0-9]{2,10})+$",
                "uniqueness": "NONE",
                "name": "emails",
                "mutability": "READ_WRITE",
                "multiValued": true,
                "caseExact": false,
                "returned": "DEFAULT",
                "sharedProfileValueResolvingMethod": "FromOrigin"
            },
     ... 
```

Part of https://github.com/wso2/product-is/issues/22126