### PR TITLE
Add thread local flag to track admin initiated password changes

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -168,6 +168,7 @@ public class SCIMUserManager implements UserManager {
     private static final int MAX_ITEM_LIMIT_UNLIMITED = -1;
     private static final String ENABLE_PAGINATED_USER_STORE = "SCIM.EnablePaginatedUserStore";
     private static final String SERVICE_PROVIDER = "serviceProvider";
+    private static final String CHANGE_PASSWORD_BY_ADMIN = "changePasswordByAdmin";
     private final String SERVICE_PROVIDER_TENANT_DOMAIN = "serviceProviderTenantDomain";
 
     // Additional wso2 user schema properties.
@@ -1301,8 +1302,13 @@ public class SCIMUserManager implements UserManager {
 
             // If password is updated, set it separately.
             if (user.getPassword() != null) {
-                carbonUM.updateCredentialByAdminWithID(user.getId(), user.getPassword());
-                publishEvent(user, IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM, true);
+                try {
+                    IdentityUtil.threadLocalProperties.get().put(CHANGE_PASSWORD_BY_ADMIN, true);
+                    carbonUM.updateCredentialByAdminWithID(user.getId(), user.getPassword());
+                    publishEvent(user, IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM, true);
+                } finally {
+                    IdentityUtil.threadLocalProperties.get().remove(CHANGE_PASSWORD_BY_ADMIN);
+                }
             }
 
             updateUserClaims(user, oldClaimList, claimValuesInLocalDialect, allSimpleMultiValuedClaimsList);


### PR DESCRIPTION
## Purpose
Enhance the handling of password update differentitions between user initiated and administrator initiated password changes. This helps improve traceability and logging, ensuring that password updates are correctly attributed to the initiating party.

## Implementation
This PR includes changes to the `SCIMUserManager` class in the `org.wso2.carbon.identity.scim2.common` package. The most important changes are focused on handling password updates by administrators.

Enhancements to password update handling:

* Added a new constant `CHANGE_PASSWORD_BY_ADMIN` to indicate when a password change is performed by an administrator.
* Updated the `updateUser` method to set the `CHANGE_PASSWORD_BY_ADMIN` flag in thread-local properties before updating the password and to remove it afterward.

## Testing
### The following flows has been tested (Demo videos)
- AdminChangingUserPassword
https://drive.google.com/file/d/1L3yc-qWgoS-nZiHPBfuy_GWRVVQNk6AY/view?usp=sharing

- ForgotPasswordFlow
https://drive.google.com/file/d/1I8oi7YTUrL5r4p7BVW46S7938M-t47kh/view?usp=sharing

- ScimMeEndpoint
https://drive.google.com/file/d/1JncVxtiUyZd_WZFgfsz5ozB_gtv5MoS0/view?usp=sharing

## Related Issues
- https://github.com/wso2/product-is/issues/11625

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6636
