### PR TITLE
Block adding custom claims to spec-defined and system schema

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/handlers/SCIMClaimOperationEventHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/handlers/SCIMClaimOperationEventHandler.java
@@ -148,7 +148,6 @@ public class SCIMClaimOperationEventHandler extends AbstractEventHandler {
             return;
         }
 
-        IdentityUtil.threadLocalProperties.get().remove(ClaimConstants.EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT);
         if (scimClaimDialects.contains(claimDialectUri)) {
             /*
              * If the claim dialect is a spec-defined SCIM dialect or system schema, then we need to prevent adding

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/handlers/SCIMClaimOperationEventHandler.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/handlers/SCIMClaimOperationEventHandler.java
@@ -147,6 +147,7 @@ public class SCIMClaimOperationEventHandler extends AbstractEventHandler {
             return;
         }
 
+        IdentityUtil.threadLocalProperties.get().remove(ClaimConstants.EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT);
         if (scimClaimDialects.contains(claimDialectUri)) {
             IdentityUtil.threadLocalProperties.get()
                     .put(ClaimConstants.EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT, true);

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.24</carbon.kernel.version>
-        <identity.framework.version>7.7.259</identity.framework.version>
+        <identity.framework.version>7.8.7</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
### Purpose

This PR introduces a validation mechanism to block the addition of custom claims to spec-defined and system SCIM schemas, ensuring compliance with SCIM standards and preventing potential conflicts.

### Related Issue
- https://github.com/wso2/product-is/issues/23162