### PR TITLE
Fix incorrect wrapping of UserStoreClientException as server error

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -115,6 +115,9 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             this.populateSCIMAttributes(userID, claims);
             return true;
         } catch (UserStoreClientException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Client error occurred while adding user with ID: " + userID + ". Error: " + e.getMessage());
+            }
             throw e;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Error while reading isScimEnabled from userstore manager", e);

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -114,6 +114,8 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             }
             this.populateSCIMAttributes(userID, claims);
             return true;
+        } catch (UserStoreClientException e) {
+            throw e;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Error while reading isScimEnabled from userstore manager", e);
         }


### PR DESCRIPTION
## Summary

- In `doPreAddUserWithID`, the broad `catch (org.wso2.carbon.user.api.UserStoreException)` block catches `UserStoreClientException` thrown by claim validation (e.g., invalid mobile number regex) and incorrectly wraps it as a server error with the misleading message "Error while reading isScimEnabled from userstore manager".
- Added a `catch (UserStoreClientException e)` block before the general catch to re-throw client errors as-is, preserving the correct error message and HTTP status code.

## Related Issue

Fixes https://github.com/wso2/product-is/issues/25822

## Test Plan

- Send a SCIM2 user creation request with an invalid mobile number (e.g., `"asfhakfh09"`)
- Verify the response returns a proper client error with the regex validation message instead of a 500 server error with "Error while reading isScimEnabled from userstore manager"