### PR TITLE
Provide the complex multi valued filtering without any configuration to disable that support

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -2304,7 +2304,7 @@ public class SCIMUserManager implements UserManager {
         int totalResults = 0;
         PaginatedUserResponse paginatedUserResult;
 
-        if (limit == 0) {
+        if (limit <= 0) {
           limit = getMaxLimit(domainName);
         }
         paginatedUserResult = getMultiAttributeFilteredUsersWithMaxLimit(node, offset, sortBy, sortOrder, domainName,


### PR DESCRIPTION
$subject

The identity & non-identity claim filtering performance has been improved recently. Previous implementation cause to delay the response time for number of minutes. As the performance is improved, we don't required to disable the filtering capability.

### Related Issues
- https://github.com/wso2/product-is/issues/24190