### PR TITLE
Throw the user creation error by the config.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -162,6 +162,7 @@ import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.BU
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.BULK_DELETE_USER_OP;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.BULK_UPDATE_GROUP_OP;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.BULK_UPDATE_USER_OP;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.SCIM2_THROW_USER_STORE_EXCEPTION_ON_USER_CREATION_ERROR;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.SCIM_ENTERPRISE_USER_CLAIM_DIALECT;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.SCIM_SYSTEM_USER_CLAIM_DIALECT;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils.buildAgentSchema;
@@ -459,6 +460,15 @@ public class SCIMUserManager implements UserManager {
 
             try {
                 handleErrorsOnUserNameAndPasswordPolicy(e);
+                boolean isThrowUserStoreExceptionOnUserCreationErrorEnabled = Boolean.parseBoolean(IdentityUtil.
+                        getProperty(SCIMCommonConstants.SCIM2_THROW_USER_STORE_EXCEPTION_ON_USER_CREATION_ERROR));
+                String errorMessage = "Error in adding the user: " + maskIfRequired(user.getUserName()) +
+                        " to the user store.";
+                if (isThrowUserStoreExceptionOnUserCreationErrorEnabled) {
+                    throw resolveError(e, errorMessage);
+                } else {
+                    log.error(errorMessage, e);
+                }
             } catch (BadRequestException | CharonException exception) {
                 publishEventOnUserRegistrationFailure(user, exception.getScimType(), exception.getDetail(),
                         claimsInLocalDialect);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -138,6 +138,8 @@ public class SCIMCommonConstants {
             "SCIM2.ConsiderServerWideUserEndpointMaxLimit";
     public static final String SCIM2_RETURN_CONFLICT_ON_CLAIM_UNIQUENESS_VIOLATION =
             "SCIM2.ReturnConflictOnClaimUniquenessViolation";
+    public static final String SCIM2_THROW_USER_STORE_EXCEPTION_ON_USER_CREATION_ERROR =
+            "SCIM2.ThrowUserStoreExceptionOnUserCreationError";
 
     // Constants related to backward compatibility configurations from config store.
     public static final String RESOURCE_TYPE_COMPATIBILITY_SETTINGS = "compatibility-settings";


### PR DESCRIPTION
## Purpose
- $subject since the user store exception it either logged or thrown.
- This PR will be throwing the error properly as correct behaviour.

## Related issues
- https://github.com/wso2/product-is/issues/25086