### PR TITLE
Add targeted debug logs for user attribute updates in SCIMUserManager

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1137,6 +1137,11 @@ public class SCIMUserManager implements UserManager {
                 isExistingUser = carbonUM.isExistingUser(user.getUserName());
             }
 
+            if (log.isDebugEnabled()) {
+                log.debug("User existence check for user: " + user.getUserName() +
+                        ", exists: " + isExistingUser);
+            }
+
             if (!isExistingUser) {
                 throw new CharonException("User name is immutable in carbon user store.");
             }
@@ -1165,6 +1170,9 @@ public class SCIMUserManager implements UserManager {
             claims.remove(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI);
 
             Map<String, String> scimToLocalClaimsMap = SCIMCommonUtils.getSCIMtoLocalMappings();
+            if (log.isDebugEnabled() && MapUtils.isEmpty(scimToLocalClaimsMap)) {
+                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getUserName());
+            }
             List<String> requiredClaims = getOnlyRequiredClaims(scimToLocalClaimsMap.keySet(), requiredAttributes);
             List<String> requiredClaimsInLocalDialect;
             if (MapUtils.isNotEmpty(scimToLocalClaimsMap)) {
@@ -5495,6 +5503,13 @@ public class SCIMUserManager implements UserManager {
         userClaimsToBeModified.putAll(userClaimsToBeAdded);
 
         preUpdateProfileActionExecutor.execute(user, userClaimsToBeModified, userClaimsToBeDeleted);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(
+                    "Updating user claims for user '%s'. Claims to be added: %s, to be deleted: %s, to be modified: %s",
+                    user.getUserName(), userClaimsToBeAdded.keySet(), userClaimsToBeDeleted.keySet(),
+                    userClaimsToBeModified.keySet()));
+        }
 
         // Remove user claims.
         for (Map.Entry<String, String> entry : userClaimsToBeDeleted.entrySet()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1138,7 +1138,7 @@ public class SCIMUserManager implements UserManager {
             }
 
             if (log.isDebugEnabled()) {
-                log.debug("User existence check for user: " + user.getUserName() +
+                log.debug("User existence check for userID: " + user.getId() +
                         ", exists: " + isExistingUser);
             }
 
@@ -1171,7 +1171,7 @@ public class SCIMUserManager implements UserManager {
 
             Map<String, String> scimToLocalClaimsMap = SCIMCommonUtils.getSCIMtoLocalMappings();
             if (log.isDebugEnabled() && MapUtils.isEmpty(scimToLocalClaimsMap)) {
-                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getId());
+                log.debug("SCIM to Local Claim mappings list is empty for userID: " + user.getId());
             }
             List<String> requiredClaims = getOnlyRequiredClaims(scimToLocalClaimsMap.keySet(), requiredAttributes);
             List<String> requiredClaimsInLocalDialect;
@@ -1361,7 +1361,7 @@ public class SCIMUserManager implements UserManager {
 
             Map<String, String> scimToLocalClaimsMap = SCIMCommonUtils.getSCIMtoLocalMappings();
             if (log.isDebugEnabled() && MapUtils.isEmpty(scimToLocalClaimsMap)) {
-                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getId());
+                log.debug("SCIM to Local Claim mappings list is empty for userID: " + user.getId());
             }
             List<String> requiredClaims = getOnlyRequiredClaims(scimToLocalClaimsMap.keySet(), requiredAttributes);
             List<String> requiredClaimsInLocalDialect;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1171,7 +1171,7 @@ public class SCIMUserManager implements UserManager {
 
             Map<String, String> scimToLocalClaimsMap = SCIMCommonUtils.getSCIMtoLocalMappings();
             if (log.isDebugEnabled() && MapUtils.isEmpty(scimToLocalClaimsMap)) {
-                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getUserName());
+                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getId());
             }
             List<String> requiredClaims = getOnlyRequiredClaims(scimToLocalClaimsMap.keySet(), requiredAttributes);
             List<String> requiredClaimsInLocalDialect;
@@ -1361,7 +1361,7 @@ public class SCIMUserManager implements UserManager {
 
             Map<String, String> scimToLocalClaimsMap = SCIMCommonUtils.getSCIMtoLocalMappings();
             if (log.isDebugEnabled() && MapUtils.isEmpty(scimToLocalClaimsMap)) {
-                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getUserName());
+                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getId());
             }
             List<String> requiredClaims = getOnlyRequiredClaims(scimToLocalClaimsMap.keySet(), requiredAttributes);
             List<String> requiredClaimsInLocalDialect;
@@ -5510,7 +5510,7 @@ public class SCIMUserManager implements UserManager {
         if (log.isDebugEnabled()) {
             log.debug(String.format(
                     "Updating user claims for user '%s'. Claims to be added: %s, to be deleted: %s, to be modified: %s",
-                    user.getUserName(), userClaimsToBeAdded.keySet(), userClaimsToBeDeleted.keySet(),
+                    user.getId(), userClaimsToBeAdded.keySet(), userClaimsToBeDeleted.keySet(),
                     userClaimsToBeModified.keySet()));
         }
 
@@ -5610,6 +5610,13 @@ public class SCIMUserManager implements UserManager {
         preUpdateProfileActionExecutor.execute(user, userClaimsToBeModified, userClaimsToBeDeleted,
                 simpleMultiValuedClaimsToBeAdded,
                 simpleMultiValuedClaimsToBeRemoved, oldClaimList);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(
+                    "Updating user claims for user '%s'. Claims to be added: %s, to be deleted: %s, to be modified: %s",
+                    user.getId(), userClaimsToBeAdded.keySet(), userClaimsToBeDeleted.keySet(),
+                    userClaimsToBeModified.keySet()));
+        }
 
         // Remove user claims.
         for (Map.Entry<String, String> entry : userClaimsToBeDeleted.entrySet()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1360,6 +1360,9 @@ public class SCIMUserManager implements UserManager {
             claims.remove(SCIMConstants.CommonSchemaConstants.RESOURCE_TYPE_URI);
 
             Map<String, String> scimToLocalClaimsMap = SCIMCommonUtils.getSCIMtoLocalMappings();
+            if (log.isDebugEnabled() && MapUtils.isEmpty(scimToLocalClaimsMap)) {
+                log.debug("SCIM to Local Claim mappings list is empty for user: " + user.getUserName());
+            }
             List<String> requiredClaims = getOnlyRequiredClaims(scimToLocalClaimsMap.keySet(), requiredAttributes);
             List<String> requiredClaimsInLocalDialect;
             if (MapUtils.isNotEmpty(scimToLocalClaimsMap)) {


### PR DESCRIPTION
### Purpose
To improve traceability of user attribute updates in the `SCIMUserManager` class by adding targeted debug logs for key operations, reducing the need for manual log patches.

### Goals

* Provide clearer context for user attribute updates.
* Improve traceability of user existence checks.
* Capture potential configuration issues in SCIM to Local claim mappings.
* Minimize unnecessary log clutter by focusing on critical checkpoints.

### Approach

* **User Existence Check:** Added a debug log to indicate the result of the user existence check.
* **Password Update Block:** Logged password update attempts without revealing sensitive information.
* **Claim Mapping Check:** Added a log to indicate if the SCIM to Local claim mapping list is unexpectedly empty.

## Related Issues
public issue: https://github.com/wso2/product-is/issues/23923
asgardeo issue: https://github.com/wso2-enterprise/asgardeo-product/issues/30830