### PR TITLE
Fix Resolving user id in PreUpdateProfileActionExecutor when shared user profile is updated

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -165,6 +165,10 @@
             <artifactId>org.wso2.carbon.identity.user.action</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -270,6 +274,8 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.*;
                             version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.*;
+                            version="${org.wso2.carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.*;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.idp.mgt.*;version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
@@ -274,6 +274,7 @@ public class PreUpdateProfileActionExecutor {
 
         if (managedOrgId == null) {
             // User is not a shared user.
+            LOG.debug("User is not a shared user. Returning user ID: " + user.getId());
             return user.getId();
         }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/component/SCIMCommonComponent.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/component/SCIMCommonComponent.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
@@ -443,6 +444,34 @@ public class SCIMCommonComponent {
     protected void unsetActionExecutorService(ActionExecutorService actionExecutorService) {
 
         SCIMCommonComponentHolder.setActionExecutorService(null);
+    }
+
+    /**
+     * Set OrganizationUserSharingService.
+     *
+     * @param organizationUserSharingService OrganizationUserSharingService
+     */
+    @Reference(
+            name = "organization.user.sharing.service",
+            service = OrganizationUserSharingService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationUserSharingService")
+    protected void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
+
+        SCIMCommonComponentHolder.setOrganizationUserSharingService(organizationUserSharingService);
+        logger.debug("OrganizationUserSharingService set in SCIMCommonComponent bundle.");
+    }
+
+    /**
+     * Unset OrganizationUserSharingService.
+     *
+     * @param organizationUserSharingService OrganizationUserSharingService
+     */
+    protected void unsetOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
+
+        SCIMCommonComponentHolder.setOrganizationUserSharingService(null);
+        logger.debug("OrganizationUserSharingService unset in SCIMCommonComponent bundle.");
     }
 
     @Deactivate

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/component/SCIMCommonComponentHolder.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/component/SCIMCommonComponentHolder.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.action.execution.api.service.ActionExecutorServi
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
@@ -48,6 +49,7 @@ public class SCIMCommonComponentHolder {
     private static IdentityEventService identityEventService;
     private static ConfigurationManager configurationManager;
     private static ActionExecutorService actionExecutorService;
+    private static OrganizationUserSharingService organizationUserSharingService;
     private static final List<SCIMUserStoreErrorResolver> scimUserStoreErrorResolvers = new ArrayList<>();
 
     /**
@@ -267,5 +269,25 @@ public class SCIMCommonComponentHolder {
     public static void setActionExecutorService(ActionExecutorService actionExecutorService) {
 
         SCIMCommonComponentHolder.actionExecutorService = actionExecutorService;
+    }
+
+    /**
+     * Get the organization user sharing service.
+     *
+     * @return OrganizationUserSharingService organization user sharing service.
+     */
+    public static OrganizationUserSharingService getOrganizationUserSharingService() {
+
+        return organizationUserSharingService;
+    }
+
+    /**
+     * Set the organization user sharing service.
+     *
+     * @param organizationUserSharingService Organization user sharing service.
+     */
+    public static void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
+
+        SCIMCommonComponentHolder.organizationUserSharingService = organizationUserSharingService;
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
@@ -39,8 +39,9 @@ import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Organization;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
-import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 import org.wso2.carbon.identity.scim2.common.internal.component.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.test.constants.TestConstants;
@@ -103,6 +104,7 @@ public class PreUpdateProfileActionExecutorTest {
     public static final String TEST_MANAGED_BY_ORG_NAME = "mySubOrg2";
     public static final String TEST_MANAGED_BY_ORG_HANDLE = "mySubOrg2.com";
     public static final int TEST_MANAGED_BY_ORG_DEPTH = 10;
+    public static final String TEST_SHARED_USER_ID = "a84a536f-c3ec-4508-a9fa-ac67087a8da3";
 
     @Mock
     private ActionExecutorService actionExecutorService;
@@ -112,6 +114,9 @@ public class PreUpdateProfileActionExecutorTest {
 
     @Mock
     private OrganizationManager organizationManager;
+
+    @Mock
+    private OrganizationUserSharingService organizationUserSharingService;
 
     private PreUpdateProfileActionExecutor preUpdateProfileActionExecutor;
 
@@ -124,6 +129,7 @@ public class PreUpdateProfileActionExecutorTest {
         SCIMCommonComponentHolder.setActionExecutorService(actionExecutorService);
         SCIMCommonComponentHolder.setClaimManagementService(claimMetadataManagementService);
         SCIMCommonComponentHolder.setOrganizationManager(organizationManager);
+        SCIMCommonComponentHolder.setOrganizationUserSharingService(organizationUserSharingService);
 
         frameworkUtils = mockStatic(FrameworkUtils.class);
         frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
@@ -239,6 +245,9 @@ public class PreUpdateProfileActionExecutorTest {
                 .depth(TEST_MANAGED_BY_ORG_DEPTH)
                 .build();
         doReturn(managedByOrg).when(organizationManager).getMinimalOrganization(any(), any());
+        UserAssociation userAssociation = mock(UserAssociation.class);
+        doReturn(TestConstants.TEST_USER_ID).when(userAssociation).getAssociatedUserId();
+        doReturn(userAssociation).when(organizationUserSharingService).getUserAssociation(anyString(), anyString());
 
         when(actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)).thenReturn(true);
 
@@ -799,7 +808,7 @@ public class PreUpdateProfileActionExecutorTest {
     private static User getSCIMSharedUser() throws CharonException, BadRequestException {
 
         User user = new User();
-        user.setId(TestConstants.TEST_USER_ID);
+        user.setId(TEST_SHARED_USER_ID);
         user.setUserName(TestConstants.TEST_USER_USERNAME);
 
         SimpleAttribute managedOrgAttribute = new SimpleAttribute("managedOrg", TEST_MANAGED_BY_ORG_ID);

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
                 <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
                 <version>${org.wso2.carbon.identity.handler.event.account.lock.version}</version>
@@ -310,13 +315,15 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.64</carbon.kernel.version>
-        <identity.framework.version>7.8.340</identity.framework.version>
+        <identity.framework.version>7.8.377</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
         <charon.version>4.0.53</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.1.45
         </org.wso2.carbon.identity.organization.management.core.version>
+        <org.wso2.carbon.identity.organization.management.version>2.0.16
+        </org.wso2.carbon.identity.organization.management.version>
         <org.wso2.carbon.identity.handler.event.account.lock.version>1.8.13
         </org.wso2.carbon.identity.handler.event.account.lock.version>
 
@@ -349,6 +356,8 @@
         </carbon.identity.framework.imp.pkg.version.range>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
+        <org.wso2.carbon.identity.organization.management.version.range>[2.0.0, 3.0.0)
+        </org.wso2.carbon.identity.organization.management.version.range>
         <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> 

## Depends on
- https://github.com/wso2/carbon-identity-framework/pull/7070
- https://github.com/wso2/carbon-identity-framework/pull/7072

## Related Issue
- https://github.com/wso2/product-is/issues/24959