### PR TITLE
Add attribute profiles properties to schema response.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6082,8 +6082,8 @@ public class SCIMUserManager implements UserManager {
         String profileName = propertyKeyParts[1];
         String profileProperty = propertyKeyParts[2];
 
-        JSONObject profilesObject = attribute.getAttributeJsonProperty(ATTRIBUTE_PROFILES_PROPERTY) != null
-                ? attribute.getAttributeJsonProperty(ATTRIBUTE_PROFILES_PROPERTY)
+        JSONObject profilesObject = attribute.getAttributeJSONProperty(ATTRIBUTE_PROFILES_PROPERTY) != null
+                ? attribute.getAttributeJSONProperty(ATTRIBUTE_PROFILES_PROPERTY)
                 : new JSONObject();
 
         if (!profilesObject.has(profileName)) {
@@ -6107,7 +6107,7 @@ public class SCIMUserManager implements UserManager {
                 break;
         }
 
-        attribute.addAttributeJsonProperty(ATTRIBUTE_PROFILES_PROPERTY, profilesObject);
+        attribute.addAttributeJSONProperty(ATTRIBUTE_PROFILES_PROPERTY, profilesObject);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6082,7 +6082,10 @@ public class SCIMUserManager implements UserManager {
         String profileName = propertyKeyParts[1];
         String profileProperty = propertyKeyParts[2];
 
-        JSONObject profilesObject = new JSONObject();
+        JSONObject profilesObject = attribute.getAttributeJsonProperty(ATTRIBUTE_PROFILES_PROPERTY) != null
+                ? attribute.getAttributeJsonProperty(ATTRIBUTE_PROFILES_PROPERTY)
+                : new JSONObject();
+
         if (!profilesObject.has(profileName)) {
             profilesObject.put(profileName, new JSONObject());
         }
@@ -6096,11 +6099,9 @@ public class SCIMUserManager implements UserManager {
                 profileObject.put(SCIMConfigConstants.REQUIRED, Boolean.parseBoolean(propertyValue));
                 break;
             case ClaimConstants.READ_ONLY_PROPERTY:
-                if (Boolean.parseBoolean(propertyValue)) {
-                    profileObject.put(SCIMConfigConstants.MUTABILITY, SCIMDefinitions.Mutability.READ_ONLY);
-                } else {
-                    profileObject.put(SCIMConfigConstants.MUTABILITY, SCIMDefinitions.Mutability.READ_WRITE);
-                }
+                profileObject.put(SCIMConfigConstants.MUTABILITY, Boolean.parseBoolean(propertyValue)
+                        ? SCIMDefinitions.Mutability.READ_ONLY
+                        : SCIMDefinitions.Mutability.READ_WRITE);
                 break;
             default:
                 break;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6055,6 +6055,10 @@ public class SCIMUserManager implements UserManager {
                 attribute.addAttributeProperty(SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY,
                         mappedLocalClaim.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD));
             }
+            if (mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY) != null) {
+                attribute.addAttributeProperty(SUPPORTED_BY_DEFAULT_PROPERTY,
+                        mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY));
+            }
 
             // Add attribute profile properties.
             for (Map.Entry<String, String> entry: mappedLocalClaim.getClaimProperties().entrySet()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpStatus;
+import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
@@ -179,6 +180,8 @@ public class SCIMUserManager implements UserManager {
     private static final String DISPLAY_ORDER_PROPERTY = "displayOrder";
     private static final String REGULAR_EXPRESSION_PROPERTY = "regEx";
     private static final String EXCLUDED_USER_STORES_PROPERTY = "excludedUserStores";
+    private static final String SUPPORTED_BY_DEFAULT_PROPERTY = "supportedByDefault";
+    private static final String ATTRIBUTE_PROFILES_PROPERTY = "profiles";
     private static final String SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY = "sharedProfileValueResolvingMethod";
     private static final String LOCATION_CLAIM = "http://wso2.org/claims/location";
     private static final String LAST_MODIFIED_CLAIM = "http://wso2.org/claims/modified";
@@ -5835,8 +5838,19 @@ public class SCIMUserManager implements UserManager {
 
     private boolean isSupportedByDefault(LocalClaim mappedLocalClaim) {
 
-        String supportedByDefault = mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY);
-        return Boolean.parseBoolean(supportedByDefault);
+        String globalSupportedByDefault =
+                mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY);
+
+        boolean profileSpecificSupportedByDefault = mappedLocalClaim.getClaimProperties().entrySet().stream()
+                .filter(entry -> StringUtils.startsWith(entry.getKey(), ClaimConstants.PROFILES_CLAIM_PROPERTY_PREFIX))
+                .anyMatch(entry -> {
+                    String[] profilePropertyKeyArray = entry.getKey().split("\\.");
+                    return profilePropertyKeyArray.length == 3 &&
+                            StringUtils.endsWith(entry.getKey(), ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY) &&
+                            Boolean.parseBoolean(entry.getValue());
+                });
+
+        return Boolean.parseBoolean(globalSupportedByDefault) || profileSpecificSupportedByDefault;
     }
 
     private boolean isUsernameClaim(ExternalClaim scimClaim) {
@@ -6041,7 +6055,58 @@ public class SCIMUserManager implements UserManager {
                 attribute.addAttributeProperty(SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY,
                         mappedLocalClaim.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD));
             }
+
+            // Add attribute profile properties.
+            for (Map.Entry<String, String> entry: mappedLocalClaim.getClaimProperties().entrySet()) {
+                if (StringUtils.startsWith(entry.getKey(), ClaimConstants.PROFILES_CLAIM_PROPERTY_PREFIX)) {
+                    addAttributeProfilesProperty(attribute, entry.getKey(), entry.getValue());
+                }
+            }
         }
+    }
+
+    /**
+     * Helper method to insert attribute profile-related properties as a JSON object to attribute.
+     *
+     * @param attribute     Attribute object.
+     * @param propertyKey   Key of the property.
+     * @param propertyValue Value of the property.
+     */
+    private void addAttributeProfilesProperty(AbstractAttribute attribute, String propertyKey, String propertyValue) {
+
+        // Example key format: "Profiles.{profileName}.{propertyName}" - Profiles.console.SupportedByDefault.
+        String[] propertyKeyParts = propertyKey.split("\\.");
+        if (propertyKeyParts.length != 3) {
+            return;
+        }
+        String profileName = propertyKeyParts[1];
+        String profileProperty = propertyKeyParts[2];
+
+        JSONObject profilesObject = new JSONObject();
+        if (!profilesObject.has(profileName)) {
+            profilesObject.put(profileName, new JSONObject());
+        }
+
+        JSONObject profileObject = profilesObject.getJSONObject(profileName);
+        switch(profileProperty) {
+            case ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY:
+                profileObject.put(SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.parseBoolean(propertyValue));
+                break;
+            case ClaimConstants.REQUIRED_PROPERTY:
+                profileObject.put(SCIMConfigConstants.REQUIRED, Boolean.parseBoolean(propertyValue));
+                break;
+            case ClaimConstants.READ_ONLY_PROPERTY:
+                if (Boolean.parseBoolean(propertyValue)) {
+                    profileObject.put(SCIMConfigConstants.MUTABILITY, SCIMDefinitions.Mutability.READ_ONLY);
+                } else {
+                    profileObject.put(SCIMConfigConstants.MUTABILITY, SCIMDefinitions.Mutability.READ_WRITE);
+                }
+                break;
+            default:
+                break;
+        }
+
+        attribute.addAttributeJsonProperty(ATTRIBUTE_PROFILES_PROPERTY, profilesObject);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONObject;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -50,6 +51,7 @@ import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.common.PaginatedUserResponse;
 import org.wso2.carbon.user.core.model.UniqueIDUserClaimSearchEntry;
+import org.wso2.charon3.core.config.SCIMConfigConstants;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.extensions.UserManager;
 import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
@@ -150,6 +152,8 @@ public class SCIMUserManagerTest {
     private static final String USER_SCHEMA_ADDRESS_WORK= "urn:ietf:params:scim:schemas:core:2.0:User:addresses.work";
     private static final String MAX_LIMIT_RESOURCE_NAME = "user-response-limit";
     private static final String SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY = "sharedProfileValueResolvingMethod";
+    private static final String ATTRIBUTE_PROFILES_PROPERTY = "profiles";
+    private static final String SUPPORTED_BY_DEFAULT_PROPERTY = "supportedByDefault";
 
     @Mock
     private AbstractUserStoreManager mockedUserStoreManager;
@@ -1284,6 +1288,89 @@ public class SCIMUserManagerTest {
         // Third item is userName claim.
         assertEquals(list.get(2).getName(), "userName");
         assertFalse(list.get(2).getAttributeProperties().containsKey(SHARED_PROFILE_VALUE_RESOLVING_METHOD_PROPERTY));
+    }
+
+    @Test
+    public void testGetUserSchemaWithAttributeProfiles() throws Exception {
+
+        String claimDialectUri = SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT;
+
+        String consoleProfile = "console";
+        String endUserProfile = "endUser";
+
+        Map<String, String> claimProperties1 = new HashMap<String, String>() {{
+            put("SupportedByDefault", "true");
+            put("ReadOnly", "true");
+            put("Required", "false");
+            put(buildAttributeProfileProperty(consoleProfile, ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY), "false");
+            put(buildAttributeProfileProperty(consoleProfile, ClaimConstants.REQUIRED_PROPERTY), "false");
+            put(buildAttributeProfileProperty(endUserProfile, ClaimConstants.REQUIRED_PROPERTY), "true");
+            put(buildAttributeProfileProperty(endUserProfile, ClaimConstants.READ_ONLY_PROPERTY), "false");
+        }};
+
+        Map<String, String> claimProperties2 = new HashMap<String, String>() {{
+            put("SupportedByDefault", "false");
+            put("ReadOnly", "false");
+            put("Required", "false");
+            put(buildAttributeProfileProperty(consoleProfile, ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY), "true");
+            put(buildAttributeProfileProperty(consoleProfile, ClaimConstants.READ_ONLY_PROPERTY), "true");
+            put(buildAttributeProfileProperty(endUserProfile, ClaimConstants.REQUIRED_PROPERTY), "true");
+            put(buildAttributeProfileProperty(endUserProfile, ClaimConstants.DISPLAY_NAME_PROPERTY), "invalid");
+        }};
+
+        List<LocalClaim> localClaimList = new ArrayList<LocalClaim>() {{
+            add(new LocalClaim(EMAIL_ADDRESS_LOCAL_CLAIM, null, claimProperties1));
+            add(new LocalClaim(GIVEN_NAME_LOCAL_CLAIM, null, claimProperties2));
+        }};
+
+        List<ExternalClaim> externalClaimList = new ArrayList<ExternalClaim>() {{
+            add(new ExternalClaim(claimDialectUri, claimDialectUri + ":emails", EMAIL_ADDRESS_LOCAL_CLAIM));
+            add(new ExternalClaim(claimDialectUri, claimDialectUri + ":name.givenName", GIVEN_NAME_LOCAL_CLAIM));
+        }};
+
+        when(mockClaimMetadataManagementService.getExternalClaims(SCIMCommonConstants.SCIM_USER_CLAIM_DIALECT,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).thenReturn(externalClaimList);
+        when(mockClaimMetadataManagementService.getLocalClaims(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(localClaimList);
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        List<Attribute> userAttributes = scimUserManager.getUserSchema();
+        
+        assertEquals(userAttributes.size(), 2);
+
+        // Emails - Simple attribute.
+        assertEquals(userAttributes.get(0).getName(), "emails");
+        assertTrue(userAttributes.get(0).getAttributeJSONProperties().containsKey(ATTRIBUTE_PROFILES_PROPERTY));
+
+        JSONObject profiles1 = userAttributes.get(0).getAttributeJSONProperties().get(ATTRIBUTE_PROFILES_PROPERTY);
+        assertTrue(profiles1.has(consoleProfile));
+        assertTrue(profiles1.has(endUserProfile));
+        assertTrue(((JSONObject) profiles1.get(consoleProfile)).has(SUPPORTED_BY_DEFAULT_PROPERTY));
+        assertTrue(((JSONObject) profiles1.get(consoleProfile)).has(SCIMConfigConstants.REQUIRED));
+        assertTrue(((JSONObject) profiles1.get(endUserProfile)).has(SCIMConfigConstants.REQUIRED));
+        assertTrue(((JSONObject) profiles1.get(endUserProfile)).has(SCIMConfigConstants.MUTABILITY));
+
+        // Given name - Complex attribute.
+        assertEquals(userAttributes.get(1).getName(), "name");
+        assertFalse(userAttributes.get(1).getAttributeProperties().containsKey(ATTRIBUTE_PROFILES_PROPERTY));
+        assertTrue(userAttributes.get(1).getSubAttribute("givenName").getAttributeJSONProperties()
+                .containsKey(ATTRIBUTE_PROFILES_PROPERTY));
+
+        JSONObject profiles2 = userAttributes.get(1).getSubAttribute("givenName").getAttributeJSONProperties()
+                .get(ATTRIBUTE_PROFILES_PROPERTY);
+        assertTrue(profiles2.has(consoleProfile));
+        assertTrue(profiles2.has(endUserProfile));
+        assertTrue(((JSONObject) profiles2.get(consoleProfile)).has(SUPPORTED_BY_DEFAULT_PROPERTY));
+        assertTrue(((JSONObject) profiles2.get(consoleProfile)).has(SCIMConfigConstants.MUTABILITY));
+        assertTrue(((JSONObject) profiles2.get(endUserProfile)).has(SCIMConfigConstants.REQUIRED));
+        assertTrue(((JSONObject) profiles2.get(endUserProfile)).has(SCIMConfigConstants.REQUIRED));
+        assertFalse(((JSONObject) profiles2.get(endUserProfile)).has(ClaimConstants.DISPLAY_NAME_PROPERTY));
+    }
+
+    private String buildAttributeProfileProperty(String profileName, String property) {
+
+        return ClaimConstants.PROFILES_CLAIM_PROPERTY_PREFIX + profileName + "." + property;
     }
 
     @Test(dataProvider = "groupPermission")

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.24</carbon.kernel.version>
-        <identity.framework.version>7.7.85</identity.framework.version>
+        <identity.framework.version>7.7.96</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>4.0.28</charon.version>
+        <charon.version>4.0.29</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.76
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.handler.event.account.lock.version>1.8.13


### PR DESCRIPTION
## Purpose
- Add attribute profiles related properties as JSON object to scim2/Schemas response.
- Introduce the global supportedByDefault property. Previously, only attributes marked as supportedByDefault were returned in the response. Now, any profiles with supportedByDefault set to true will also be included.

<img width="385" alt="image" src="https://github.com/user-attachments/assets/e3f033cb-f1b5-4d4e-b01a-dcabc8233116" />

### Related Issues
- https://github.com/wso2/product-is/issues/22163

## Related PRs
- https://github.com/wso2/charon/pull/420