### PR TITLE
[NEXT] Support returning 409 Conflict for duplicate claims in SCIM2 user management

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/pom.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/pom.xml
@@ -149,6 +149,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
@@ -163,6 +167,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.action</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.unique.claim.mgt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management</groupId>

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -1495,8 +1495,9 @@ public class SCIMUserManager implements UserManager {
         } catch (UserStoreException e) {
             handleAndThrowClientExceptionForActionFailure(e);
             if (e instanceof UserStoreClientException) {
+                UserStoreClientException clientException = (UserStoreClientException) e;
                 String errorMessage = String.format("Error while updating attributes of user. %s", e.getMessage());
-                handleAndThrowClientExceptionForDuplicateClaim((UserStoreClientException) e, errorMessage);
+                handleAndThrowClientExceptionForDuplicateClaim(clientException, errorMessage);
             }
             handleErrorsOnUserNameAndPasswordPolicy(e);
             throw resolveError(e, "Error while updating attributes of user: " +
@@ -1558,14 +1559,14 @@ public class SCIMUserManager implements UserManager {
      * duplicate claim and the system is configured to return a 409 Conflict status for such violations,
      * this method will throw a {@link ConflictException}
      *
-     * @param e            UserStoreClientException.
+     * @param exception    UserStoreClientException.
      * @param errorMessage Error message to be thrown.
      * @throws ConflictException If the error is a duplicate claim error and configuration is enabled.
      */
-    private void handleAndThrowClientExceptionForDuplicateClaim(UserStoreClientException e, String errorMessage)
+    private void handleAndThrowClientExceptionForDuplicateClaim(UserStoreClientException exception, String errorMessage)
             throws ConflictException {
 
-        if (isDuplicateClaimError(e) && isConflictOnClaimUniquenessViolationEnabled()) {
+        if (isDuplicateClaimError(exception) && isConflictOnClaimUniquenessViolationEnabled()) {
             throw new ConflictException(errorMessage);
         }
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -67,6 +67,7 @@ import org.wso2.carbon.identity.scim2.common.internal.component.SCIMCommonCompon
 import org.wso2.carbon.identity.scim2.common.utils.AttributeMapper;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
+import org.wso2.carbon.identity.unique.claim.mgt.constants.UniqueClaimConstants;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
@@ -421,7 +422,7 @@ public class SCIMUserManager implements UserManager {
             if (isResourceLimitReachedError(e)) {
                 handleResourceLimitReached();
             }
-
+            handleAndThrowClientExceptionForDuplicateClaim(e, errorMessage);
             publishEventOnUserRegistrationFailure(user, e.getErrorCode(), e.getMessage(), claimsInLocalDialect);
             throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_VALUE);
         } catch (UserStoreException e) {
@@ -1142,7 +1143,7 @@ public class SCIMUserManager implements UserManager {
 
     @Override
     public User updateUser(User user, Map<String, Boolean> requiredAttributes) throws CharonException,
-            BadRequestException {
+            BadRequestException, ConflictException {
 
         try {
             if (log.isDebugEnabled()) {
@@ -1295,6 +1296,7 @@ public class SCIMUserManager implements UserManager {
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }
+            handleAndThrowClientExceptionForDuplicateClaim(e, errorMessage);
             throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_VALUE);
         } catch (UserStoreException e) {
             String errMsg = "Error while updating attributes of user: " + maskIfRequired(user.getUserName());
@@ -1342,7 +1344,8 @@ public class SCIMUserManager implements UserManager {
      * @throws BadRequestException Exception occurred due to a bad request.
      */
     public User updateUser(User user, Map<String, Boolean> requiredAttributes,
-                           List<String> allSimpleMultiValuedAttributes) throws CharonException, BadRequestException {
+                           List<String> allSimpleMultiValuedAttributes) throws CharonException, BadRequestException,
+            ConflictException {
 
         try {
             if (log.isDebugEnabled()) {
@@ -1490,6 +1493,10 @@ public class SCIMUserManager implements UserManager {
             return getUser(user.getId(), requiredAttributes);
         } catch (UserStoreException e) {
             handleAndThrowClientExceptionForActionFailure(e);
+            if (e instanceof UserStoreClientException) {
+                String errorMessage = String.format("Error while updating attributes of user. %s", e.getMessage());
+                handleAndThrowClientExceptionForDuplicateClaim((UserStoreClientException) e, errorMessage);
+            }
             handleErrorsOnUserNameAndPasswordPolicy(e);
             throw resolveError(e, "Error while updating attributes of user: " +
                     maskIfRequired(user.getUserName()));
@@ -1529,6 +1536,48 @@ public class SCIMUserManager implements UserManager {
                     (UserActionExecutionClientException) e;
             throw new BadRequestException(userActionExecutionClientException.getDescription(),
                     userActionExecutionClientException.getError());
+        }
+    }
+
+    /**
+     * Checks whether the given UserStoreClientException is a duplicate claim error.
+     *
+     * @param e UserStoreClientException to check.
+     * @return true if it is a duplicate claim error, false otherwise.
+     */
+    private boolean isDuplicateClaimError(UserStoreClientException e) {
+
+        String errorCode = e.getErrorCode();
+        return UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode().equals(errorCode) ||
+                UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode().equals(errorCode);
+    }
+
+    /**
+     * Checks whether SCIM2 endpoints should return a 409 Conflict response instead of a 400 Bad Request when
+     * duplicate claims (uniqueness violations) are encountered.
+     *
+     * @return true if 409 Conflict responses should be returned for duplicate claims,
+     *         false if 400 Bad Request responses should be used instead.
+     */
+    private boolean isReturnConflictResponseForDuplicateClaimsEnabled() {
+
+        return Boolean.parseBoolean(
+                IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS));
+    }
+
+    /**
+     * Handles a UserStoreClientException by throwing a ConflictException if it's a duplicate claim error
+     * and the ReturnConflictOnDuplicateClaim configuration is enabled.
+     *
+     * @param e            UserStoreClientException.
+     * @param errorMessage Error message to be thrown.
+     * @throws ConflictException If the error is a duplicate claim error and configuration is enabled.
+     */
+    private void handleAndThrowClientExceptionForDuplicateClaim(UserStoreClientException e, String errorMessage)
+            throws ConflictException {
+
+        if (isDuplicateClaimError(e) && isReturnConflictResponseForDuplicateClaimsEnabled()) {
+            throw new ConflictException(errorMessage);
         }
     }
 
@@ -2969,7 +3018,7 @@ public class SCIMUserManager implements UserManager {
 
     @Override
     public User updateMe(User user, Map<String, Boolean> requiredAttributes)
-            throws NotImplementedException, CharonException, BadRequestException {
+            throws NotImplementedException, CharonException, BadRequestException, ConflictException {
 
         return updateUser(user, requiredAttributes);
     }

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -125,6 +125,8 @@ public class SCIMCommonConstants {
             "SCIM2MultiAttributeFiltering.UsePagination";
     public static final String CONSIDER_SERVER_WIDE_MAX_LIMIT_ENABLED=
             "SCIM2.ConsiderServerWideUserEndpointMaxLimit";
+    public static final String SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS =
+            "SCIM2.ReturnConflictResponseForDuplicateClaims";
 
     public static final String URL_SEPERATOR = "/";
     public static final String TENANT_URL_SEPERATOR = "/t/";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -123,10 +123,16 @@ public class SCIMCommonConstants {
             "SCIM2.RemoveDuplicateUsersInUsersResponse";
     public static final String SCIM2_COMPLEX_MULTI_ATTRIBUTE_FILTERING_ENABLED =
             "SCIM2MultiAttributeFiltering.UsePagination";
-    public static final String CONSIDER_SERVER_WIDE_MAX_LIMIT_ENABLED=
+    public static final String CONSIDER_SERVER_WIDE_MAX_LIMIT_ENABLED =
             "SCIM2.ConsiderServerWideUserEndpointMaxLimit";
-    public static final String SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS =
-            "SCIM2.ReturnConflictResponseForDuplicateClaims";
+    public static final String SCIM2_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION =
+            "SCIM2.ConflictOnClaimUniquenessViolation";
+
+    // Constants related to backward compatibility configurations from config store.
+    public static final String RESOURCE_TYPE_COMPATIBILITY_SETTINGS = "compatibility-settings";
+    public static final String RESOURCE_NAME_SCIM2 = "scim2";
+    public static final String ATTRIBUTE_NAME_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION =
+            "conflictOnClaimUniquenessViolation";
 
     public static final String URL_SEPERATOR = "/";
     public static final String TENANT_URL_SEPERATOR = "/t/";

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -30,6 +30,9 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.context.IdentityContext;
@@ -1273,6 +1276,49 @@ public class SCIMCommonUtils {
         }
 
         return multiValuedClaimsToModify;
+    }
+
+    /**
+     * Checks whether SCIM2 Users endpoints should return a 409 Conflict response instead of a 400 Bad Request when
+     * duplicate claims (uniqueness violations) are encountered. This setting is retrieved from the tenant-level
+     * configuration store first. If it is not defined there, the method falls back to the server-level default
+     * configuration.
+     *
+     * @return true if 409 Conflict responses should be returned for duplicate claims,
+     *         false if 400 Bad Request responses should be used instead.
+     */
+    public static boolean isConflictOnClaimUniquenessViolationEnabled() {
+
+        String returnConflictOnClaimUniquenessViolationEnabled = null;
+
+        try {
+            // Get the configuration from the config store.
+            Resource resource = SCIMCommonComponentHolder.getConfigurationManager()
+                    .getResource(SCIMCommonConstants.RESOURCE_TYPE_COMPATIBILITY_SETTINGS,
+                            SCIMCommonConstants.RESOURCE_NAME_SCIM2, true);
+
+            if (resource != null && resource.getAttributes() != null) {
+                returnConflictOnClaimUniquenessViolationEnabled = resource.getAttributes().stream()
+                        .filter(attribute -> SCIMCommonConstants.ATTRIBUTE_NAME_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION
+                                .equals(attribute.getKey()))
+                        .map(Attribute::getValue)
+                        .findFirst()
+                        .orElse(null);
+            }
+        } catch (ConfigurationManagementException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while retrieving configuration from config store for SCIM2 conflict on claim " +
+                        "uniqueness violation. Falling back to server level config.", e);
+            }
+        }
+
+        // Fallback to server level config if not found in config store.
+        if (StringUtils.isBlank(returnConflictOnClaimUniquenessViolationEnabled)) {
+            returnConflictOnClaimUniquenessViolationEnabled =
+                    IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION);
+        }
+
+        return Boolean.parseBoolean(returnConflictOnClaimUniquenessViolationEnabled);
     }
 
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -2529,20 +2529,20 @@ public class SCIMUserManagerTest {
     public Object[][] duplicateClaimErrorDataProvider() {
 
         return new Object[][]{
-                {"true", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode(),
+                {true, UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode(),
                         ConflictException.class},
-                {"false", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode(),
+                {false, UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode(),
                         BadRequestException.class},
-                {"true", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode(),
+                {true, UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode(),
                         ConflictException.class},
-                {"false", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode(),
+                {false, UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode(),
                         BadRequestException.class}
         };
     }
 
     @Test(dataProvider = "duplicateClaimErrorDataProvider")
     public void testCreateUser_DuplicateClaimErrorReturnsExpectedResponse(
-            String isReturnConflictResponseForDuplicateClaimsEnabled,
+            boolean isConflictOnClaimUniquenessViolationEnabled,
             String duplicateClaimErrorCode, Class<? extends AbstractCharonException> expectedException)
             throws Exception {
 
@@ -2551,8 +2551,8 @@ public class SCIMUserManagerTest {
 
         when(IdentityUtil.getProperty(SCIMCommonConstants.ENABLE_LOGIN_IDENTIFIERS))
                 .thenReturn("false");
-        when(IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS))
-                .thenReturn(isReturnConflictResponseForDuplicateClaimsEnabled);
+        scimCommonUtils.when(SCIMCommonUtils::isConflictOnClaimUniquenessViolationEnabled)
+                .thenReturn(isConflictOnClaimUniquenessViolationEnabled);
         when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
 
         when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
@@ -2583,7 +2583,7 @@ public class SCIMUserManagerTest {
 
     @Test(dataProvider = "duplicateClaimErrorDataProvider")
     public void testUpdateUser_DuplicateClaimErrorReturnsExpectedResponse(
-            String isReturnConflictResponseForDuplicateClaimsEnabled,
+            boolean isConflictOnClaimUniquenessViolationEnabled,
             String duplicateClaimErrorCode, Class<? extends AbstractCharonException> expectedException)
             throws Exception {
 
@@ -2594,8 +2594,8 @@ public class SCIMUserManagerTest {
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, USERID_LOCAL_CLAIM);
 
-        when(IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS))
-                .thenReturn(isReturnConflictResponseForDuplicateClaimsEnabled);
+        scimCommonUtils.when(SCIMCommonUtils::isConflictOnClaimUniquenessViolationEnabled)
+                .thenReturn(isConflictOnClaimUniquenessViolationEnabled);
         when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 
@@ -2624,7 +2624,7 @@ public class SCIMUserManagerTest {
 
     @Test(dataProvider = "duplicateClaimErrorDataProvider")
     public void testUpdateUserWithMultiValuedAttributes_DuplicateClaimErrorReturnsExpectedResponse(
-            String isReturnConflictResponseForDuplicateClaimsEnabled,
+            boolean isConflictOnClaimUniquenessViolationEnabled,
             String duplicateClaimErrorCode, Class<? extends AbstractCharonException> expectedException)
             throws Exception {
 
@@ -2635,8 +2635,8 @@ public class SCIMUserManagerTest {
         Map<String, String> scimToLocalClaimsMap = new HashMap<>();
         scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, USERID_LOCAL_CLAIM);
 
-        when(IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS))
-                .thenReturn(isReturnConflictResponseForDuplicateClaimsEnabled);
+        scimCommonUtils.when(SCIMCommonUtils::isConflictOnClaimUniquenessViolationEnabled)
+                .thenReturn(isConflictOnClaimUniquenessViolationEnabled);
         when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
         when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.core.context.model.UserActor;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.extenstion.SCIMUserStoreErrorResolver;
 import org.wso2.carbon.identity.scim2.common.group.SCIMGroupHandler;
@@ -108,6 +109,7 @@ import org.wso2.charon3.core.utils.codeutils.FilterTreeManager;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.unique.claim.mgt.constants.UniqueClaimConstants;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -185,6 +187,7 @@ public class SCIMUserManagerTest {
     private static final String TEST_PRE_PASSWORD_ACTION_FAILURE_MESSAGE = "Compromised password";
     private static final String TEST_PRE_PASSWORD_ACTION_FAILURE_DESCRIPTION =
             "The provided password is compromised. Provide something different.";
+    private static final String DUPLICATE_CLAIM_ERROR_MESSAGE = "Duplicate Claim!";
 
     @Mock
     private AbstractUserStoreManager mockedUserStoreManager;
@@ -2520,5 +2523,180 @@ public class SCIMUserManagerTest {
         resource.setResourceName(MAX_LIMIT_RESOURCE_NAME);
         resource.setAttributes(getResourceAttribute());
         return resource;
+    }
+
+    @DataProvider(name = "duplicateClaimErrorDataProvider")
+    public Object[][] duplicateClaimErrorDataProvider() {
+
+        return new Object[][]{
+                {"true", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode(),
+                        ConflictException.class},
+                {"false", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_SINGLE_CLAIM.getCode(),
+                        BadRequestException.class},
+                {"true", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode(),
+                        ConflictException.class},
+                {"false", UniqueClaimConstants.ErrorMessages.ERROR_CODE_DUPLICATE_MULTIPLE_CLAIMS.getCode(),
+                        BadRequestException.class}
+        };
+    }
+
+    @Test(dataProvider = "duplicateClaimErrorDataProvider")
+    public void testCreateUser_DuplicateClaimErrorReturnsExpectedResponse(
+            String isReturnConflictResponseForDuplicateClaimsEnabled,
+            String duplicateClaimErrorCode, Class<? extends AbstractCharonException> expectedException)
+            throws Exception {
+
+        User user = new User();
+        user.setUserName("DomainName/testUser1");
+
+        when(IdentityUtil.getProperty(SCIMCommonConstants.ENABLE_LOGIN_IDENTIFIERS))
+                .thenReturn("false");
+        when(IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS))
+                .thenReturn(isReturnConflictResponseForDuplicateClaimsEnabled);
+        when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(false);
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString()))
+                .thenReturn(mockedUserStoreManager);
+        when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
+
+        UserStoreException duplicateClaimException = createDuplicateClaimUserStoreClientException(duplicateClaimErrorCode);
+        when(mockedUserStoreManager.addUserWithID(anyString(), any(), any(), any(), any()))
+                .thenThrow(duplicateClaimException);
+
+        IdentityEventService mockService = mock(IdentityEventService.class);
+        scimCommonComponentHolder.when(SCIMCommonComponentHolder::getIdentityEventService).thenReturn(mockService);
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        try {
+            scimUserManager.createUser(user, null);
+            Assert.fail("Expected " + expectedException.getSimpleName());
+        } catch (AbstractCharonException e) {
+            verifyDuplicateClaimErrorResponse(e, expectedException);
+        }
+    }
+
+    @Test(dataProvider = "duplicateClaimErrorDataProvider")
+    public void testUpdateUser_DuplicateClaimErrorReturnsExpectedResponse(
+            String isReturnConflictResponseForDuplicateClaimsEnabled,
+            String duplicateClaimErrorCode, Class<? extends AbstractCharonException> expectedException)
+            throws Exception {
+
+        User user = new User();
+        user.setId("12345");
+        user.setUserName("DomainName/testUser1");
+
+        Map<String, String> scimToLocalClaimsMap = new HashMap<>();
+        scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, USERID_LOCAL_CLAIM);
+
+        when(IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS))
+                .thenReturn(isReturnConflictResponseForDuplicateClaimsEnabled);
+        when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+        when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
+
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
+        resourceManagerUtil.when(() -> ResourceManagerUtil.getAllAttributeURIs(any())).thenReturn(new HashMap<>());
+
+        SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+        doReturn(user).when(scimUserManager).getUser(anyString(), anyMap());
+        when(mockedUserStoreManager.isExistingUserWithID(anyString())).thenReturn(true);
+
+        UserStoreException duplicateClaimException = createDuplicateClaimUserStoreClientException(duplicateClaimErrorCode);
+        doThrow(duplicateClaimException).when(mockedUserStoreManager)
+                .setUserClaimValuesWithID(anyString(), anyMap(), nullable(String.class));
+
+        try {
+            scimUserManager.updateUser(user, Collections.emptyMap());
+            Assert.fail("Expected " + expectedException.getSimpleName());
+        } catch (AbstractCharonException e) {
+            verifyDuplicateClaimErrorResponse(e, expectedException);
+        }
+    }
+
+    @Test(dataProvider = "duplicateClaimErrorDataProvider")
+    public void testUpdateUserWithMultiValuedAttributes_DuplicateClaimErrorReturnsExpectedResponse(
+            String isReturnConflictResponseForDuplicateClaimsEnabled,
+            String duplicateClaimErrorCode, Class<? extends AbstractCharonException> expectedException)
+            throws Exception {
+
+        User user = new User();
+        user.setId("12345");
+        user.setUserName("DomainName/testUser1");
+
+        Map<String, String> scimToLocalClaimsMap = new HashMap<>();
+        scimToLocalClaimsMap.put(SCIMConstants.CommonSchemaConstants.ID_URI, USERID_LOCAL_CLAIM);
+
+        when(IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_RETURN_CONFLICT_RESPONSE_FOR_DUPLICATE_CLAIMS))
+                .thenReturn(isReturnConflictResponseForDuplicateClaimsEnabled);
+        when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+        when(IdentityUtil.isUserStoreInUsernameCaseSensitive(anyString())).thenReturn(true);
+
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        when(SCIMCommonUtils.getSCIMtoLocalMappings()).thenReturn(scimToLocalClaimsMap);
+        when(SCIMCommonUtils.convertSCIMtoLocalDialect(anyMap())).thenReturn(new HashMap<>());
+        resourceManagerUtil.when(() -> ResourceManagerUtil.getAllAttributeURIs(any())).thenReturn(new HashMap<>());
+
+        SCIMUserManager scimUserManager = spy(new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
+        doReturn(user).when(scimUserManager).getUser(anyString(), anyMap());
+        when(mockedUserStoreManager.isExistingUserWithID(anyString())).thenReturn(true);
+
+        UserStoreException duplicateClaimException = createDuplicateClaimUserStoreClientException(duplicateClaimErrorCode);
+        doThrow(duplicateClaimException).when(mockedUserStoreManager)
+                .setUserClaimValuesWithID(anyString(), anyMap(), nullable(String.class));
+
+        try {
+            scimUserManager.updateUser(user, Collections.emptyMap(), Collections.emptyList());
+            Assert.fail("Expected " + expectedException.getSimpleName());
+        } catch (AbstractCharonException e) {
+            verifyDuplicateClaimErrorResponse(e, expectedException);
+        }
+    }
+
+    /**
+     * Verifies that the duplicate claim error response matches the expected exception type and contains
+     * the duplicate claim error message. For BadRequestException also validates the SCIM type.
+     *
+     * @param actualException The exception that was thrown
+     * @param expectedException The expected exception class
+     */
+    private void verifyDuplicateClaimErrorResponse(AbstractCharonException actualException,
+                                                   Class<? extends AbstractCharonException> expectedException) {
+
+        assertTrue(expectedException.isInstance(actualException),
+                "Expected " + expectedException.getSimpleName() + " but got " +
+                        actualException.getClass().getSimpleName());
+        assertTrue(actualException.getDetail().contains(DUPLICATE_CLAIM_ERROR_MESSAGE),
+                "Exception should contain '" + DUPLICATE_CLAIM_ERROR_MESSAGE + "' error message");
+
+        if (actualException instanceof BadRequestException) {
+            BadRequestException badRequestException = (BadRequestException) actualException;
+            assertEquals(badRequestException.getScimType(), ResponseCodeConstants.INVALID_VALUE,
+                    "BadRequestException should have INVALID_VALUE scim type");
+        }
+    }
+
+    /**
+     * Creates a UserStoreClientException for duplicate claim error.
+     *
+     * @param duplicateClaimErrorCode The error code for the duplicate claim
+     * @return UserStoreClientException
+     */
+    private UserStoreClientException createDuplicateClaimUserStoreClientException(String duplicateClaimErrorCode) {
+
+        return new UserStoreClientException(
+                DUPLICATE_CLAIM_ERROR_MESSAGE, duplicateClaimErrorCode,
+                new PolicyViolationException("testCode", DUPLICATE_CLAIM_ERROR_MESSAGE));
     }
 }

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtilsTest.java
@@ -26,14 +26,21 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.DefaultServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.scim2.common.internal.component.SCIMCommonComponentHolder;
 import org.wso2.carbon.identity.scim2.common.test.utils.CommonTestUtils;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -66,10 +73,14 @@ public class SCIMCommonUtilsTest {
     @Mock
     DefaultServiceURLBuilder defaultServiceURLBuilder1;
 
+    @Mock
+    ConfigurationManager configurationManager;
+
     private MockedStatic<UserCoreUtil> userCoreUtil;
     private MockedStatic<IdentityTenantUtil> identityTenantUtil;
     private MockedStatic<ServiceURLBuilder> serviceURLBuilder;
     private MockedStatic<IdentityUtil> identityUtil;
+    private MockedStatic<SCIMCommonComponentHolder> scimComponentHolder;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -78,6 +89,7 @@ public class SCIMCommonUtilsTest {
         userCoreUtil = mockStatic(UserCoreUtil.class);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
         serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+        scimComponentHolder = mockStatic(SCIMCommonComponentHolder.class);
         identityUtil.when(() -> IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(SCIM_URL);
         identityUtil.when(() -> IdentityUtil.getPrimaryDomainName()).thenReturn(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
         serviceURLBuilder.when(() -> ServiceURLBuilder.create()).thenReturn(defaultServiceURLBuilder);
@@ -96,6 +108,7 @@ public class SCIMCommonUtilsTest {
         userCoreUtil.close();
         identityTenantUtil.close();
         serviceURLBuilder.close();
+        scimComponentHolder.close();
         System.clearProperty(CarbonBaseConstants.CARBON_HOME);
     }
 
@@ -337,5 +350,152 @@ public class SCIMCommonUtilsTest {
         SCIMCommonUtils.unsetThreadLocalIsSCIMAgentFlow();
     }
 
-    
+    @DataProvider
+    public Object[][] conflictOnClaimUniquenessViolationData() {
+        return new Object[][]{
+                // Config store value, server config value, expected result.
+
+                // Config store has values - should use config store, ignore server config.
+                {"true", "false", true},          // Config store "true" takes priority.
+                {"false", "true", false},         // Config store "false" takes priority.
+                {"TRUE", "false", true},          // Config store uppercase "TRUE".
+                {"False", "true", false},         // Config store mixed case "False".
+                {" ", "true", true},              // Config store whitespace.
+                {" ", "false", false},            // Config store whitespace.
+                {"invalid", "true", false},       // Config store invalid value.
+
+                // Config store not available - should fall back to server config.
+                {null, "true", true},             // Fallback to server "true".
+                {null, "false", false},           // Fallback to server "false".
+                {null, "TRUE", true},             // Fallback to server uppercase.
+                {null, "invalid", false},         // Fallback to server invalid value.
+                {null, "", false},                // Fallback to server empty string.
+                {null, null, false}               // No config anywhere - default false.
+        };
+    }
+
+    @Test(dataProvider = "conflictOnClaimUniquenessViolationData",
+            description = "Test various config store and server config combinations.")
+    public void testIsConflictOnClaimUniquenessViolationEnabled(String configStoreValue, String serverConfigValue,
+                                                                boolean expectedResult) throws Exception {
+
+        scimComponentHolder.when(SCIMCommonComponentHolder::getConfigurationManager).thenReturn(configurationManager);
+
+        if (configStoreValue != null) {
+            // Config store has a value.
+            when(configurationManager.getResource(
+                    SCIMCommonConstants.RESOURCE_TYPE_COMPATIBILITY_SETTINGS,
+                    SCIMCommonConstants.RESOURCE_NAME_SCIM2,
+                    true
+            )).thenReturn(createMockResource(SCIMCommonConstants.ATTRIBUTE_NAME_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION,
+                    configStoreValue));
+        } else {
+            // Config store doesn't have the value - trigger fallback.
+            when(configurationManager.getResource(
+                    SCIMCommonConstants.RESOURCE_TYPE_COMPATIBILITY_SETTINGS,
+                    SCIMCommonConstants.RESOURCE_NAME_SCIM2,
+                    true
+            )).thenReturn(null);
+        }
+
+        // Setup server-level configuration (fallback).
+        identityUtil.when(() ->
+                        IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION))
+                .thenReturn(serverConfigValue);
+
+        boolean result = SCIMCommonUtils.isConflictOnClaimUniquenessViolationEnabled();
+        assertEquals(result, expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] serverConfigFallbackData() {
+        return new Object[][]{
+                {"true", true},
+                {"false", false}
+        };
+    }
+
+    @Test(dataProvider = "serverConfigFallbackData",
+            description = "Test fallback to server config when configuration store throws exception.")
+    public void testIsConflictOnClaimUniquenessViolationEnabled_ConfigStoreException(String serverConfigValue,
+                                                                                     boolean expectedResult)
+            throws Exception {
+
+        scimComponentHolder.when(SCIMCommonComponentHolder::getConfigurationManager).thenReturn(configurationManager);
+        when(configurationManager.getResource(
+                SCIMCommonConstants.RESOURCE_TYPE_COMPATIBILITY_SETTINGS,
+                SCIMCommonConstants.RESOURCE_NAME_SCIM2,
+                true
+        )).thenThrow(new ConfigurationManagementException());
+
+        identityUtil.when(() ->
+                        IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION))
+                .thenReturn(serverConfigValue);
+
+        boolean result = SCIMCommonUtils.isConflictOnClaimUniquenessViolationEnabled();
+        assertEquals(result, expectedResult);
+    }
+
+    @Test(dataProvider = "serverConfigFallbackData",
+            description = "Test fallback to server config when configuration resource has null attributes.")
+    public void testIsConflictOnClaimUniquenessViolationEnabled_ConfigStoreResourceWithNullAttributes(
+            String serverConfigValue, boolean expectedResult) throws Exception {
+
+        scimComponentHolder.when(SCIMCommonComponentHolder::getConfigurationManager).thenReturn(configurationManager);
+        when(configurationManager.getResource(
+                SCIMCommonConstants.RESOURCE_TYPE_COMPATIBILITY_SETTINGS,
+                SCIMCommonConstants.RESOURCE_NAME_SCIM2,
+                true
+        )).thenReturn(createMockResource(null, null));
+
+        identityUtil.when(() ->
+                        IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION))
+                .thenReturn(serverConfigValue);
+
+        boolean result = SCIMCommonUtils.isConflictOnClaimUniquenessViolationEnabled();
+        assertEquals(result, expectedResult);
+    }
+
+    @Test(dataProvider = "serverConfigFallbackData",
+            description = "Test fallback to server config when configuration resource has different attributes.")
+    public void testIsConflictOnClaimUniquenessViolationEnabled_ConfigStoreResourceWithDifferentAttribute(
+            String serverConfigValue, boolean expectedResult) throws Exception {
+
+        scimComponentHolder.when(SCIMCommonComponentHolder::getConfigurationManager).thenReturn(configurationManager);
+        when(configurationManager.getResource(
+                SCIMCommonConstants.RESOURCE_TYPE_COMPATIBILITY_SETTINGS,
+                SCIMCommonConstants.RESOURCE_NAME_SCIM2,
+                true
+        )).thenReturn(createMockResource("someOtherAttribute", "someOtherValue"));
+
+        identityUtil.when(() ->
+                        IdentityUtil.getProperty(SCIMCommonConstants.SCIM2_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION))
+                .thenReturn(serverConfigValue);
+
+        boolean result = SCIMCommonUtils.isConflictOnClaimUniquenessViolationEnabled();
+        assertEquals(result, expectedResult);
+    }
+
+
+    /**
+     * Helper method to create a mock Resource with specified attributes.
+     *
+     * @param key   Attribute key.
+     * @param value Attribute value.
+     * @return Mock Resource object with the specified attributes.
+     */
+    private Resource createMockResource(String key, String value) {
+        Resource mockResource = new Resource();
+
+        if (key == null) {
+            mockResource.setAttributes(Collections.emptyList());
+        } else {
+            Attribute mockAttribute = new Attribute();
+            mockAttribute.setKey(key);
+            mockAttribute.setValue(value);
+            mockResource.setAttributes(Collections.singletonList(mockAttribute));
+        }
+
+        return mockResource;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>4.0.54</charon.version>
+        <charon.version>5.0.0</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.1.45
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.version>2.0.16

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.64</carbon.kernel.version>
-        <identity.framework.version>7.8.416</identity.framework.version>
+        <identity.framework.version>7.9.46</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+                <scope>provided</scope>
+                <version>${identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
                 <version>${identity.framework.version}</version>
             </dependency>
@@ -197,6 +203,12 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.user.action</artifactId>
                 <version>${identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.unique.claim.mgt</artifactId>
+                <version>${identity.framework.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>

--- a/scim2.yaml
+++ b/scim2.yaml
@@ -122,6 +122,11 @@ paths:
           schema:
             $ref: '#/definitions/ErrorUserNotAvailable'
 
+        409:
+          description: User attribute value already exists
+          schema:
+            $ref: '#/definitions/ErrorUserConflict'
+
         500:
           description: Internal Server Error
           schema:
@@ -164,6 +169,10 @@ paths:
           description: User is updated
           schema:
             $ref: '#/definitions/UserResponseObject'
+        400:
+          description: Invalid Input
+          schema:
+            $ref: '#/definitions/ErrorInvalidInput'
         401:
           description: Unauthorized
           schema:
@@ -172,6 +181,10 @@ paths:
           description: Valid user is not found
           schema:
             $ref: '#/definitions/ErrorUserNotAvailable'
+        409:
+          description: User attribute value already exists
+          schema:
+            $ref: '#/definitions/ErrorUserConflict'
     delete:
       tags:
         - Me Endpoint
@@ -239,6 +252,10 @@ paths:
           description: User is updated
           schema:
             $ref: '#/definitions/PatchOperationResponseOutput'
+        400:
+          description: Invalid Input
+          schema:
+            $ref: '#/definitions/ErrorInvalidInput'
         401:
           description: Unauthorized
           schema:
@@ -247,6 +264,10 @@ paths:
           description: Valid user is not found
           schema:
             $ref: '#/definitions/ErrorUserNotAvailable'
+        409:
+          description: User attribute value already exists
+          schema:
+            $ref: '#/definitions/ErrorUserConflict'
   /Groups:
     get:
       tags:
@@ -741,6 +762,11 @@ paths:
           schema:
             $ref: '#/definitions/ErrorUserNotAvailable'
 
+        409:
+          description: User attribute value already exists
+          schema:
+            $ref: '#/definitions/ErrorUserConflict'
+
         500:
           description: Internal Server Error
           schema:
@@ -872,7 +898,10 @@ paths:
           description: Valid user is found
           schema:
             $ref: '#/definitions/UserResponseObject'
-
+        400:
+          description: Invalid Input
+          schema:
+            $ref: '#/definitions/ErrorInvalidInput'
         401:
           description: Unauthorized
           schema:
@@ -885,6 +914,10 @@ paths:
           description: Valid user is not found
           schema:
             $ref: '#/definitions/ErrorUserNotAvailable'
+        409:
+          description: User attribute value already exists
+          schema:
+            $ref: '#/definitions/ErrorUserConflict'
     delete:
       tags:
         - Users Endpoint
@@ -967,7 +1000,10 @@ paths:
           description: Valid user is found
           schema:
             $ref: '#/definitions/UserResponseObject'
-
+        400:
+          description: Invalid Input
+          schema:
+            $ref: '#/definitions/ErrorInvalidInput'
         401:
           description: Unauthorized
           schema:
@@ -980,6 +1016,10 @@ paths:
           description: Valid user is not found
           schema:
             $ref: '#/definitions/ErrorUserNotAvailable'
+        409:
+          description: User attribute value already exists
+          schema:
+            $ref: '#/definitions/ErrorUserConflict'
 
   /Roles:
     get:
@@ -4488,6 +4528,26 @@ definitions:
       scimType:
         type: string
         example: "Forbidden"
+
+  #-----------------------------------------------------
+  # The Error User Conflict - for user attribute uniqueness violations
+  #-----------------------------------------------------
+  ErrorUserConflict:
+    type: object
+    required:
+      - status
+      - schemas
+      - detail
+    properties:
+      status:
+        type: string
+        example: "409"
+      schemas:
+        type: string
+        example: "urn:ietf:params:scim:api:messages:2.0:Error"
+      detail:
+        type: string
+        example: "The value defined for Email is already in use by a different user!"
 
   #-----------------------------------------------------
   # The Error User Not Available


### PR DESCRIPTION
## Purpose
- According to the [SCIM 2.0 specification](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12:~:text=If%20the%20service,Section%203.12.), a 409 Conflict response should be returned when a uniqueness constraint is violated. This PR introduces configurable error handling for duplicate claims in SCIM2 user management by adding a new configuration property (Property is retrieved from the config store, if not found fall back to the server level config) that allows SCIM2 endpoints to return a 409 Conflict instead of the current default 400 Bad Request when such violations occur.

- To enable the corresponding configuration, execute the following curl :

```
curl --location 'https://<HOSTNAME>/t/<ORG>/api/identity/config-mgt/v1.0/resource/compatibility-settings' \
--header 'Authorization: Bearer <TOKEN>' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data '{
    "name": "scim2",
    "attributes": [
        { "key": "conflictOnClaimUniquenessViolation", "value": true }
    ]
}'
```

- Resolves https://github.com/wso2/product-is/issues/25252

### To be merged after 
- https://github.com/wso2/carbon-identity-framework/pull/7290