### PR TITLE
Handle workflow engagement during role creation for the role-v3 API

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -545,6 +545,10 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
             } else if (INVALID_AUDIENCE.getCode().equals(e.getErrorCode()) ||
                     INVALID_PERMISSION.getCode().equals(e.getErrorCode())) {
                 throw new BadRequestException(e.getMessage(), ResponseCodeConstants.INVALID_VALUE);
+            } else if (ROLE_WORKFLOW_CREATED.getCode().equals(e.getErrorCode())) {
+                CharonException charonException = new CharonException(e.getMessage());
+                charonException.setStatus(ResponseCodeConstants.CODE_ACCEPTED);
+                throw charonException;
             }
             throw new CharonException(
                     String.format("Error occurred while adding a new role: %s", role.getDisplayName()), e);


### PR DESCRIPTION
## Purpose
> With new role v3 implementation it looks it has missed / removed to have the error handling for the workflow engaged during role creation.

### Related Issues
- https://github.com/wso2/product-is/issues/23374

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/658
