### PR TITLE
Add process operations support for profile action

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
@@ -66,13 +66,13 @@ public class PreUpdateProfileActionExecutor {
      * @param userClaimsToBeDeleted  Collection of existing claims that deletes from the profile
      * @throws UserStoreException If an error occurs while executing the action
      */
-    public void execute(User user, Map<String, String> userClaimsToBeModified,
-                        Map<String, String> userClaimsToBeDeleted) throws UserStoreException {
+    public ActionExecutionStatus<?> execute(User user, Map<String, String> userClaimsToBeModified,
+                                                  Map<String, String> userClaimsToBeDeleted) throws UserStoreException {
 
         ActionExecutorService actionExecutorService = SCIMCommonComponentHolder.getActionExecutorService();
 
         if (!actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)) {
-            return;
+            return null;
         }
 
         LOG.debug("Executing pre update profile action for user: " + user.getId());
@@ -89,7 +89,7 @@ public class PreUpdateProfileActionExecutor {
                     actionExecutorService.execute(ActionType.PRE_UPDATE_PROFILE, flowContext,
                             IdentityContext.getThreadLocalIdentityContext().getTenantDomain());
 
-            handleActionExecutionStatus(actionExecutionStatus);
+            return handleActionExecutionStatus(actionExecutionStatus);
         } catch (ActionExecutionException e) {
             throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PROFILE_ACTION_SERVER_ERROR,
                     "Error while executing pre update profile action.", e);
@@ -109,12 +109,12 @@ public class PreUpdateProfileActionExecutor {
         return userActionRequestDTOBuilder.build();
     }
 
-    private void handleActionExecutionStatus(ActionExecutionStatus<?> actionExecutionStatus)
+    private ActionExecutionStatus<?>  handleActionExecutionStatus(ActionExecutionStatus<?> actionExecutionStatus)
             throws UserStoreException {
 
         switch (actionExecutionStatus.getStatus()) {
             case SUCCESS:
-                return;
+                return actionExecutionStatus;
             case FAILED:
                 Failure failure = (Failure) actionExecutionStatus.getResponse();
                 throw new UserActionExecutionClientException(UserActionError.PRE_UPDATE_PROFILE_ACTION_EXECUTION_FAILED,

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -2312,7 +2312,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
+        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);
@@ -2360,7 +2360,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
+        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);
@@ -2405,7 +2405,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
+        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds state change support pre update profile action.

Therefore it allows ,

- ADD
- REPLACE
- REMOVE
 
operations to be done on the profile update.
