### PR TITLE
Introduce date and epoch data types

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -6440,10 +6440,6 @@ public class SCIMUserManager implements UserManager {
 
         dataType = dataType.toUpperCase();
 
-        if (SCIMCommonConstants.DateFormats.getList().contains(dataType)) {
-            return SCIMDefinitions.DataType.DATE_TIME;
-        }
-
         switch (SCIMDefinitions.DataType.valueOf(dataType)) {
             case BOOLEAN:
                 return SCIMDefinitions.DataType.BOOLEAN;
@@ -6453,6 +6449,10 @@ public class SCIMUserManager implements UserManager {
                 return SCIMDefinitions.DataType.INTEGER;
             case DATE_TIME:
                 return SCIMDefinitions.DataType.DATE_TIME;
+            case DATE:
+                return SCIMDefinitions.DataType.DATE;
+            case EPOCH:
+                return SCIMDefinitions.DataType.EPOCH;
             case BINARY:
                 return SCIMDefinitions.DataType.BINARY;
             case REFERENCE:
@@ -6568,10 +6568,6 @@ public class SCIMUserManager implements UserManager {
             if (StringUtils.isNotEmpty(mappedLocalClaim.getClaimProperty(ClaimConstants.INPUT_FORMAT_PROPERTY))) {
                 JSONObject inputFormat =
                         new JSONObject(mappedLocalClaim.getClaimProperty(ClaimConstants.INPUT_FORMAT_PROPERTY));
-                if (SCIMDefinitions.DataType.DATE_TIME.equals(attribute.getType())) {
-                    String format = mappedLocalClaim.getClaimProperties().get(SCIMConfigConstants.DATA_TYPE);
-                    inputFormat.put(INPUT_FORMAT_DATA_FORMAT_PROPERTY, format);
-                }
                 attribute.addAttributeJSONProperty(ClaimConstants.INPUT_FORMAT_PROPERTY, inputFormat);
             }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -21,11 +21,8 @@ package org.wso2.carbon.identity.scim2.common.utils;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.charon3.core.schema.SCIMConstants;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Class to hold Identity SCIM Constants.
@@ -201,18 +198,6 @@ public class SCIMCommonConstants {
     public static Map<String, String> getGroupAttributeSchemaMap() {
 
         return groupAttributeSchemaMap;
-    }
-
-    public enum DateFormats {
-
-        DATE_TIME,
-        DATE,
-        EPOCH;
-
-        public static List<String> getList() {
-
-            return Arrays.stream(values()).map(Enum::name).collect(Collectors.toList());
-        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -1652,7 +1652,7 @@ public class SCIMUserManagerTest {
 
         Map<String, String> dateTimeProperties = new HashMap<String, String>() {{
             put("SupportedByDefault", "true");
-            put("dataType", SCIMCommonConstants.DateFormats.DATE.name());
+            put("dataType", SCIMDefinitions.DataType.DATE.name());
             put("inputFormat", "{\"inputType\" : \"date_picker\"}");
         }};
 
@@ -1684,13 +1684,12 @@ public class SCIMUserManagerTest {
         }
 
         assertNotNull(createdAttribute, "Created attribute should exist in schema");
-        assertEquals(createdAttribute.getType(), SCIMDefinitions.DataType.DATE_TIME);
+        assertEquals(createdAttribute.getType(), SCIMDefinitions.DataType.DATE);
         
         // Verify that the inputFormat contains both the original inputType and the format from DataType
         JSONObject inputFormat = createdAttribute.getAttributeJSONProperty("inputFormat");
         assertNotNull(inputFormat, "InputFormat should not be null");
         assertEquals(inputFormat.get("inputType"), "date_picker");
-        assertEquals(inputFormat.get("format"), SCIMCommonConstants.DateFormats.DATE.name());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>
-        <charon.version>5.0.0</charon.version>
+        <charon.version>5.0.1</charon.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.1.45
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.version>2.0.16


### PR DESCRIPTION
## Purpose
Reverted previously added logic to expose the date and epoch data types as date_time type from the scim2/Schemas response. Improved the date type handling logic to consider the extended SCIM date types.

## Related Issues
- https://github.com/wso2/product-is/issues/25560

## Related PRs
- https://github.com/wso2/charon/pull/448

