### PR TITLE
Improve performance when calculating total user count in JDBC user stores

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -781,7 +781,7 @@ public class SCIMUserManager implements UserManager {
             if (canPaginate(offset, limit)) {
                 coreUsers = listUsernames(offset, limit, sortBy, sortOrder, domainName);
                 if (SCIMCommonUtils.isConsiderTotalRecordsForTotalResultOfLDAPEnabled() &&
-                        !isJDBCUSerStore(domainName)) {
+                        !isJDBCUserStore(domainName)) {
                     int maxLimit = Integer.MAX_VALUE;
                     if (SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
                         maxLimit = getMaxLimit(domainName);
@@ -852,14 +852,14 @@ public class SCIMUserManager implements UserManager {
     private boolean canCountTotalUserCount(String[] userStoreDomainNames) {
 
         for (String userStoreDomainName : userStoreDomainNames) {
-            if (!isJDBCUSerStore(userStoreDomainName)) {
+            if (!isJDBCUserStore(userStoreDomainName)) {
                 return false;
             }
         }
         return true;
     }
 
-    private boolean isJDBCUSerStore(String userStoreDomainName) {
+    private boolean isJDBCUserStore(String userStoreDomainName) {
 
         AbstractUserStoreManager secondaryUserStoreManager = (AbstractUserStoreManager) carbonUM
                 .getSecondaryUserStoreManager(userStoreDomainName);
@@ -1631,7 +1631,7 @@ public class SCIMUserManager implements UserManager {
                 filteredUsers.addAll(getFilteredUserDetails(users, requiredAttributes));
             }
             // Check that total user count matching the client query needs to be calculated.
-            if (isJDBCUSerStore(domainName) || isAllConfiguredUserStoresJDBC()
+            if (isJDBCUserStore(domainName) || isAllConfiguredUserStoresJDBC()
                     || SCIMCommonUtils.isConsiderTotalRecordsForTotalResultOfLDAPEnabled()) {
                 int maxLimit;
                 if (!SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
@@ -1641,7 +1641,7 @@ public class SCIMUserManager implements UserManager {
                 }
                 // Get total users based on the filter query without depending on pagination params.
                 if (SCIMCommonUtils.isGroupBasedUserFilteringImprovementsEnabled() &&
-                        (isJDBCUSerStore(domainName) || isAllConfiguredUserStoresJDBC())) {
+                        (isJDBCUserStore(domainName) || isAllConfiguredUserStoresJDBC())) {
                     // Get the total user count by the filter query.
                     // This is only implemented for JDBC userstores.
                     totalResults += getUserCountByAttribute(node, 1, maxLimit, sortBy, sortOrder, domainName);
@@ -1699,7 +1699,7 @@ public class SCIMUserManager implements UserManager {
             domainName = getPrimaryUserStoreDomain();
         }
         int maxLimit = getMaxLimit(domainName);
-        if (isJDBCUSerStore(domainName) && !SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
+        if (isJDBCUserStore(domainName) && !SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
             maxLimit = Integer.MAX_VALUE;
         }
         return maxLimit;
@@ -2023,7 +2023,7 @@ public class SCIMUserManager implements UserManager {
             int filteredUsersCount = 0;
             for (String userStoreDomainName : userStoreDomainNames) {
                 try {
-                    if (isJDBCUSerStore(userStoreDomainName)) {
+                    if (isJDBCUserStore(userStoreDomainName)) {
                         filteredUsersCount += (int) getTotalUsers(userStoreDomainName);
                     } else {
                         filteredUsersCount +=
@@ -2401,7 +2401,7 @@ public class SCIMUserManager implements UserManager {
                 totalResults = maxLimitForTotalResults;
             }
         } else {
-            if (isJDBCUSerStore(domainName) || isAllConfiguredUserStoresJDBC() ||
+            if (isJDBCUserStore(domainName) || isAllConfiguredUserStoresJDBC() ||
                     SCIMCommonUtils.isConsiderTotalRecordsForTotalResultOfLDAPEnabled()) {
                 // Get total users based on the filter query.
                 totalResults += getMultiAttributeFilteredUsersCount(node, 1, domainName, maxLimitForTotalResults);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -780,7 +780,8 @@ public class SCIMUserManager implements UserManager {
         if (StringUtils.isNotEmpty(domainName)) {
             if (canPaginate(offset, limit)) {
                 coreUsers = listUsernames(offset, limit, sortBy, sortOrder, domainName);
-                if (SCIMCommonUtils.isConsiderTotalRecordsForTotalResultOfLDAPEnabled()) {
+                if (SCIMCommonUtils.isConsiderTotalRecordsForTotalResultOfLDAPEnabled() &&
+                        !isJDBCUSerStore(domainName)) {
                     int maxLimit = Integer.MAX_VALUE;
                     if (SCIMCommonUtils.isConsiderMaxLimitForTotalResultEnabled()) {
                         maxLimit = getMaxLimit(domainName);
@@ -2022,8 +2023,12 @@ public class SCIMUserManager implements UserManager {
             int filteredUsersCount = 0;
             for (String userStoreDomainName : userStoreDomainNames) {
                 try {
-                    filteredUsersCount +=
-                            getFilteredUserCountFromSingleDomain(condition, offset, maxLimit, userStoreDomainName);
+                    if (isJDBCUSerStore(userStoreDomainName)) {
+                        filteredUsersCount += (int) getTotalUsers(userStoreDomainName);
+                    } else {
+                        filteredUsersCount +=
+                                getFilteredUserCountFromSingleDomain(condition, offset, maxLimit, userStoreDomainName);
+                    }
                 } catch (CharonException e) {
                     log.error("Error occurred while getting the users count for domain: " + userStoreDomainName, e);
                 }


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/24574

## Approach
> When `consider_total_records_for_total_results_of_ldap = true`, it should only be applicable for LDAP userstores. If there are JDBC user stores, we can use the optimal approach to achieve better performance. 