### PR TITLE
Support ne operation for user's filtering

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1520,7 +1520,8 @@ public class SCIMUserManager implements UserManager {
                     node.getValue()));
         }
         // Check whether the filter operation is supported by the users endpoint.
-        if (isFilteringNotSupported(node.getOperation())) {
+        if (isFilteringNotSupported(node.getOperation()) &&
+                !node.getOperation().equalsIgnoreCase(SCIMCommonConstants.NE)) {
             String errorMessage =
                     "Filter operation: " + node.getOperation() + " is not supported for filtering in users endpoint.";
             throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_FILTER);
@@ -2401,6 +2402,8 @@ public class SCIMUserManager implements UserManager {
                 conditionOperation = ExpressionOperation.GE.toString();
             } else if (SCIMCommonConstants.LE.equals(operation)) {
                 conditionOperation = ExpressionOperation.LE.toString();
+            } else if (SCIMCommonConstants.NE.equals(operation)) {
+                conditionOperation = ExpressionOperation.NE.toString();
             } else {
                 conditionOperation = operation;
             }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -831,6 +831,15 @@ public class SCIMUserManagerTest {
         testUser2.setUserStoreDomain("PRIMARY");
         users.add(testUser2);
 
+        org.wso2.carbon.user.core.common.User testUser3 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
+                .toString(), "testUser3", "testUser3");
+        Map<String, String> testUser3Attributes = new HashMap<>();
+        testUser3Attributes.put("http://wso2.org/claims/givenname", "testNewUser");
+        testUser3Attributes.put("http://wso2.org/claims/emailaddress", "testUser3@wso2.com");
+        testUser3.setAttributes(testUser3Attributes);
+        testUser3.setUserStoreDomain("PRIMARY");
+        users.add(testUser3);
+
         return new Object[][]{
 
                 {users, "name.givenName eq testUser", 2,
@@ -841,6 +850,24 @@ public class SCIMUserManagerTest {
                 {users, "name.givenName eq testUser and emails eq testUser1@wso2.com", 1,
                         new ArrayList<org.wso2.carbon.user.core.common.User>() {{
                             add(testUser1);
+                        }}},
+                {users, "name.givenName ne testUser", 1,
+                        new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser3);
+                        }}},
+                {users, "userName ne testUser1", 2,
+                        new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2);
+                            add(testUser3);
+                        }}},
+                {users, "name.givenName ne testNewUser and emails ne testUser1@wso2.com", 1,
+                        new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2);
+                        }}},
+                // 'testUser1' is assumed to be part of the admin group.
+                {users, "groups ne admin", 2,
+                        new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
                         }}}
         };
     }
@@ -870,9 +897,17 @@ public class SCIMUserManagerTest {
 
         mockedUserStoreManager = mock(AbstractUserStoreManager.class);
 
-        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), anyInt(),
+        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(), eq(count),
                 anyInt(), nullable(String.class), nullable(String.class)))
                 .thenReturn(filteredUsersWithPagination.getFilteredUsers());
+
+        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(),
+                eq(configuredMaxLimit), anyInt(), nullable(String.class), nullable(String.class)))
+                .thenReturn(filteredUsersWithoutPagination.getFilteredUsers());
+
+        when(mockedUserStoreManager.getUserListWithID(any(Condition.class), anyString(), anyString(),
+                eq(Integer.MAX_VALUE), anyInt(), nullable(String.class), nullable(String.class)))
+                .thenReturn(filteredUsersWithoutPagination.getFilteredUsers());
 
         when(mockedUserStoreManager.getPaginatedUserListWithID(any(Condition.class), anyString(), anyString(), eq(count),
                 anyInt(), nullable(String.class), nullable(String.class))).thenReturn(filteredUsersWithPagination);
@@ -1126,7 +1161,103 @@ public class SCIMUserManagerTest {
                             add(testUser5);
                         }}),
                         false, false, "SECONDARY", 1, 4, 1, 2},
-
+                {users, "userName ne testUser1",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        true,  false, "PRIMARY",  2, 4, 2, 4},
+                {users, "userName ne testUser1",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        false, false, "PRIMARY",  2, 4, 2, 2},
+                {users, "userName ne testUser1",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        true,  false, "SECONDARY", 2, 4, 2, 4},
+                {users, "userName ne testUser1",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        true,  true,  "SECONDARY", 2, 4, 2, 4},
+                {users, "name.givenName ne testUser",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4); add(testUser5);
+                        }}),
+                        true,  false, "PRIMARY",  1, 4, 1, 2},
+                {users, "name.givenName ne testUser",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4); add(testUser5);
+                        }}),
+                        false, false, "PRIMARY",  1, 4, 1, 1},
+                {users, "userName ne testUser1 and name.givenName ne testUser",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4); add(testUser5);
+                        }}),
+                        true,  false, "PRIMARY",  1, 4, 1, 2},
+                {users, "userName ne testUser1 and name.givenName ne testUser",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser4); add(testUser5);
+                        }}),
+                        false, false, "PRIMARY",  1, 4, 1, 1},
+                // 'testUser1' is assumed to be part of the admin group.
+                {users, "groups ne admin",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        true,  false, "PRIMARY",  2, 4, 2, 4},
+                {users, "groups ne admin",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser1); add(testUser2);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        false, false, "PRIMARY",  2, 4, 2, 2},
+                {users, "groups ne admin",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        true,  false, "SECONDARY", 2, 4, 2, 4},
+                {users, "groups ne admin",
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3);
+                        }}),
+                        new PaginatedUserResponse(new ArrayList<org.wso2.carbon.user.core.common.User>() {{
+                            add(testUser2); add(testUser3); add(testUser4); add(testUser5);
+                        }}),
+                        true,  true,  "SECONDARY", 2, 4, 2, 4},
         };
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.10.47</carbon.kernel.version>
+        <carbon.kernel.version>4.10.55</carbon.kernel.version>
         <identity.framework.version>7.8.114</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
### Purpose 
- $Subject
- With this PR Ne filering operation is supported only for the user's filtering(`scim2/Users`), for the group's filtering (`scim2/Groups`) a `400 Bad Request` response is returned.
<img width="1241" alt="Screenshot 2025-05-27 at 10 06 56" src="https://github.com/user-attachments/assets/2b2634c9-da1e-4dc3-ad70-c5021bcc0362" />
 

### To be merged after
- https://github.com/wso2/carbon-kernel/pull/4305
- https://github.com/wso2-extensions/identity-governance/pull/957