### PR TITLE
Add Fine-Grained Scope Validation for SCIM2 Bulk API

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -101,10 +101,11 @@ public class SCIMRoleManager implements RoleManager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_create") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_create"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }
@@ -206,10 +207,11 @@ public class SCIMRoleManager implements RoleManager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_delete") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_delete"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }
@@ -402,10 +404,11 @@ public class SCIMRoleManager implements RoleManager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_update") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_update"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }
@@ -593,10 +596,11 @@ public class SCIMRoleManager implements RoleManager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_update") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_update"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -390,7 +390,6 @@ public class SCIMRoleManager implements RoleManager {
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
         if (SCIMCommonUtils.isBulkRequest()) {
-
             SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
                     "internal_bulk_resource_create", "internal_bulk_role_update",
                     "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));
@@ -577,7 +576,6 @@ public class SCIMRoleManager implements RoleManager {
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
         if (SCIMCommonUtils.isBulkRequest()) {
-
             SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
                     "internal_bulk_resource_create", "internal_bulk_role_update",
                     "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -98,16 +98,10 @@ public class SCIMRoleManager implements RoleManager {
     public Role createRole(Role role) throws CharonException, ConflictException,
             BadRequestException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
-
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_create") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_create"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+        if (SCIMCommonUtils.isBulkRequest()) {
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_create",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_create"));
         }
 
         if (log.isDebugEnabled()) {
@@ -204,16 +198,10 @@ public class SCIMRoleManager implements RoleManager {
     public void deleteRole(String roleID) throws CharonException, NotFoundException,
             BadRequestException, ForbiddenException{
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
-
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_delete") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_delete"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+        if (SCIMCommonUtils.isBulkRequest()) {
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_delete",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_delete"));
         }
 
         try {
@@ -401,16 +389,11 @@ public class SCIMRoleManager implements RoleManager {
     public Role updateRole(Role oldRole, Role newRole)
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
+        if (SCIMCommonUtils.isBulkRequest()) {
 
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_update") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_update"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_update",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));
         }
 
         doUpdateRoleName(oldRole, newRole);
@@ -593,16 +576,11 @@ public class SCIMRoleManager implements RoleManager {
     public Role patchRole(String roleId, Map<String, List<PatchOperation>> patchOperations)
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
+        if (SCIMCommonUtils.isBulkRequest()) {
 
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_update") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_update"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_update",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));
         }
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManager.java
@@ -95,7 +95,19 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     @Override
-    public Role createRole(Role role) throws CharonException, ConflictException, BadRequestException {
+    public Role createRole(Role role) throws CharonException, ConflictException,
+            BadRequestException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_create") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_create"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         if (log.isDebugEnabled()) {
             log.debug("Creating role: " + role.getDisplayName());
@@ -188,7 +200,19 @@ public class SCIMRoleManager implements RoleManager {
     }
 
     @Override
-    public void deleteRole(String roleID) throws CharonException, NotFoundException, BadRequestException {
+    public void deleteRole(String roleID) throws CharonException, NotFoundException,
+            BadRequestException, ForbiddenException{
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_delete") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_delete"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         try {
             roleManagementService.deleteRole(roleID, tenantDomain);
@@ -373,7 +397,18 @@ public class SCIMRoleManager implements RoleManager {
 
     @Override
     public Role updateRole(Role oldRole, Role newRole)
-            throws BadRequestException, CharonException, ConflictException, NotFoundException {
+            throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_update") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_update"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         doUpdateRoleName(oldRole, newRole);
         doUpdateUsers(oldRole, newRole);
@@ -554,6 +589,17 @@ public class SCIMRoleManager implements RoleManager {
     @Override
     public Role patchRole(String roleId, Map<String, List<PatchOperation>> patchOperations)
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_update") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_update"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -127,13 +127,14 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_create") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_create") ||
                         authorizedScopes.contains("internal_org_role_mgt_create") ||
                         authorizedScopes.contains("internal_org_bulk_resource_create") ||
                         authorizedScopes.contains("internal_org_bulk_role_create"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }
@@ -376,13 +377,14 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_delete") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_delete") ||
                         authorizedScopes.contains("internal_org_role_mgt_delete") ||
                         authorizedScopes.contains("internal_org_bulk_resource_create") ||
                         authorizedScopes.contains("internal_org_bulk_role_delete"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }
@@ -435,13 +437,14 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_update") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
                         authorizedScopes.contains("internal_bulk_role_update") ||
                         authorizedScopes.contains("internal_org_role_mgt_update") ||
                         authorizedScopes.contains("internal_org_bulk_resource_create") ||
                         authorizedScopes.contains("internal_org_bulk_role_update"))) {
+
             throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
                     " make this request..");
         }
@@ -467,15 +470,16 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_role_mgt_update") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_update") ||
-                        authorizedScopes.contains("internal_org_role_mgt_update") ||
-                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_org_bulk_role_update"))) {
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+                    authorizedScopes.contains("internal_bulk_resource_create") ||
+                    authorizedScopes.contains("internal_bulk_role_update") ||
+                    authorizedScopes.contains("internal_org_role_mgt_update") ||
+                    authorizedScopes.contains("internal_org_bulk_resource_create") ||
+                    authorizedScopes.contains("internal_org_bulk_role_update"))) {
+
+                throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                        " make this request..");
         }
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -122,7 +122,21 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
     }
 
     public RoleV2 createRole(RoleV2 role)
-            throws CharonException, ConflictException, NotImplementedException, BadRequestException {
+            throws CharonException, ConflictException, NotImplementedException, BadRequestException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_create") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_create") ||
+                        authorizedScopes.contains("internal_org_role_mgt_create") ||
+                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_org_bulk_role_create"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         try {
             // Check if the role already exists.
@@ -356,7 +370,22 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
         return rolePropertyValues;
     }
 
-    public void deleteRole(String roleID) throws CharonException, NotFoundException, BadRequestException {
+    public void deleteRole(String roleID) throws CharonException, NotFoundException,
+            BadRequestException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_delete") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_delete") ||
+                        authorizedScopes.contains("internal_org_role_mgt_delete") ||
+                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_org_bulk_role_delete"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         try {
             if (isSharedRole(roleID)) {
@@ -401,7 +430,21 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
 
     @Override
     public RoleV2 updateRole(RoleV2 oldRole, RoleV2 newRole)
-            throws BadRequestException, CharonException, ConflictException, NotFoundException {
+            throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_update") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_update") ||
+                        authorizedScopes.contains("internal_org_role_mgt_update") ||
+                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_org_bulk_role_update"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         doUpdateRoleName(oldRole, newRole);
         doUpdateUsers(oldRole, newRole);
@@ -420,6 +463,20 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
     @Override
     public RoleV2 patchRole(String roleId, Map<String, List<PatchOperation>> patchOperations)
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_role_mgt_update") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_bulk_role_update") ||
+                        authorizedScopes.contains("internal_org_role_mgt_update") ||
+                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_org_bulk_role_update"))) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                    " make this request..");
+        }
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);
         if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -126,7 +126,6 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             BadRequestException, ForbiddenException {
 
         if (SCIMCommonUtils.isBulkRequest()) {
-
             SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
                     "internal_bulk_resource_create", "internal_bulk_role_create",
                     "internal_org_bulk_resource_create", "internal_org_bulk_role_create"));
@@ -419,7 +418,6 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
         if (SCIMCommonUtils.isBulkRequest()) {
-
             SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
                     "internal_bulk_resource_create", "internal_bulk_role_update",
                     "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));
@@ -444,7 +442,6 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
         if (SCIMCommonUtils.isBulkRequest()) {
-
             SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
                     "internal_bulk_resource_create", "internal_bulk_role_update",
                     "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -122,21 +122,14 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
     }
 
     public RoleV2 createRole(RoleV2 role)
-            throws CharonException, ConflictException, NotImplementedException, BadRequestException, ForbiddenException {
+            throws CharonException, ConflictException, NotImplementedException,
+            BadRequestException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
+        if (SCIMCommonUtils.isBulkRequest()) {
 
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_create") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_create") ||
-                        authorizedScopes.contains("internal_org_role_mgt_create") ||
-                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_org_bulk_role_create"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_create",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_create"));
         }
 
         try {
@@ -374,19 +367,10 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
     public void deleteRole(String roleID) throws CharonException, NotFoundException,
             BadRequestException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
-
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_delete") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_delete") ||
-                        authorizedScopes.contains("internal_org_role_mgt_delete") ||
-                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_org_bulk_role_delete"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+        if (SCIMCommonUtils.isBulkRequest()) {
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_delete",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_delete"));
         }
 
         try {
@@ -434,19 +418,11 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
     public RoleV2 updateRole(RoleV2 oldRole, RoleV2 newRole)
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
+        if (SCIMCommonUtils.isBulkRequest()) {
 
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_update") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_bulk_role_update") ||
-                        authorizedScopes.contains("internal_org_role_mgt_update") ||
-                        authorizedScopes.contains("internal_org_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_org_bulk_role_update"))) {
-
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                    " make this request..");
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_update",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));
         }
 
         doUpdateRoleName(oldRole, newRole);
@@ -467,19 +443,11 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
     public RoleV2 patchRole(String roleId, Map<String, List<PatchOperation>> patchOperations)
             throws BadRequestException, CharonException, ConflictException, NotFoundException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
+        if (SCIMCommonUtils.isBulkRequest()) {
 
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_role_mgt_update") ||
-                    authorizedScopes.contains("internal_bulk_resource_create") ||
-                    authorizedScopes.contains("internal_bulk_role_update") ||
-                    authorizedScopes.contains("internal_org_role_mgt_update") ||
-                    authorizedScopes.contains("internal_org_bulk_resource_create") ||
-                    authorizedScopes.contains("internal_org_bulk_role_update"))) {
-
-                throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                        " make this request..");
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList(
+                    "internal_bulk_resource_create", "internal_bulk_role_update",
+                    "internal_org_bulk_resource_create", "internal_org_bulk_role_update"));
         }
 
         String currentRoleName = getCurrentRoleName(roleId, tenantDomain);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -224,18 +224,11 @@ public class SCIMUserManager implements UserManager {
     public User createUser(User user, Map<String, Boolean> requiredAttributes)
             throws CharonException, ConflictException, BadRequestException, ForbiddenException {
 
-        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                SCIMCommonConstants.AUTHORIZED_SCOPES);
+        if (SCIMCommonUtils.isBulkRequest()) {
 
-        if (authorizedScopes != null &&
-                !(authorizedScopes.contains("internal_user_mgt_create") ||
-                        authorizedScopes.contains("internal_bulk_user_create") ||
-                        authorizedScopes.contains("internal_bulk_resource_create") ||
-                        authorizedScopes.contains("internal_org_user_mgt_create") ||
-                        authorizedScopes.contains("internal_org_bulk_user_create") ||
-                        authorizedScopes.contains("internal_org_bulk_resource_create")  )) {
-            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                            " make this request..");
+            SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList("internal_bulk_user_create",
+                    "internal_bulk_resource_create", "internal_org_bulk_user_create",
+                    "internal_org_bulk_resource_create"));
         }
 
         String userStoreName = null;
@@ -3709,19 +3702,10 @@ public class SCIMUserManager implements UserManager {
             Set<Object> deletedMemberIds = new HashSet<>();
 
             if (CollectionUtils.isNotEmpty(memberOperations)){
-
-                List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
-                        SCIMCommonConstants.AUTHORIZED_SCOPES);
-
-                if (authorizedScopes != null &&
-                        !(authorizedScopes.contains("internal_group_mgt_update") ||
-                                authorizedScopes.contains("internal_bulk_resource_create") ||
-                                authorizedScopes.contains("internal_bulk_group_update") ||
-                                authorizedScopes.contains("internal_org_group_mgt_update") ||
-                                authorizedScopes.contains("internal_org_bulk_resource_create") ||
-                                authorizedScopes.contains("internal_org_bulk_group_update") )) {
-                    throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
-                            " make this request..");
+                if (SCIMCommonUtils.isBulkRequest()) {
+                    SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList("internal_bulk_resource_create",
+                            "internal_bulk_group_update", "internal_org_bulk_resource_create",
+                            "internal_org_bulk_group_update"));
                 }
             }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -225,7 +225,6 @@ public class SCIMUserManager implements UserManager {
             throws CharonException, ConflictException, BadRequestException, ForbiddenException {
 
         if (SCIMCommonUtils.isBulkRequest()) {
-
             SCIMCommonUtils.validateAuthorizedScopes(Arrays.asList("internal_bulk_user_create",
                     "internal_bulk_resource_create", "internal_org_bulk_user_create",
                     "internal_org_bulk_resource_create"));

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -224,6 +224,20 @@ public class SCIMUserManager implements UserManager {
     public User createUser(User user, Map<String, Boolean> requiredAttributes)
             throws CharonException, ConflictException, BadRequestException, ForbiddenException {
 
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes == null ||
+                !(authorizedScopes.contains("internal_user_mgt_create") ||
+                        authorizedScopes.contains("internal_bulk_user_create") ||
+                        authorizedScopes.contains("internal_bulk_resource_create") ||
+                        authorizedScopes.contains("internal_org_user_mgt_create") ||
+                        authorizedScopes.contains("internal_org_bulk_user_create") ||
+                        authorizedScopes.contains("internal_org_bulk_resource_create")  )) {
+            throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                            " make this request..");
+        }
+
         String userStoreName = null;
         try {
             String userStoreDomainFromSP = getUserStoreDomainFromSP();
@@ -3643,7 +3657,8 @@ public class SCIMUserManager implements UserManager {
 
     @Override
     public void patchGroup(String groupId, String currentGroupName, Map<String, List<PatchOperation>> patchOperations)
-            throws NotImplementedException, BadRequestException, CharonException, NotFoundException {
+            throws NotImplementedException, BadRequestException, CharonException,
+            NotFoundException, ForbiddenException {
 
         doPatchGroup(groupId, currentGroupName, patchOperations);
     }
@@ -3651,14 +3666,15 @@ public class SCIMUserManager implements UserManager {
     @Override
     public Group patchGroup(String groupId, String currentGroupName, Map<String, List<PatchOperation>> patchOperations,
                             Map<String, Boolean> requiredAttributes) throws NotImplementedException,
-            BadRequestException, CharonException, NotFoundException {
+            BadRequestException, CharonException, NotFoundException, ForbiddenException {
 
         doPatchGroup(groupId, currentGroupName, patchOperations);
         return getGroup(groupId, requiredAttributes);
     }
 
     private void doPatchGroup(String groupId, String currentGroupName, Map<String, List<PatchOperation>> patchOperations) throws
-            NotImplementedException, BadRequestException, CharonException, NotFoundException {
+            NotImplementedException, BadRequestException, CharonException, NotFoundException,
+            ForbiddenException {
 
         if (log.isDebugEnabled()) {
             log.debug("Updating group: " + currentGroupName);
@@ -3691,6 +3707,23 @@ public class SCIMUserManager implements UserManager {
             Set<String> deletedMembers = new HashSet<>();
             Set<Object> newlyAddedMemberIds = new HashSet<>();
             Set<Object> deletedMemberIds = new HashSet<>();
+
+            if (CollectionUtils.isNotEmpty(memberOperations)){
+
+                List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                        SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+                if (authorizedScopes == null ||
+                        !(authorizedScopes.contains("internal_group_mgt_update") ||
+                                authorizedScopes.contains("internal_bulk_resource_create") ||
+                                authorizedScopes.contains("internal_bulk_group_update") ||
+                                authorizedScopes.contains("internal_org_group_mgt_update") ||
+                                authorizedScopes.contains("internal_org_bulk_resource_create") ||
+                                authorizedScopes.contains("internal_org_bulk_group_update") )) {
+                    throw new ForbiddenException("Operation is not permitted. You do not have permissions to" +
+                            " make this request..");
+                }
+            }
 
             for (PatchOperation memberOperation : memberOperations) {
                 if (memberOperation.getValues() instanceof Map) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -227,7 +227,7 @@ public class SCIMUserManager implements UserManager {
         List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                 SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-        if (authorizedScopes == null ||
+        if (authorizedScopes != null &&
                 !(authorizedScopes.contains("internal_user_mgt_create") ||
                         authorizedScopes.contains("internal_bulk_user_create") ||
                         authorizedScopes.contains("internal_bulk_resource_create") ||
@@ -3713,7 +3713,7 @@ public class SCIMUserManager implements UserManager {
                 List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
                         SCIMCommonConstants.AUTHORIZED_SCOPES);
 
-                if (authorizedScopes == null ||
+                if (authorizedScopes != null &&
                         !(authorizedScopes.contains("internal_group_mgt_update") ||
                                 authorizedScopes.contains("internal_bulk_resource_create") ||
                                 authorizedScopes.contains("internal_bulk_group_update") ||

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -40,6 +40,8 @@ public class SCIMCommonConstants {
     public static final String RESOURCE_TYPE = "/ResourceTypes";
     public static final String DEFAULT = "default";
     public static final String AUTHORIZED_SCOPES = "authorizedScopes";
+    public static final String NORMALIZED_REQUEST_URI = "normalizedRequestURI";
+    public static final String BULK_ENDPOINT = "/scim2/Bulk";
 
     public static final int USER = 1;
     public static final int GROUP = 2;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -39,6 +39,7 @@ public class SCIMCommonConstants {
     public static final String SERVICE_PROVIDER_CONFIG = "/ServiceProviderConfig";
     public static final String RESOURCE_TYPE = "/ResourceTypes";
     public static final String DEFAULT = "default";
+    public static final String AUTHORIZED_SCOPES = "authorizedScopes";
 
     public static final int USER = 1;
     public static final int GROUP = 2;

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -53,6 +53,7 @@ import org.wso2.charon3.core.config.SCIMCustomSchemaExtensionBuilder;
 import org.wso2.charon3.core.config.SCIMSystemSchemaExtensionBuilder;
 import org.wso2.charon3.core.config.SCIMUserSchemaExtensionBuilder;
 import org.wso2.charon3.core.exceptions.CharonException;
+import org.wso2.charon3.core.exceptions.ForbiddenException;
 import org.wso2.charon3.core.exceptions.InternalErrorException;
 import org.wso2.charon3.core.schema.AttributeSchema;
 import org.wso2.charon3.core.schema.SCIMConstants;
@@ -1071,5 +1072,29 @@ public class SCIMCommonUtils {
             return true;
         }
         return Boolean.parseBoolean(considerServerWideUserEndpointMaxLimitProperty);
+    }
+
+    public static boolean isBulkRequest() {
+
+        if (IdentityUtil.threadLocalProperties.get().get(SCIMCommonConstants.NORMALIZED_REQUEST_URI) != null) {
+            return IdentityUtil.threadLocalProperties.get()
+                    .get(SCIMCommonConstants.NORMALIZED_REQUEST_URI).toString()
+                    .contains(SCIMCommonConstants.BULK_ENDPOINT);
+        }
+
+        return false;
+    }
+
+    public static void validateAuthorizedScopes(List<String> requiredScopes)
+            throws ForbiddenException {
+
+        List<String> authorizedScopes = (List<String>) IdentityUtil.threadLocalProperties.get().get(
+                SCIMCommonConstants.AUTHORIZED_SCOPES);
+
+        if (authorizedScopes != null &&
+                requiredScopes.stream().noneMatch(authorizedScopes::contains)) {
+            throw new ForbiddenException(
+                    "Operation is not permitted. You do not have permissions to make this request.");
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -650,7 +650,7 @@ public class SCIMRoleManagerTest {
     public void testUpdateRoleUpdateRoleName(String roleId, String oldRoleName, String newRoleName, String tenantDomain,
                                              String type)
             throws IdentityRoleManagementException, BadRequestException, CharonException, ConflictException,
-            NotFoundException {
+            NotFoundException, ForbiddenException {
 
         RoleBasicInfo roleBasicInfo = new RoleBasicInfo(roleId, newRoleName);
         Role[] oldAndNewRoles = getOldAndNewRoleDummies(roleId, oldRoleName, newRoleName, type);
@@ -716,7 +716,7 @@ public class SCIMRoleManagerTest {
     public void testUpdateRoleUpdateRoleNameThrowingErrors(String roleId, String oldRoleName, String newRoleName,
                                                            String tenantDomain, String sError)
             throws IdentityRoleManagementException, BadRequestException, CharonException, ConflictException,
-            NotFoundException {
+            NotFoundException, ForbiddenException {
 
         Role[] oldAndNewRoles = getOldAndNewRoleDummies(roleId, oldRoleName, newRoleName);
 
@@ -769,7 +769,7 @@ public class SCIMRoleManagerTest {
     public void testUpdateRoleUpdateUserListOfRoleThrowingErrors(String roleId, String oldRoleName, String newRoleName,
                                                                  String tenantDomain, String type, String sError)
             throws IdentityRoleManagementException, BadRequestException, CharonException, ConflictException,
-            NotFoundException {
+            NotFoundException, ForbiddenException {
 
         RoleBasicInfo roleBasicInfo = new RoleBasicInfo(roleId, newRoleName);
         Role[] oldAndNewRoles = getOldAndNewRoleDummies(roleId, oldRoleName, newRoleName, type);
@@ -815,7 +815,7 @@ public class SCIMRoleManagerTest {
     public void testUpdateRoleUpdateGroupListOfRoleThrowingErrors(String roleId, String oldRoleName, String newRoleName,
                                                                   String tenantDomain, String type, String sError)
             throws IdentityRoleManagementException, BadRequestException, CharonException, ConflictException,
-            NotFoundException {
+            NotFoundException, ForbiddenException {
 
         RoleBasicInfo roleBasicInfo = new RoleBasicInfo(roleId, newRoleName);
         Role[] oldAndNewRoles = getOldAndNewRoleDummies(roleId, oldRoleName, newRoleName, type);
@@ -862,7 +862,7 @@ public class SCIMRoleManagerTest {
                                                                  String tenantDomain, String permissionType,
                                                                  String sError)
             throws IdentityRoleManagementException, BadRequestException, CharonException,
-            ConflictException, NotFoundException {
+            ConflictException, NotFoundException, ForbiddenException {
 
         RoleBasicInfo roleBasicInfo = new RoleBasicInfo(roleId, newRoleName);
         Role[] oldAndNewRoles = getOldAndNewRoleDummies(roleId, oldRoleName, newRoleName, permissionType);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerTest.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.charon3.core.exceptions.BadRequestException;
 import org.wso2.charon3.core.exceptions.CharonException;
 import org.wso2.charon3.core.exceptions.ConflictException;
+import org.wso2.charon3.core.exceptions.ForbiddenException;
 import org.wso2.charon3.core.exceptions.NotFoundException;
 import org.wso2.charon3.core.exceptions.NotImplementedException;
 import org.wso2.charon3.core.objects.Group;
@@ -236,7 +237,7 @@ public class SCIMRoleManagerTest {
     @Test(dataProvider = "dataProviderForCreateRolePositive")
     public void testCreateRolePositive(String roleId, String roleDisplayName, String tenantDomain)
             throws IdentityRoleManagementException, BadRequestException, CharonException, ConflictException,
-            OrganizationManagementException {
+            OrganizationManagementException, ForbiddenException {
 
         Role role = getDummyRole(roleId, roleDisplayName);
         when(mockRoleManagementService.addRole(nullable(String.class), anyList(), anyList(),
@@ -388,7 +389,8 @@ public class SCIMRoleManagerTest {
 
     @Test(dataProvider = "dataProviderForDeleteRolePositive")
     public void testDeleteRolePositive(String roleId, String tenantDomain)
-            throws IdentityRoleManagementException, NotFoundException, BadRequestException, CharonException {
+            throws IdentityRoleManagementException, NotFoundException, BadRequestException,
+            CharonException, ForbiddenException {
 
         doNothing().when(mockRoleManagementService).deleteRole(roleId, tenantDomain);
         SCIMRoleManager roleManager = new SCIMRoleManager(mockRoleManagementService, tenantDomain);


### PR DESCRIPTION
This PR introduces fine-grained scope validation to the SCIM layer, specifically enhancing access control for bulk operations.  If the request is a bulk operation, the server checks whether the user has the required scope. If the scope is not available, a Forbidden exception is thrown.


Related PR:
- https://github.com/wso2/charon/pull/437