### PR TITLE
Exclude flowInitiator claims

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
@@ -349,7 +349,7 @@ public class PreUpdateProfileActionExecutor {
                 Optional<LocalClaim> localClaim = claimMetadataManagementService.getLocalClaim(claimUri, tenantDomain);
                 return localClaim.isPresent() && !localClaim.get().getFlowInitiator();
             } catch (ClaimMetadataException e) {
-                throw new UserStoreException("Error while getting local claim", e);
+                throw new UserStoreException(String.format("Error while reading claim meta data of %s", claimUri), e);
             }
         }
         return false;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
@@ -56,8 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -72,7 +71,7 @@ import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants
 import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.DELETING_MULTIVALUE_INPUT_VALUE_AS_STRING_LIST_CLAIM8;
 import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.DELETING_MULTI_ATTRIBUTE_SEPARATOR_INCLUDED_SINGLEVALUE_CLAIM5;
 import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.DELETING_SINGLEVALUE_CLAIM4;
-import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.EXCLUDED_SINGLEVALUE_IDENTITY_CLAIM1;
+import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1;
 import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.NEW_MULTIVALUE_INPUT_VALUE_AS_STRING_CLAIM6;
 import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.NEW_MULTIVALUE_INPUT_VALUE_AS_STRING_LIST_CLAIM6;
 import static org.wso2.carbon.identity.scim2.common.test.constants.TestConstants.Claims.NEW_SINGLEVALUE_CLAIM1;
@@ -242,7 +241,7 @@ public class PreUpdateProfileActionExecutorTest {
     }
 
     @Test
-    public void testSuccessExecutionForExcludedIdentityClaimUpdateExecutionAtPutOperation() throws Exception {
+    public void testSuccessExecutionForFlowInitiatorClaimUpdateExecutionAtPutOperation() throws Exception {
 
         when(actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)).thenReturn(true);
 
@@ -250,14 +249,15 @@ public class PreUpdateProfileActionExecutorTest {
         when(status.getStatus()).thenReturn(ActionExecutionStatus.Status.SUCCESS);
         when(actionExecutorService.execute(eq(ActionType.PRE_UPDATE_PROFILE), any(), any())).thenReturn(status);
 
-        LocalClaim newClaim = getMockedLocalClaim(EXCLUDED_SINGLEVALUE_IDENTITY_CLAIM1);
-        when(claimMetadataManagementService.getLocalClaim(eq(EXCLUDED_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI()), any(String.class)))
+        LocalClaim newClaim = getMockedLocalClaim(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1);
+        when(claimMetadataManagementService.getLocalClaim(eq(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI()), anyString()))
                 .thenReturn(Optional.of(newClaim));
+        when(newClaim.getFlowInitiator()).thenReturn(true);
 
         User user = getSCIMUser();
 
         Map<String, String> claimsToModify = new HashMap<>();
-        claimsToModify.put(EXCLUDED_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI(), EXCLUDED_SINGLEVALUE_IDENTITY_CLAIM1.getInputValueAsString());
+        claimsToModify.put(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI(), FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getInputValueAsString());
 
         Map<String, String> claimsToDelete = new HashMap<>();
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
@@ -241,7 +241,7 @@ public class PreUpdateProfileActionExecutorTest {
     }
 
     @Test
-    public void testSuccessExecutionForFlowInitiatorClaimUpdateExecutionAtPutOperation() throws Exception {
+    public void testExecutionSkippedForFlowInitiatorClaimUpdateExecutionAtPutOperation() throws Exception {
 
         when(actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)).thenReturn(true);
 
@@ -250,14 +250,15 @@ public class PreUpdateProfileActionExecutorTest {
         when(actionExecutorService.execute(eq(ActionType.PRE_UPDATE_PROFILE), any(), any())).thenReturn(status);
 
         LocalClaim newClaim = getMockedLocalClaim(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1);
-        when(claimMetadataManagementService.getLocalClaim(eq(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI()), anyString()))
-                .thenReturn(Optional.of(newClaim));
+        when(claimMetadataManagementService.getLocalClaim(eq(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI()),
+                anyString())).thenReturn(Optional.of(newClaim));
         when(newClaim.getFlowInitiator()).thenReturn(true);
 
         User user = getSCIMUser();
 
         Map<String, String> claimsToModify = new HashMap<>();
-        claimsToModify.put(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI(), FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getInputValueAsString());
+        claimsToModify.put(FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getClaimURI(),
+                FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1.getInputValueAsString());
 
         Map<String, String> claimsToDelete = new HashMap<>();
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/test/constants/TestConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/test/constants/TestConstants.java
@@ -53,7 +53,7 @@ public class TestConstants {
         DELETING_MULTIVALUE_INPUT_VALUE_AS_STRING_CLAIM8("http://wso2.org/claims/claim8", true,
                 "value81,value80",
                 new String[]{}, "value81,value80,value82"),
-        EXCLUDED_SINGLEVALUE_IDENTITY_CLAIM1("http://wso2.org/claims/identity/adminForcedPasswordReset", false, "true", "false", null);
+        FLOW_INITIATOR_SINGLEVALUE_IDENTITY_CLAIM1("http://wso2.org/claims/identity/adminForcedPasswordReset", false, "true", "false", null);
 
         private String claimURI;
         private boolean isMultiValued;

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.42</carbon.kernel.version>
-        <identity.framework.version>7.8.68</identity.framework.version>
+        <identity.framework.version>7.8.114</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
#### Description

This PR updates the pre executable validations for the PRE PROFILE UPDATE ACTION execution consuming the flowInitiator claim property of the particular local claim. 

The particular local claims which is getting updated or deleted will be retrieved from the claim metadata service and check whether it is a flowInitiator typed claim.

Further this updates the relevant unit tests written for updating flowInitiator typed claims.

#### Merging 
Merge after https://github.com/wso2/carbon-identity-framework/pull/6688

#### Related issue
- https://github.com/wso2/product-is/issues/23838

