### PR TITLE
[Next Branch] Fix scimType and description for role workflow errors 

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMRoleManagerV2.java
@@ -1560,7 +1560,7 @@ public class SCIMRoleManagerV2 implements RoleV2Manager {
                         ERROR_CODE_ROLE_WF_USER_NOT_FOUND.getCode().equals(errorCode) ||
                         ERROR_CODE_ROLE_WF_PENDING_ALREADY_EXISTS.getCode().equals(errorCode) ||
                         ERROR_CODE_ROLE_WF_ROLE_NOT_FOUND.getCode().equals(errorCode)) {
-                    throw new BadRequestException(e.getMessage());
+                    throw new BadRequestException(e.getMessage(), ResponseCodeConstants.INVALID_VALUE);
                 } else if (OPERATION_FORBIDDEN.getCode().equals(errorCode)) {
                     throw new ForbiddenException(e.getMessage());
                 } else if (ROLE_WORKFLOW_CREATED.getCode().equals(errorCode)) {


### PR DESCRIPTION
## Purpose

Currently, for user role assignment related workflow errors, scimType and description of the returned error are incorrect. This PR addresses this by assigning `invalidValue` as the scimType with appropriate error description.

Related Issue: 
- https://github.com/wso2/product-is/issues/25251