### PR TITLE
Add cache for system attribute schema

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCache.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCache.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.cache;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.charon3.core.schema.AttributeSchema;
+
+/**
+ * This stores system AttributeSchema against tenants.
+ */
+public class SCIMSystemAttributeSchemaCache 
+        extends BaseCache<SCIMSystemAttributeSchemaCacheKey, SCIMSystemAttributeSchemaCacheEntry> {
+
+    private static final String SCIM_SYSTEM_SCHEMA_CACHE = "SCIMSystemAttributeSchemaCache";
+    private static final Log log = LogFactory.getLog(SCIMSystemAttributeSchemaCache.class);
+
+    private static volatile SCIMSystemAttributeSchemaCache instance;
+
+    private SCIMSystemAttributeSchemaCache() {
+
+        super(SCIM_SYSTEM_SCHEMA_CACHE);
+    }
+
+    public static SCIMSystemAttributeSchemaCache getInstance() {
+
+        if (instance == null) {
+            synchronized (SCIMSystemAttributeSchemaCache.class) {
+                if (instance == null) {
+                    instance = new SCIMSystemAttributeSchemaCache();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Add system attribute schema to cache against tenantId.
+     *
+     * @param tenantId TenantId.
+     * @param systemAttributeSchema SystemAttributeSchema.
+     */
+    public void addSCIMSystemAttributeSchema(int tenantId, AttributeSchema systemAttributeSchema){
+
+        SCIMSystemAttributeSchemaCacheKey cacheKey = new SCIMSystemAttributeSchemaCacheKey(tenantId);
+        SCIMSystemAttributeSchemaCacheEntry cacheEntry = new SCIMSystemAttributeSchemaCacheEntry(systemAttributeSchema);
+        super.addToCache(cacheKey, cacheEntry);
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully added scim system attributes into SCIMSystemSchemaCache for the tenant:"
+                    + tenantId);
+        }
+
+    }
+
+
+    /**
+     * Get SCIM2 System AttributeSchema by tenantId.
+     *
+     * @param tenantId TenantId.
+     * @return AttributeSchema.
+     */
+    public AttributeSchema getSCIMSystemAttributeSchemaByTenant(int tenantId) {
+
+        SCIMSystemAttributeSchemaCacheKey cacheKey = new SCIMSystemAttributeSchemaCacheKey(tenantId);
+        SCIMSystemAttributeSchemaCacheEntry cacheEntry = super.getValueFromCache(cacheKey);
+        if (cacheEntry != null) {
+            return cacheEntry.getSCIMSystemAttributeSchema();
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache entry is null for tenantId: " + tenantId);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Clear SCIM2 System AttributeSchema by tenantId.
+     *
+     * @param tenantId TenantId.
+     */
+    public void clearSCIMSystemAttributeSchemaByTenant(int tenantId) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Clearing SCIMSystemAttributeSchemaCache entry by the tenant with id: " + tenantId);
+        }
+        SCIMSystemAttributeSchemaCacheKey cacheKey = new SCIMSystemAttributeSchemaCacheKey(tenantId);
+        super.clearCacheEntry(cacheKey);
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheEntry.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheEntry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.cache;
+
+import org.wso2.charon3.core.schema.AttributeSchema;
+
+import java.io.Serializable;
+
+/**
+ * This stores list of custom attributes of SCIM2 system schema.
+ */
+public class SCIMSystemAttributeSchemaCacheEntry implements Serializable {
+
+    private static final long serialVersionUID = 3784848233717914594L;
+
+    private final AttributeSchema attributeSchema;
+
+    public SCIMSystemAttributeSchemaCacheEntry(AttributeSchema attributeSchema) {
+
+        this.attributeSchema = attributeSchema;
+    }
+
+    public AttributeSchema getSCIMSystemAttributeSchema() {
+
+        return attributeSchema;
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheKey.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.cache;
+
+import java.io.Serializable;
+
+/**
+ * SCIM System Schema Cache key. This contains tenant ID as the key.
+ */
+public class SCIMSystemAttributeSchemaCacheKey implements Serializable {
+
+    private static final long serialVersionUID = -6137657709191460466L;
+
+    private final int tenantId;
+
+    public SCIMSystemAttributeSchemaCacheKey(int tenantId) {
+
+        this.tenantId = tenantId;
+    }
+
+    public int getTenantId() {
+
+        return tenantId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof SCIMSystemAttributeSchemaCacheKey)) {
+            return false;
+        }
+
+        SCIMSystemAttributeSchemaCacheKey that = (SCIMSystemAttributeSchemaCacheKey) o;
+        return tenantId == that.tenantId;
+    }
+
+    @Override
+    public int hashCode() {
+        return tenantId;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagemen
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.cache.SCIMCustomAttributeSchemaCache;
+import org.wso2.carbon.identity.scim2.common.cache.SCIMSystemAttributeSchemaCache;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreException;
@@ -6530,6 +6531,11 @@ public class SCIMUserManager implements UserManager {
     public AttributeSchema getCustomAttributeSchemaInSystemExtension() throws CharonException {
 
         if (tenantDomain != null) {
+            AttributeSchema schema = SCIMSystemAttributeSchemaCache.getInstance().
+                    getSCIMSystemAttributeSchemaByTenant(IdentityTenantUtil.getTenantId(tenantDomain));
+            if (schema != null) {
+                return schema;
+            }
             try {
                 return buildSystemSchema(carbonUM.getTenantId());
             } catch (UserStoreException e) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.organization.management.service.util.Organizatio
 import org.wso2.carbon.identity.role.mgt.core.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.mgt.core.util.UserIDResolver;
 import org.wso2.carbon.identity.scim2.common.cache.SCIMCustomAttributeSchemaCache;
+import org.wso2.carbon.identity.scim2.common.cache.SCIMSystemAttributeSchemaCache;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
 import org.wso2.carbon.identity.scim2.common.internal.SCIMCommonComponentHolder;
@@ -951,7 +952,10 @@ public class SCIMCommonUtils {
             List<SCIMCustomAttribute> attributes =
                     scimCustomSchemaProcessor.getCustomAttributes(IdentityTenantUtil.getTenantDomain(tenantId),
                             SCIMConstants.SYSTEM_USER_SCHEMA_URI);
-            return SCIMSystemSchemaExtensionBuilder.getInstance().buildSystemSchemaExtension(attributes);
+            AttributeSchema attributeSchema = SCIMSystemSchemaExtensionBuilder.getInstance()
+                    .buildSystemSchemaExtension(attributes);
+            SCIMSystemAttributeSchemaCache.getInstance().addSCIMSystemAttributeSchema(tenantId, attributeSchema);
+            return attributeSchema;
         } catch (InternalErrorException | IdentitySCIMException e) {
             throw new CharonException("Error while building scim system schema", e);
         }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCustomSchemaProcessor.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCustomSchemaProcessor.java
@@ -24,7 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.charon3.core.attributes.SCIMCustomAttribute;
 import org.wso2.charon3.core.config.SCIMConfigConstants;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheTest.java
@@ -1,0 +1,96 @@
+package org.wso2.carbon.identity.scim2.common.cache;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.charon3.core.schema.AttributeSchema;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+@WithCarbonHome
+public class SCIMSystemAttributeSchemaCacheTest {
+
+    private SCIMSystemAttributeSchemaCache cache;
+    private AttributeSchema mockAttributeSchema;
+
+    @BeforeMethod
+    public void setUp() {
+
+        cache = SCIMSystemAttributeSchemaCache.getInstance();
+        mockAttributeSchema = mock(AttributeSchema.class);
+    }
+
+    @Test
+    public void testAddSCIMSystemAttributeSchema() {
+
+        cache.addSCIMSystemAttributeSchema(1, mockAttributeSchema);
+        AttributeSchema result = cache.getSCIMSystemAttributeSchemaByTenant(1);
+        assertNotNull(result);
+        assertEquals(mockAttributeSchema, result);
+    }
+
+    @Test
+    public void testGetSCIMSystemAttributeSchemaByTenant() {
+
+        cache.addSCIMSystemAttributeSchema(1, mockAttributeSchema);
+        AttributeSchema result = cache.getSCIMSystemAttributeSchemaByTenant(1);
+        assertNotNull(result);
+        assertEquals(mockAttributeSchema, result);
+    }
+
+    @Test
+    public void testGetSCIMSystemAttributeSchemaByTenant_NotFound() {
+
+        AttributeSchema result = cache.getSCIMSystemAttributeSchemaByTenant(2);
+        assertNull(result);
+    }
+
+    @Test
+    public void testClearSCIMSystemAttributeSchemaByTenant() {
+
+        cache.addSCIMSystemAttributeSchema(1, mockAttributeSchema);
+        cache.clearSCIMSystemAttributeSchemaByTenant(1);
+        AttributeSchema result = cache.getSCIMSystemAttributeSchemaByTenant(1);
+        assertNull(result);
+    }
+
+    @Test
+    public void testSingletonInstance() {
+
+        SCIMSystemAttributeSchemaCache instance1 = SCIMSystemAttributeSchemaCache.getInstance();
+        SCIMSystemAttributeSchemaCache instance2 = SCIMSystemAttributeSchemaCache.getInstance();
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testClearSCIMSystemAttributeSchemaByTenant_NonExistentTenant() {
+
+        cache.clearSCIMSystemAttributeSchemaByTenant(2);
+        // No exception should be thrown.
+    }
+
+    @Test
+    public void testCacheKeyEquality() {
+
+        SCIMSystemAttributeSchemaCacheKey key1 = new SCIMSystemAttributeSchemaCacheKey(1);
+        SCIMSystemAttributeSchemaCacheKey key2 = new SCIMSystemAttributeSchemaCacheKey(1);
+        SCIMSystemAttributeSchemaCacheKey key3 = new SCIMSystemAttributeSchemaCacheKey(2);
+
+        assertEquals(key1, key2);
+        assertNotEquals(key1, key3);
+    }
+
+    @Test
+    public void testCacheKeyHashCode() {
+
+        SCIMSystemAttributeSchemaCacheKey key1 = new SCIMSystemAttributeSchemaCacheKey(1);
+        SCIMSystemAttributeSchemaCacheKey key2 = new SCIMSystemAttributeSchemaCacheKey(1);
+
+        assertEquals(key1.hashCode(), key2.hashCode());
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/handlers/SCIMClaimOperationEventHandlerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/handlers/SCIMClaimOperationEventHandlerTest.java
@@ -1,0 +1,109 @@
+package org.wso2.carbon.identity.scim2.common.handlers;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.scim2.common.cache.SCIMCustomAttributeSchemaCache;
+import org.wso2.carbon.identity.scim2.common.cache.SCIMSystemAttributeSchemaCache;
+import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
+import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
+import org.wso2.charon3.core.schema.AttributeSchema;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.wso2.carbon.identity.scim2.common.handlers.SCIMClaimOperationEventHandler.WSO2_CARBON_DIALECT;
+
+@WithCarbonHome
+public class SCIMClaimOperationEventHandlerTest {
+
+    private SCIMClaimOperationEventHandler handler;
+    private Event mockEvent;
+
+    @BeforeMethod
+    public void setUp() {
+
+        handler = new SCIMClaimOperationEventHandler();
+        mockEvent = mock(Event.class);
+    }
+
+    @Test
+    public void handleEvent_SCIMSystemUserClaimDialect_ClearsSystemCache() throws IdentityEventException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_ID, 1);
+        eventProperties.put(IdentityEventConstants.EventProperty.CLAIM_DIALECT_URI, SCIMCommonConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT);
+        when(mockEvent.getEventProperties()).thenReturn(eventProperties);
+
+        SCIMSystemAttributeSchemaCache cache = SCIMSystemAttributeSchemaCache.getInstance();
+        cache.addSCIMSystemAttributeSchema(1, mock(AttributeSchema.class));
+
+        handler.handleEvent(mockEvent);
+
+        assertNull(cache.getSCIMSystemAttributeSchemaByTenant(1));
+    }
+
+    @Test
+    public void handleEvent_CustomSchemaUri_ClearsCustomCache() throws IdentityEventException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_ID, 1);
+        eventProperties.put(IdentityEventConstants.EventProperty.CLAIM_DIALECT_URI, SCIMCommonUtils.getCustomSchemaURI());
+        when(mockEvent.getEventProperties()).thenReturn(eventProperties);
+
+        SCIMCustomAttributeSchemaCache cache = SCIMCustomAttributeSchemaCache.getInstance();
+        cache.addSCIMCustomAttributeSchema(1, mock(AttributeSchema.class));
+
+        handler.handleEvent(mockEvent);
+
+        assertNull(cache.getSCIMCustomAttributeSchemaByTenant(1));
+    }
+
+    @Test
+    public void handleEvent_LocalClaimUpdate_ClearsBothCaches() throws IdentityEventException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_ID, 1);
+        eventProperties.put(IdentityEventConstants.EventProperty.CLAIM_DIALECT_URI, WSO2_CARBON_DIALECT);
+        when(mockEvent.getEventProperties()).thenReturn(eventProperties);
+
+        SCIMSystemAttributeSchemaCache systemCache = SCIMSystemAttributeSchemaCache.getInstance();
+        SCIMCustomAttributeSchemaCache customCache = SCIMCustomAttributeSchemaCache.getInstance();
+        systemCache.addSCIMSystemAttributeSchema(1, mock(AttributeSchema.class));
+        customCache.addSCIMCustomAttributeSchema(1, mock(AttributeSchema.class));
+
+        handler.handleEvent(mockEvent);
+
+        assertNull(systemCache.getSCIMSystemAttributeSchemaByTenant(1));
+        assertNull(customCache.getSCIMCustomAttributeSchemaByTenant(1));
+    }
+
+    @Test
+    public void handleEvent_CustomSchemaDisabled_DoesNotClearCache() throws IdentityEventException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_ID, 1);
+        eventProperties.put(IdentityEventConstants.EventProperty.CLAIM_DIALECT_URI, SCIMCommonUtils.getCustomSchemaURI());
+        when(mockEvent.getEventProperties()).thenReturn(eventProperties);
+
+        MockedStatic<SCIMCommonUtils> mockUtils = mockStatic(SCIMCommonUtils.class);
+        mockUtils.when(SCIMCommonUtils::isCustomSchemaEnabled).thenReturn(false);
+        SCIMCustomAttributeSchemaCache cache = SCIMCustomAttributeSchemaCache.getInstance();
+        cache.addSCIMCustomAttributeSchema(1, mock(AttributeSchema.class));
+
+        handler.handleEvent(mockEvent);
+
+        assertNotNull(cache.getSCIMCustomAttributeSchemaByTenant(1));
+
+        mockUtils.close();
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -35,6 +35,8 @@
             <class name="org.wso2.carbon.identity.scim2.common.impl.IdentityResourceURLBuilderTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.DefaultSCIMUserStoreErrorResolverTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.impl.SCIMRoleManagerV2Test"/>
+            <class name="org.wso2.carbon.identity.scim2.common.handlers.SCIMClaimOperationEventHandlerTest"/>
+            <class name="org.wso2.carbon.identity.scim2.common.cache.SCIMSystemAttributeSchemaCacheTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
### Purpose

This PR introduces a caching mechanism for SCIM system attribute schemas to improve performance and reduce redundant processing. The `SCIMSystemAttributeSchemaCache` is implemented to store system attribute schemas per tenant, along with corresponding cache entry and key classes for efficient management. The caching logic is integrated into `SCIMUserManager` and `SCIMCommonUtils` to optimize schema retrieval, while `SCIMClaimOperationEventHandler` has been updated to clear the cache when relevant claims are modified.

### Related Issues
- https://github.com/wso2/product-is/issues/23104