### PR TITLE
Fix incorrect SCIM failure response in Pre Update Password Action

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -413,6 +413,7 @@ public class SCIMUserManager implements UserManager {
             }
 
         } catch (UserStoreClientException e) {
+            handleAndThrowClientExceptionForActionFailure(e);
             String errorMessage = String.format("Error in adding the user: " + maskIfRequired(user.getUserName()) +
                     ". %s", e.getMessage());
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
> Related Issue: https://github.com/wso2/product-is/issues/25067

## Purpose
This pull request introduces a change to the error handling logic in the `createUser` method of `SCIMUserManager.java`. The update improves how client exceptions are processed when user creation fails.

## Goals
- Ensure SCIM API failure responses clearly represent the cause of the error.
- Remove redundant details such as masked usernames from failure messages when unnecessary.

## Approach
- Added a call to `handleAndThrowClientExceptionForActionFailure(e)` in the `UserStoreClientException` catch block.
- Verified that responses now have the following improved format:

**Previous response format:**

```json
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:Error"
  ],
  "scimType": "invalidValue",
  "detail": "Error in adding the user: P**************2. Compromised password. The provided password is compromised. Provide something different.",
  "status": "400"
}

```

**Updated response format:**

```json
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "scimType": "Compromised password",
    "detail": "The provided password is compromised. Provide something different.",
    "status": "400"
}

```

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.