### PR TITLE
Support canonical values for SCIM schema response

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpStatus;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
@@ -6215,6 +6216,11 @@ public class SCIMUserManager implements UserManager {
             if (mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY) != null) {
                 attribute.addAttributeProperty(SUPPORTED_BY_DEFAULT_PROPERTY,
                         mappedLocalClaim.getClaimProperty(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY));
+            }
+            if (StringUtils.isNotEmpty(mappedLocalClaim.getClaimProperty(ClaimConstants.CANONICAL_VALUES_PROPERTY))) {
+                JSONArray canonicalValues =
+                        new JSONArray(mappedLocalClaim.getClaimProperty(ClaimConstants.CANONICAL_VALUES_PROPERTY));
+                attribute.addAttributeJSONPropertyArray(ClaimConstants.CANONICAL_VALUES_PROPERTY, canonicalValues);
             }
 
             // Add attribute profile properties.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6220,7 +6220,7 @@ public class SCIMUserManager implements UserManager {
             if (StringUtils.isNotEmpty(mappedLocalClaim.getClaimProperty(ClaimConstants.CANONICAL_VALUES_PROPERTY))) {
                 JSONArray canonicalValues =
                         new JSONArray(mappedLocalClaim.getClaimProperty(ClaimConstants.CANONICAL_VALUES_PROPERTY));
-                attribute.addAttributeJSONPropertyArray(ClaimConstants.CANONICAL_VALUES_PROPERTY, canonicalValues);
+                attribute.addAttributeJSONArray(ClaimConstants.CANONICAL_VALUES_PROPERTY, canonicalValues);
             }
 
             // Add attribute profile properties.

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1391,9 +1391,6 @@ public class SCIMUserManagerTest {
                 .thenReturn(localClaimMap);
         scimCommonUtils.when(SCIMCommonUtils::isUserExtensionEnabled).thenReturn(true);
 
-        SCIMUserSchemaExtensionBuilder sb = spy(new SCIMUserSchemaExtensionBuilder());
-        scimUserSchemaExtensionBuilder.when(SCIMUserSchemaExtensionBuilder::getInstance).thenReturn(sb);
-        when(sb.getExtensionSchema()).thenReturn(mockedSCIMAttributeSchema);
         when(mockedSCIMAttributeSchema.getSubAttributeSchema(anyString())).thenReturn(mockedAttributeSchema);
         when(mockedAttributeSchema.getType()).thenReturn(SCIMDefinitions.DataType.STRING);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.scim2.common.impl;
 
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -1347,6 +1348,61 @@ public class SCIMUserManagerTest {
         SCIMUserManager userManager = new SCIMUserManager(mockedUserStoreManager, mockClaimMetadataManagementService,
                 MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertEquals(userManager.getEnterpriseUserSchema().size(), 2);
+    }
+
+    @Test
+    public void testGetSystemUserSchema() throws Exception {
+
+        JSONArray canonicalValues = new JSONArray();
+
+        JSONObject localUser = new JSONObject();
+        localUser.put("value", "LOCAL");
+        localUser.put("displayValue", "Local User");
+
+        JSONObject federatedUser = new JSONObject();
+        federatedUser.put("value", "FEDERATED");
+        federatedUser.put("displayValue", "Federated User");
+
+        canonicalValues.put(localUser);
+        canonicalValues.put(federatedUser);
+
+        Map<String, String> properties = new HashMap<String, String>() {{
+            put("ReadOnly", "true");
+            put("SupportedByDefault", "true");
+            put("Description", "sample");
+            put("Required", "true");
+            put("DataType", "Integer");
+            put("canonicalValues", canonicalValues.toString());
+        }};
+
+        List<LocalClaim> localClaimMap = new ArrayList<LocalClaim>() {{
+            add(new LocalClaim("userType", new ArrayList<>(), properties));
+        }};
+        List<ExternalClaim> externalClaimMap = new ArrayList<ExternalClaim>() {{
+            add(new ExternalClaim(SCIMCommonConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT,
+                    SCIMCommonConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT + ":userType",
+                    "userType"));
+        }};
+
+        when(mockClaimMetadataManagementService
+                .getExternalClaims(SCIMCommonConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT,
+                        MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).thenReturn(externalClaimMap);
+        when(mockClaimMetadataManagementService.getLocalClaims(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(localClaimMap);
+        scimCommonUtils.when(SCIMCommonUtils::isUserExtensionEnabled).thenReturn(true);
+
+        SCIMUserSchemaExtensionBuilder sb = spy(new SCIMUserSchemaExtensionBuilder());
+        scimUserSchemaExtensionBuilder.when(SCIMUserSchemaExtensionBuilder::getInstance).thenReturn(sb);
+        when(sb.getExtensionSchema()).thenReturn(mockedSCIMAttributeSchema);
+        when(mockedSCIMAttributeSchema.getSubAttributeSchema(anyString())).thenReturn(mockedAttributeSchema);
+        when(mockedAttributeSchema.getType()).thenReturn(SCIMDefinitions.DataType.STRING);
+
+        SCIMUserManager userManager = new SCIMUserManager(mockedUserStoreManager, mockClaimMetadataManagementService,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        List<Attribute> systemSchema = userManager.getSystemUserSchema();
+        assertEquals(systemSchema.size(), 1);
+        JSONObject jsonObject = systemSchema.get(0).getAttributeJSONArray("canonicalValues").getJSONObject(0);
+        assertEquals(jsonObject.get("displayValue"), canonicalValues.getJSONObject(0).get("displayValue"));
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1391,9 +1391,6 @@ public class SCIMUserManagerTest {
                 .thenReturn(localClaimMap);
         scimCommonUtils.when(SCIMCommonUtils::isUserExtensionEnabled).thenReturn(true);
 
-        when(mockedSCIMAttributeSchema.getSubAttributeSchema(anyString())).thenReturn(mockedAttributeSchema);
-        when(mockedAttributeSchema.getType()).thenReturn(SCIMDefinitions.DataType.STRING);
-
         SCIMUserManager userManager = new SCIMUserManager(mockedUserStoreManager, mockClaimMetadataManagementService,
                 MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         List<Attribute> systemSchema = userManager.getSystemUserSchema();

--- a/pom.xml
+++ b/pom.xml
@@ -305,11 +305,11 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.47</carbon.kernel.version>
-        <identity.framework.version>7.8.138</identity.framework.version>
+        <identity.framework.version>7.8.150</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>4.0.36</charon.version>
+        <charon.version>4.0.45</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.76
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.handler.event.account.lock.version>1.8.13

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>4.0.45</charon.version>
+        <charon.version>4.0.45-SNAPSHOT</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.76
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.handler.event.account.lock.version>1.8.13

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>4.0.45-SNAPSHOT</charon.version>
+        <charon.version>4.0.46</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.76
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.handler.event.account.lock.version>1.8.13


### PR DESCRIPTION
### Related Issues
- https://github.com/wso2/product-is/issues/24049

### Depends on
- https://github.com/wso2/charon/pull/433
- https://github.com/wso2/carbon-identity-framework/pull/6753

```
{
    "displayName": "Account Type",
    "displayOrder": "20",
    "profiles": {
        "console": {
            "supportedByDefault": true
        }
    },
    "sharedProfileValueResolvingMethod": "FromOrigin",
    "type": "STRING",
    "required": false,
    "uniqueness": "NONE",
    "name": "account_type",
    "canonicalValues": [
        {
            "value": "SVA",
            "displayValue": "SAVINGS Account"
        },
        {
            "value": "CA",
            "displayValue": "CURRENT Account"
        },
        {
            "value": "FD",
            "displayValue": "FIXED Deposit"
        }
    ],
    "supportedByDefault": "false",
    "mutability": "READ_WRITE",
    "multiValued": false,
    "caseExact": false,
    "returned": "DEFAULT"
}
```