### PR TITLE
Changed managedOrg claim to a readonly claim

### DIFF
--- a/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
+++ b/features/org.wso2.carbon.identity.scim2.common.feature/resources/scim2-schema-extension.config
@@ -1327,7 +1327,7 @@
 "description":"Organization where the user is managed",
 "required":"false",
 "caseExact":"false",
-"mutability":"readwrite",
+"mutability":"readOnly",
 "returned":"default",
 "uniqueness":"none",
 "subAttributes":"null",


### PR DESCRIPTION
## Purpose
`managedOrg` attribute in `urn:scim:wso2:schema` is used to denote the organization id where the user is managed.
This value will be populated in the shared and invited users to identify their managed organization from the sub org level.

Since this attribute is managed internally, it shouldn't get updated. 
Eventhough currently the attribute modification is validated at the user core level, we need to enforce the validation from the scim level as well.

So this PR will update the scim2-extension-schema.config file to make the mutability of this claim to be `readOnly`

So with this error message shown after trying to update the claim value will be changed as follows,

Previous error
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "The managed organization is a read only property.",
    "status": "400"
}
```
New error
```
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "mutability",
    "detail": "Can not replace a immutable attribute or a read-only attribute",
    "status": "400"
}
```

### Related issue
- https://github.com/wso2/product-is/issues/24832

