### PR TITLE
[Claim][IS] Update SCIM2 Schema to Include Shared Type Attribute

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -1425,6 +1425,21 @@
 "referenceTypes":[]
 },
 {
+"attributeURI":"urn:scim:wso2:schema:sharedType",
+"attributeName":"sharedType",
+"dataType":"string",
+"multiValued":"false",
+"description":"Shared Type of the user",
+"required":"false",
+"caseExact":"false",
+"mutability":"readOnly",
+"returned":"default",
+"uniqueness":"none",
+"subAttributes":"null",
+"canonicalValues":[],
+"referenceTypes":[]
+},
+{
 "attributeURI":"urn:scim:wso2:schema",
 "attributeName":"urn:scim:wso2:schema",
 "dataType":"complex",
@@ -1435,7 +1450,7 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile country userSourceId totpEnabled backupCodeEnabled enabledAuthenticators failedBackupCodeAttempts managedOrg preferredMFAOption emailAddresses verifiedEmailAddresses mobileNumbers verifiedMobileNumbers passwordExpiryTime",
+"subAttributes":"verifyEmail askPassword pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile country userSourceId totpEnabled backupCodeEnabled enabledAuthenticators failedBackupCodeAttempts managedOrg preferredMFAOption emailAddresses verifiedEmailAddresses mobileNumbers verifiedMobileNumbers passwordExpiryTime sharedType",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }

--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -1425,21 +1425,6 @@
 "referenceTypes":[]
 },
 {
-"attributeURI":"urn:scim:wso2:schema:sharedType",
-"attributeName":"sharedType",
-"dataType":"string",
-"multiValued":"false",
-"description":"Shared Type of the user",
-"required":"false",
-"caseExact":"false",
-"mutability":"readOnly",
-"returned":"default",
-"uniqueness":"none",
-"subAttributes":"null",
-"canonicalValues":[],
-"referenceTypes":[]
-},
-{
 "attributeURI":"urn:scim:wso2:schema",
 "attributeName":"urn:scim:wso2:schema",
 "dataType":"complex",
@@ -1450,7 +1435,7 @@
 "mutability":"readWrite",
 "returned":"default",
 "uniqueness":"none",
-"subAttributes":"verifyEmail askPassword pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile country userSourceId totpEnabled backupCodeEnabled enabledAuthenticators failedBackupCodeAttempts managedOrg preferredMFAOption emailAddresses verifiedEmailAddresses mobileNumbers verifiedMobileNumbers passwordExpiryTime sharedType",
+"subAttributes":"verifyEmail askPassword pendingEmails accountLocked accountState emailOTPDisabled emailVerified failedEmailOTPAttempts failedLoginAttempts failedLoginAttemptsBeforeSuccess failedLoginLockoutCount failedPasswordRecoveryAttempts failedSMSOTPAttempts failedTOTPAttempts isLiteUser lastLoginTime lastLogonTime lastPasswordUpdateTime lockedReason phoneVerified preferredChannel smsOTPDisabled tenantAdminAskPassword unlockTime accountDisabled dateOfBirth isReadOnlyUser pendingMobileNumber forcePasswordReset oneTimePassword verifyMobile country userSourceId totpEnabled backupCodeEnabled enabledAuthenticators failedBackupCodeAttempts managedOrg preferredMFAOption emailAddresses verifiedEmailAddresses mobileNumbers verifiedMobileNumbers passwordExpiryTime",
 "canonicalValues":[],
 "referenceTypes":["external"]
 }


### PR DESCRIPTION
## Purpose
Extend the SCIM2 schema to support the new shared type attribute and return it as part of the user response.

## Goals
- Introduce `sharedType` as a standalone SCIM2 attribute.
- Add `sharedType` as a sub-attribute under `urn:scim:wso2:schema`.
- Ensure the attribute follows SCIM2 standards (read-only, default returned, etc.).

## Approach
- Defined a new SCIM2 attribute with `attributeURI: urn:scim:wso2:schema:sharedType`.
- Set `mutability` to `readOnly`, `returned` to `default`, and `dataType` to `string`.
- Added `sharedType` to the `subAttributes` list of `urn:scim:wso2:schema`.

## Related PRs
Merge after: [[Claim][IS] Add Shared Type Local Claim and Map to SCIM2 Claim #6511](https://github.com/wso2/carbon-identity-framework/pull/6511)
Merge before: [[Claim] Return Shared Type Claim in User Profile Responses #475](https://github.com/wso2-extensions/identity-organization-management/pull/475)

---

## Related Issues
[Display user shared type in shared user profile #23071](https://github.com/wso2/product-is/issues/23071)