### PR TITLE
Handle failures from Pre Update Password action

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -161,6 +161,10 @@
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.action</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1390,8 +1390,8 @@ public class SCIMUserManager implements UserManager {
 
     private void handleAndThrowClientExceptionForActionFailure(UserStoreException e) throws BadRequestException {
 
-        if (e instanceof UserStoreClientException && ((UserStoreClientException) e).getErrorCode()
-                .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {
+        if (e instanceof UserStoreClientException && UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
+                .equals(((UserStoreClientException) e).getErrorCode())) {
             throw new BadRequestException(e.getMessage(), ResponseCodeConstants.INVALID_VALUE);
         }
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1183,7 +1183,7 @@ public class SCIMUserManager implements UserManager {
             }
             return getUser(user.getId(), requiredAttributes);
         } catch (UserStoreClientException e) {
-            handleActionFailure(e);
+            handleAndThrowClientExceptionForActionFailure(e);
             String errorMessage = String.format("Error while updating attributes of user. %s", e.getMessage());
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
@@ -1368,7 +1368,7 @@ public class SCIMUserManager implements UserManager {
             }
             return getUser(user.getId(), requiredAttributes);
         } catch (UserStoreException e) {
-            handleActionFailure(e);
+            handleAndThrowClientExceptionForActionFailure(e);
             handleErrorsOnUserNameAndPasswordPolicy(e);
             throw resolveError(e, "Error while updating attributes of user: " +
                     maskIfRequired(user.getUserName()));
@@ -1388,7 +1388,7 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
-    private void handleActionFailure(UserStoreException e) throws BadRequestException {
+    private void handleAndThrowClientExceptionForActionFailure(UserStoreException e) throws BadRequestException {
 
         if (e instanceof UserStoreClientException && ((UserStoreClientException) e).getErrorCode()
                 .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -61,7 +61,7 @@ import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
-import org.wso2.carbon.identity.user.action.service.constant.UserActionError;
+import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.user.api.ClaimMapping;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.PaginatedUserStoreManager;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -50,7 +50,7 @@ import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
-import org.wso2.carbon.identity.user.action.service.constant.UserActionError;
+import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.common.PaginatedUserResponse;
 import org.wso2.carbon.user.core.model.UniqueIDUserClaimSearchEntry;

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,11 @@
                 <version>${identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.user.action</artifactId>
+                <version>${identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.24</carbon.kernel.version>
-        <identity.framework.version>7.7.248</identity.framework.version>
+        <identity.framework.version>7.7.259</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
### Purpose

- Failures from Pre Update Password Action returns to scim level as UserStoreClientExceptions. 
- Since those failures comes with a respective error code, we can directly handle them using that.
- Hence added a method to handle the failures from the Pre Update Password action


#### Previous API responses

Scim2/users update:

```
{

    "schemas": [

        "urn:ietf:params:scim:api:messages:2.0:Error"

    ],

    "detail": "Compromized Password. Provided Password has been compromized",

    "status": "400"

}
```

Scim2/me update:

```
{

    "schemas": [

        "urn:ietf:params:scim:api:messages:2.0:Error"

    ],

    "scimType": "invalidValue",

    "detail": "Error while updating attributes of user. Compromized Password. Provided Password has been compromized",

    "status": "400"

}
```

New API responses:

Scim2/users update:

```
{

    "schemas": [

        "urn:ietf:params:scim:api:messages:2.0:Error"

    ],

    "scimType": "invalidValue",

    "detail": "Compromized Password. Provided Password has been compromized",

    "status": "400"

}
```

Scim2/me update:

```
{

    "schemas": [

        "urn:ietf:params:scim:api:messages:2.0:Error"

    ],

    "scimType": "invalidValue",

    "detail": "Compromized Password. Provided Password has been compromized",

    "status": "400"

}
```

### Related Issue
- https://github.com/wso2/product-is/issues/23080