### PR TITLE
Map failure message and description from pre update password extension to scimType and detail

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1395,9 +1395,17 @@ public class SCIMUserManager implements UserManager {
 
     private void handleAndThrowClientExceptionForActionFailure(UserStoreException e) throws BadRequestException {
 
+        /* Note that UserActionExecutionClientException has been wrapped multiple times at this point and needs to be
+         unwrapped accordingly. Since there is a possibility of altering the error stack and not constructing the
+         failure response correctly, integration tests are added to detect any regressions.
+         */
         if (e instanceof UserStoreClientException && UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
-                .equals(((UserStoreClientException) e).getErrorCode())) {
-            throw new BadRequestException(e.getMessage(), ResponseCodeConstants.INVALID_VALUE);
+                .equals(((UserStoreClientException) e).getErrorCode()) &&
+                e.getCause().getCause().getCause() instanceof UserActionExecutionClientException) {
+            UserActionExecutionClientException userActionExecutionClientException =
+                    (UserActionExecutionClientException) e.getCause().getCause().getCause();
+            throw new BadRequestException(userActionExecutionClientException.getDescription(),
+                    userActionExecutionClientException.getError());
         }
 
         if (e instanceof UserActionExecutionClientException) {


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23568

With this PR, the `failureReason` and `failureDescription` from the external authentication service response are correctly mapped to `scimType` and `detail`, respectively, ensuring proper error representation in the SCIM error response.

The current response received for the password update request is:  

```json
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "invalidValue",
    "detail": "The provided password is compromised. Provide something different.",
    "status": "400"
}
```

However, to ensure proper error representation, the response should follow this format:  

```json
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "Compromised password",
    "detail": "The provided password is compromised. Provide something different.",
    "status": "400"
}
```
Related PR:
- https://github.com/wso2/carbon-identity-framework/pull/6634