### PR TITLE
Expose input formats from SCIM schemas response

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6291,6 +6291,12 @@ public class SCIMUserManager implements UserManager {
                 attribute.addAttributeJSONArray(ClaimConstants.CANONICAL_VALUES_PROPERTY, canonicalValues);
             }
 
+            if (StringUtils.isNotEmpty(mappedLocalClaim.getClaimProperty(ClaimConstants.INPUT_FORMAT_PROPERTY))) {
+                JSONObject inputFormat =
+                        new JSONObject(mappedLocalClaim.getClaimProperty(ClaimConstants.INPUT_FORMAT_PROPERTY));
+                attribute.addAttributeJSONProperty(ClaimConstants.INPUT_FORMAT_PROPERTY, inputFormat);
+            }
+
             // Add attribute profile properties.
             for (Map.Entry<String, String> entry: mappedLocalClaim.getClaimProperties().entrySet()) {
                 if (StringUtils.startsWith(entry.getKey(), ClaimConstants.PROFILES_CLAIM_PROPERTY_PREFIX)) {

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1504,6 +1504,7 @@ public class SCIMUserManagerTest {
             put("Required", "true");
             put("DataType", "Integer");
             put("canonicalValues", canonicalValues.toString());
+            put("inputFormat", "{\"inputType\" : \"dropdown\"}");
         }};
 
         List<LocalClaim> localClaimMap = new ArrayList<LocalClaim>() {{
@@ -1528,6 +1529,9 @@ public class SCIMUserManagerTest {
         assertEquals(systemSchema.size(), 1);
         JSONObject jsonObject = systemSchema.get(0).getAttributeJSONArray("canonicalValues").getJSONObject(0);
         assertEquals(jsonObject.get("displayValue"), canonicalValues.getJSONObject(0).get("displayValue"));
+
+        jsonObject = systemSchema.get(0).getAttributeJSONProperty("inputFormat");
+        assertEquals(jsonObject.get("inputType"), "dropdown");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.55</carbon.kernel.version>
-        <identity.framework.version>7.8.150</identity.framework.version>
+        <identity.framework.version>7.8.244</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>


### PR DESCRIPTION
## Purpose
> $subject

### Related Issues
- https://github.com/wso2/product-is/issues/24392

The SCIM2 schemas response will have the input formats as shown below.

<img width="404" alt="Screenshot 2025-06-23 at 19 13 31" src="https://github.com/user-attachments/assets/75744f31-8ace-4ca3-a39d-577e296b580a" />
