### PR TITLE
Improve error handling of password policy validation in SCIM User Manager

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -145,6 +145,7 @@ import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_EMAIL_DOMAIN_ASSOCIATED_WITH_DIFFERENT_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_EMAIL_DOMAIN_NOT_MAPPED_TO_ORGANIZATION;
+import static org.wso2.carbon.identity.password.policy.constants.PasswordPolicyConstants.ErrorMessages.ERROR_CODE_LOADING_PASSWORD_POLICY_CLASSES;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.buildCustomSchema;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.buildSystemSchema;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.getCustomSchemaURI;
@@ -434,7 +435,8 @@ public class SCIMUserManager implements UserManager {
         }
     }
 
-    private void handleErrorsOnUserNameAndPasswordPolicy(Throwable e) throws BadRequestException {
+    private void handleErrorsOnUserNameAndPasswordPolicy(Throwable e)
+            throws BadRequestException, CharonException {
 
         int i = 0; // this variable is used to avoid endless loop if the e.getCause never becomes null.
         while (e != null && i < 10) {
@@ -463,6 +465,11 @@ public class SCIMUserManager implements UserManager {
                         (ERROR_CODE_EMAIL_DOMAIN_ASSOCIATED_WITH_DIFFERENT_ORGANIZATION.getCode())) ||
                         StringUtils.equals(errorCode, ERROR_CODE_EMAIL_DOMAIN_NOT_MAPPED_TO_ORGANIZATION.getCode())) {
                     throw new BadRequestException(e.getMessage(), ResponseCodeConstants.INVALID_VALUE);
+                }
+                if (StringUtils.equals(errorCode, ERROR_CODE_LOADING_PASSWORD_POLICY_CLASSES.getCode())) {
+                    String message = "Error occurred while loading Password Policies. The configured password-pattern " +
+                            "regex is invalid. Please verify and correct your regex syntax.";
+                    throw new CharonException(message);
                 }
             }
             e = e.getCause();


### PR DESCRIPTION
### Purpose

This PR improves the SCIM user‐creation flow to show a clear error whenever the configured password-pattern regex is malformed. Instead of continuing silently or returning `202 Accepted`, `500 Internal Server Error` with a detailed error message is thrown as soon as the loading password policies error code is encountered.

```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Error occurred while loading Password Policies: the configured password-pattern regex is invalid. Please verify and correct your regex syntax.",
    "status": "500"
}
```

### Related Issues
- https://github.com/wso2/product-is/issues/23943

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/955
