### PR TITLE
Set the last update date in the post-update role name listener

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/DAO/GroupDAO.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/DAO/GroupDAO.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -289,16 +289,38 @@ public class GroupDAO {
         }
     }
 
+    /**
+     * Update SCIM group attributes.
+     *
+     * @param tenantId      Tenant id.
+     * @param roleName      Group name.
+     * @param attributes    Attributes to be updated.
+     * @throws IdentitySCIMException If an error occurred while updating the attributes.
+     */
     public void updateSCIMGroupAttributes(int tenantId, String roleName,
                                           Map<String, String> attributes) throws IdentitySCIMException {
 
-        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        doUpdateSCIMGroupAttributes(tenantId, roleName, attributes, SQLQueries.UPDATE_ATTRIBUTES_SQL);
+    }
+
+    /**
+     * Do update SCIM group attributes.
+     *
+     * @param tenantId      Tenant id.
+     * @param roleName      Group name.
+     * @param attributes    Attributes to be updated.
+     * @param sqlQuery      SQL query to update the attributes.
+     * @throws IdentitySCIMException If an error occurred while updating the attributes.
+     */
+    private void doUpdateSCIMGroupAttributes(int tenantId, String roleName, Map<String, String> attributes,
+                                             String sqlQuery) throws IdentitySCIMException {
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection(true);
         PreparedStatement prepStmt = null;
 
         if (isExistingGroup(SCIMCommonUtils.getGroupNameWithDomain(roleName), tenantId)) {
             try {
-                prepStmt = connection.prepareStatement(SQLQueries.UPDATE_ATTRIBUTES_SQL);
-
+                prepStmt = connection.prepareStatement(sqlQuery);
                 prepStmt.setInt(2, tenantId);
                 prepStmt.setString(3, roleName);
 
@@ -308,19 +330,16 @@ public class GroupDAO {
                         prepStmt.setString(4, entry.getKey());
                         prepStmt.setString(1, entry.getValue());
                         prepStmt.addBatch();
-
                     } else {
                         throw new IdentitySCIMException("Error when adding SCIM Attribute: "
-                                + entry.getKey()
-                                + " An attribute with the same name doesn't exists.");
+                                + entry.getKey() + " An attribute with the same name doesn't exists.");
                     }
                 }
-                int[] return_count = prepStmt.executeBatch();
+                int[] returnCount = prepStmt.executeBatch();
                 if (log.isDebugEnabled()) {
-                    log.debug("No. of records updated for updating SCIM Group : " + return_count.length);
+                    log.debug("No. of records updated for updating SCIM Group : " + returnCount.length);
                 }
                 connection.commit();
-
             } catch (SQLException e) {
                 throw new IdentitySCIMException("Error updating the SCIM Group Attributes.", e);
             } finally {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/DAO/SQLQueries.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/DAO/SQLQueries.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -15,7 +15,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.carbon.identity.scim2.common.DAO;
+
 /**
  * SQL Queries for SCIM_IDENTITY_TABLE which persists SCIM_GROUP info.
  */
@@ -42,7 +44,7 @@ public class SQLQueries {
             "SELECT TENANT_ID, ROLE_NAME, ATTR_NAME FROM IDN_SCIM_GROUP WHERE IDN_SCIM_GROUP.TENANT_ID=? AND " +
                     "IDN_SCIM_GROUP.ROLE_NAME=? AND IDN_SCIM_GROUP.ATTR_NAME=? AND IDN_SCIM_GROUP.AUDIENCE_REF_ID=?";
     public static final String UPDATE_ATTRIBUTES_SQL =
-            "UPDATE IDN_SCIM_GROUP SET UM_ATTR_VALUE=? WHERE TENANT_ID=? AND ROLE_NAME=? AND ATTR_NAME=?";
+            "UPDATE IDN_SCIM_GROUP SET ATTR_VALUE=? WHERE TENANT_ID=? AND ROLE_NAME=? AND ATTR_NAME=?";
     public static final String UPDATE_GROUP_NAME_SQL =
             "UPDATE IDN_SCIM_GROUP SET ROLE_NAME=? WHERE TENANT_ID=? AND ROLE_NAME=?";
     public static final String DELETE_GROUP_SQL =

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/group/SCIMGroupHandler.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-
 
 /**
  * This is for managing SCIM specific attributes related to Group resource in Identity_SCIM_GROUP
@@ -334,5 +333,18 @@ public class SCIMGroupHandler {
 
         GroupDAO groupDAO = new GroupDAO();
         return groupDAO.getGroupNameList(attributeName, searchAttribute, this.tenantId, domainName);
+    }
+
+    /**
+     * Update SCIM attributes of the group.
+     *
+     * @param groupName     The display name of the group.
+     * @param attributes    The attributes to be updated.
+     * @throws IdentitySCIMException IdentitySCIMException when updating the SCIM Group information.
+     */
+    public void updateSCIMAttributes(String groupName, Map<String, String> attributes) throws IdentitySCIMException {
+
+        GroupDAO groupDAO = new GroupDAO();
+        groupDAO.updateSCIMGroupAttributes(tenantId, groupName, attributes);
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -51,6 +51,7 @@ import org.wso2.charon3.core.utils.AttributeUtil;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -698,7 +699,6 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
         }
 
         try {
-            //TODO:set last update date
             SCIMGroupHandler scimGroupHandler = new SCIMGroupHandler(userStoreManager.getTenantId());
 
             String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
@@ -711,6 +711,17 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                 scimGroupHandler.updateRoleName(roleNameWithDomain, newRoleNameWithDomain);
             } catch (IdentitySCIMException e) {
                 throw new UserStoreException("Error updating group information in SCIM Tables.", e);
+            }
+
+            // Update the last modified time of the group.
+            Date groupLastUpdatedTime = new Date();
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put(SCIMConstants.CommonSchemaConstants.LAST_MODIFIED_URI,
+                    AttributeUtil.formatDateTime(groupLastUpdatedTime.toInstant()));
+            try {
+                scimGroupHandler.updateSCIMAttributes(newRoleNameWithDomain, attributes);
+            } catch (IdentitySCIMException e) {
+                throw new UserStoreException("Failed to update group's last modified date in SCIM tables.", e);
             }
             return true;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.org)
+ * Copyright (c) 2017-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -39,6 +39,7 @@ import org.wso2.carbon.user.api.Permission;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.common.UserStore;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -50,6 +51,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -59,6 +61,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -76,6 +79,7 @@ public class SCIMUserOperationListenerTest {
     private String profile = "testProfile";
     private String claimURI = "http://wso2.org/claims/country";
     private String claimValue = "dummyValue";
+    private String domainName = "testDomain";
     private boolean isAuthenticated = true;
     SCIMUserOperationListener scimUserOperationListener;
 
@@ -283,12 +287,13 @@ public class SCIMUserOperationListenerTest {
 
     @DataProvider(name = "testDoPostAddRoleData")
     public Object[][] testDoPostAddRoleData() {
+
         return new Object[][]{
-                {true, true, true, "testDomain"},
+                {true, true, true, domainName},
                 {true, true, false, null},
-                {false, false, true, "testDomain"},
-                {true, false, false, "testDomain"},
-                {false, true, true, "testDomain"}
+                {false, false, true, domainName},
+                {true, false, false, domainName},
+                {false, true, true, domainName}
         };
     }
 
@@ -311,7 +316,8 @@ public class SCIMUserOperationListenerTest {
 
     @Test(expectedExceptions = UserStoreException.class)
     public void testDoPostAddRole2() throws Exception {
-        mockTestEnvironment(true, true, "testDomain");
+
+        mockTestEnvironment(true, true, domainName);
         try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
                 (mock, context) -> {
                     when(mock.isExistingGroup(anyString(), anyInt()))
@@ -331,7 +337,8 @@ public class SCIMUserOperationListenerTest {
 
     @Test(expectedExceptions = UserStoreException.class)
     public void testDoPreDeleteRole2() throws Exception {
-        mockTestEnvironment(true, true, "testDomain");
+
+        mockTestEnvironment(true, true, domainName);
         try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
                 (mock, context) -> {
                     when(mock.isExistingGroup(nullable(String.class), anyInt()))
@@ -353,12 +360,13 @@ public class SCIMUserOperationListenerTest {
 
     @DataProvider(name = "testDoPostUpdateRoleNameData")
     public Object[][] testDoPostUpdateRoleNameData() {
+
         return new Object[][]{
-                {true, true, "testDomain"},
+                {true, true, domainName},
                 {true, true, null},
-                {false, false, "testDomain"},
-                {true, false, "testDomain"},
-                {false, true, "testDomain"}
+                {false, false, domainName},
+                {true, false, domainName},
+                {false, true, domainName}
         };
     }
 
@@ -383,13 +391,52 @@ public class SCIMUserOperationListenerTest {
 
     @Test(expectedExceptions = UserStoreException.class)
     public void testDoPostUpdateRoleName2() throws Exception {
-        mockTestEnvironment(true, true, "testDomain");
+
+        mockTestEnvironment(true, true, domainName);
         try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
                 (mock, context) -> {
                     when(mock.isExistingGroup(anyString(), anyInt()))
                             .thenThrow(new IdentitySCIMException("IdentitySCIMException"));
                 })) {
             scimUserOperationListener.doPostUpdateRoleName(roleName, roleName, userStoreManager);
+        }
+    }
+
+    @DataProvider(name = "testDoPostUpdateRoleNameForUniqueGroupIdFlag")
+    public Object[][] testDoPostUpdateRoleNameForUniqueGroupIdFlag() {
+
+        return new Object[][]{
+                {true}, {false}
+        };
+    }
+
+    @Test(dataProvider = "testDoPostUpdateRoleNameForUniqueGroupIdFlag")
+    public void testDoPostUpdateRoleNameForUniqueGroupIdFlag(boolean isUniqueGroupIdEnabled) throws Exception {
+
+        try (MockedConstruction<GroupDAO> mockedGroupDAO = Mockito.mockConstruction(GroupDAO.class,
+                (mock, context) -> {
+                    when(mock.isExistingGroup(anyString(), anyInt())).thenReturn(true);
+                })) {
+            AbstractUserStoreManager mockUserStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+            when(mockUserStoreManager.isSCIMEnabled()).thenReturn(true);
+            when(mockUserStoreManager.isUniqueGroupIdEnabled()).thenReturn(isUniqueGroupIdEnabled);
+            when(scimUserOperationListener.isEnable()).thenReturn(true);
+
+            userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString()))
+                    .thenReturn(domainName);
+
+            assertTrue(scimUserOperationListener.doPostUpdateRoleName(roleName, roleName, mockUserStoreManager));
+
+            GroupDAO groupDAO = mockedGroupDAO.constructed().stream()
+                    .findFirst()
+                    .orElse(null);
+
+            if (isUniqueGroupIdEnabled) {
+                assertNull(groupDAO, "GroupDAO instance should have not been created");
+            } else {
+                assertNotNull(groupDAO, "GroupDAO instance should have been created");
+                Mockito.verify(groupDAO, Mockito.times(1)).updateRoleName(anyInt(), anyString(), anyString());
+            }
         }
     }
 


### PR DESCRIPTION
$subject

This adds the fix introduced in https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/590 to the **doPostUpdateRoleName** listener in SCIMUserOperationListener.

### Purpose
When a group is modified by renaming its display name, the group's last modified date needs to be updated. This PR fixes that issue by updating the group's last modified date on such scenarios.

**Note**: The SCIM level update is only required when the group unique id feature is disabled. Otherwise, the attributes will be stored in the user store.

### Related issues:
https://github.com/wso2/product-is/issues/19244