### PR TITLE
Refactor cache operations to use read-safe methods for concurrent environments

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMAgentAttributeSchemaCache.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMAgentAttributeSchemaCache.java
@@ -72,6 +72,25 @@ public class SCIMAgentAttributeSchemaCache
     }
 
     /**
+     * Add agent attribute schema to cache against tenantId during a read flow.
+     * This method does not send cache invalidation messages to other cluster nodes,
+     * preventing redundant invalidations when populating the cache from a DB read.
+     *
+     * @param tenantId             TenantId.
+     * @param agentAttributeSchema AgentAttributeSchema.
+     */
+    public void addSCIMAgentAttributeSchemaOnRead(int tenantId, AttributeSchema agentAttributeSchema) {
+
+        SCIMAgentAttributeSchemaCacheKey cacheKey = new SCIMAgentAttributeSchemaCacheKey(tenantId);
+        SCIMAgentAttributeSchemaCacheEntry cacheEntry = new SCIMAgentAttributeSchemaCacheEntry(agentAttributeSchema);
+        super.addToCacheOnRead(cacheKey, cacheEntry);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("[AddToCacheOnRead] Successfully added scim agent attributes into SCIMAgentSchemaCache "
+                    + "for the tenant: " + tenantId);
+        }
+    }
+
+    /**
      * Get SCIM2 Agent AttributeSchema by tenantId.
      *
      * @param tenantId TenantId.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMCustomAttributeSchemaCache.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMCustomAttributeSchemaCache.java
@@ -71,6 +71,25 @@ public class SCIMCustomAttributeSchemaCache extends BaseCache<SCIMCustomAttribut
 
     }
 
+    /**
+     * Add custom attribute schema to cache against tenantId during a read flow.
+     * This method does not send cache invalidation messages to other cluster nodes,
+     * preventing redundant invalidations when populating the cache from a DB read.
+     *
+     * @param tenantId TenantId.
+     * @param customAttributeSchema CustomAttributeSchema.
+     */
+    public void addSCIMCustomAttributeSchemaOnRead(int tenantId, AttributeSchema customAttributeSchema) {
+
+        SCIMCustomAttributeSchemaCacheKey cacheKey = new SCIMCustomAttributeSchemaCacheKey(tenantId);
+        SCIMCustomAttributeSchemaCacheEntry cacheEntry = new SCIMCustomAttributeSchemaCacheEntry(customAttributeSchema);
+        super.addToCacheOnRead(cacheKey, cacheEntry);
+        if (log.isDebugEnabled()) {
+            log.debug("[AddToCacheOnRead] Successfully added scim custom attributes into SCIMCustomSchemaCache "
+                    + "for the tenant: " + tenantId);
+        }
+    }
+
 
     /**
      * Get SCIM2 Custom AttributeSchema by tenantId.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCache.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCache.java
@@ -72,6 +72,25 @@ public class SCIMSystemAttributeSchemaCache
 
     }
 
+    /**
+     * Add system attribute schema to cache against tenantId during a read flow.
+     * This method does not send cache invalidation messages to other cluster nodes,
+     * preventing redundant invalidations when populating the cache from a DB read.
+     *
+     * @param tenantId TenantId.
+     * @param systemAttributeSchema SystemAttributeSchema.
+     */
+    public void addSCIMSystemAttributeSchemaOnRead(int tenantId, AttributeSchema systemAttributeSchema) {
+
+        SCIMSystemAttributeSchemaCacheKey cacheKey = new SCIMSystemAttributeSchemaCacheKey(tenantId);
+        SCIMSystemAttributeSchemaCacheEntry cacheEntry = new SCIMSystemAttributeSchemaCacheEntry(systemAttributeSchema);
+        super.addToCacheOnRead(cacheKey, cacheEntry);
+        if (log.isDebugEnabled()) {
+            log.debug("[AddToCacheOnRead] Successfully added scim system attributes into SCIMSystemSchemaCache "
+                    + "for the tenant: " + tenantId);
+        }
+    }
+
 
     /**
      * Get SCIM2 System AttributeSchema by tenantId.

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonUtils.java
@@ -1059,7 +1059,7 @@ public class SCIMCommonUtils {
                             getCustomSchemaURI());
             AttributeSchema attributeSchema = SCIMCustomSchemaExtensionBuilder.getInstance()
                     .buildUserCustomSchemaExtension(attributes);
-            SCIMCustomAttributeSchemaCache.getInstance().addSCIMCustomAttributeSchema(tenantId, attributeSchema);
+            SCIMCustomAttributeSchemaCache.getInstance().addSCIMCustomAttributeSchemaOnRead(tenantId, attributeSchema);
             return attributeSchema;
         } catch (InternalErrorException | IdentitySCIMException e) {
             throw new CharonException("Error while building scim custom schema", e);
@@ -1082,7 +1082,7 @@ public class SCIMCommonUtils {
                             SCIMConstants.SYSTEM_USER_SCHEMA_URI);
             AttributeSchema attributeSchema = SCIMSystemSchemaExtensionBuilder.getInstance()
                     .buildSystemSchemaExtension(attributes);
-            SCIMSystemAttributeSchemaCache.getInstance().addSCIMSystemAttributeSchema(tenantId, attributeSchema);
+            SCIMSystemAttributeSchemaCache.getInstance().addSCIMSystemAttributeSchemaOnRead(tenantId, attributeSchema);
             return attributeSchema;
         } catch (InternalErrorException | IdentitySCIMException e) {
             throw new CharonException("Error while building scim system schema", e);
@@ -1104,7 +1104,7 @@ public class SCIMCommonUtils {
                     SCIMConstants.AGENT_SCHEMA_URI);
             AttributeSchema attributeSchema = SCIMAgentSchemaExtensionBuilder.getInstance()
                     .buildAgentSchemaExtension(attributes);
-            SCIMAgentAttributeSchemaCache.getInstance().addSCIMAgentAttributeSchema(tenantId, attributeSchema);
+            SCIMAgentAttributeSchemaCache.getInstance().addSCIMAgentAttributeSchemaOnRead(tenantId, attributeSchema);
             return attributeSchema;
         } catch (InternalErrorException | IdentitySCIMException e) {
             log.error("Error while building SCIM agent schema", e);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMAgentAttributeSchemaCacheTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMAgentAttributeSchemaCacheTest.java
@@ -239,6 +239,90 @@ public class SCIMAgentAttributeSchemaCacheTest {
         assertEquals(schema, cache.getSCIMAgentAttributeSchemaByTenant(tenantId));
     }
 
+    // --- Read-path (addSCIMAgentAttributeSchemaOnRead) tests ---
+    // Use dedicated tenant IDs (500+) to avoid collisions with write-path tests
+    // running in the same singleton cache instance.
+
+    @Test
+    public void testAddSCIMAgentAttributeSchemaOnRead() {
+
+        cache.addSCIMAgentAttributeSchemaOnRead(501, mockAttributeSchema);
+        AttributeSchema result = cache.getSCIMAgentAttributeSchemaByTenant(501);
+        assertNotNull(result);
+        assertEquals(mockAttributeSchema, result);
+    }
+
+    @Test
+    public void testAddSCIMAgentAttributeSchemaOnRead_NullSchema() {
+
+        cache.addSCIMAgentAttributeSchemaOnRead(502, null);
+        assertNull(cache.getSCIMAgentAttributeSchemaByTenant(502));
+    }
+
+    @Test
+    public void testAddSCIMAgentAttributeSchemaOnRead_MultipleTenants() {
+
+        AttributeSchema schema1 = mock(AttributeSchema.class);
+        AttributeSchema schema2 = mock(AttributeSchema.class);
+
+        cache.addSCIMAgentAttributeSchemaOnRead(510, schema1);
+        cache.addSCIMAgentAttributeSchemaOnRead(520, schema2);
+
+        assertEquals(schema1, cache.getSCIMAgentAttributeSchemaByTenant(510));
+        assertEquals(schema2, cache.getSCIMAgentAttributeSchemaByTenant(520));
+    }
+
+    @Test
+    public void testAddSCIMAgentAttributeSchemaOnRead_DoesNotOverwriteExistingEntry() {
+
+        AttributeSchema firstSchema = mock(AttributeSchema.class);
+        AttributeSchema secondSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMAgentAttributeSchemaOnRead(503, firstSchema);
+        cache.addSCIMAgentAttributeSchemaOnRead(503, secondSchema);
+
+        // putOnRead is a no-op if entry already exists; first value retained.
+        AttributeSchema result = cache.getSCIMAgentAttributeSchemaByTenant(503);
+        assertEquals(firstSchema, result);
+        assertNotEquals(secondSchema, result);
+    }
+
+    @Test
+    public void testAddSCIMAgentAttributeSchemaOnRead_WritePathOverridesOnReadEntry() {
+
+        AttributeSchema readSchema = mock(AttributeSchema.class);
+        AttributeSchema writeSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMAgentAttributeSchemaOnRead(504, readSchema);
+        cache.addSCIMAgentAttributeSchema(504, writeSchema);
+
+        assertEquals(writeSchema, cache.getSCIMAgentAttributeSchemaByTenant(504));
+    }
+
+    @Test
+    public void testAddSCIMAgentAttributeSchemaOnRead_OnReadDoesNotOverwriteWritePathEntry() {
+
+        AttributeSchema writeSchema = mock(AttributeSchema.class);
+        AttributeSchema readSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMAgentAttributeSchema(505, writeSchema);
+        cache.addSCIMAgentAttributeSchemaOnRead(505, readSchema);
+
+        // putOnRead should not overwrite; write-path value retained.
+        assertEquals(writeSchema, cache.getSCIMAgentAttributeSchemaByTenant(505));
+    }
+
+    @Test
+    public void testOnReadEntry_ClearedByTenantClear() {
+
+        final List<Integer> tenantList = new ArrayList<>(Collections.singletonList(506));
+        scimCommonUtilsStaticMock.when(() -> SCIMCommonUtils.getOrganizationsToInvalidateCaches(506))
+                .thenReturn(tenantList);
+        cache.addSCIMAgentAttributeSchemaOnRead(506, mockAttributeSchema);
+        cache.clearSCIMAgentAttributeSchemaByTenant(506);
+        assertNull(cache.getSCIMAgentAttributeSchemaByTenant(506));
+    }
+
     @AfterClass
     public void tearDown() {
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMCustomAttributeSchemaCacheTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMCustomAttributeSchemaCacheTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim2.common.cache;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
+import org.wso2.charon3.core.schema.AttributeSchema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Unit tests for SCIMCustomAttributeSchemaCache.
+ */
+@WithCarbonHome
+public class SCIMCustomAttributeSchemaCacheTest {
+
+    private SCIMCustomAttributeSchemaCache cache;
+    private AttributeSchema mockAttributeSchema;
+    private MockedStatic<SCIMCommonUtils> scimCommonUtilsStaticMock;
+
+    private final List<Integer> v0TenantList = new ArrayList<>(Collections.singletonList(1));
+    private final List<Integer> v1TenantList = new ArrayList<>(Arrays.asList(1, 111));
+
+    @BeforeClass
+    public void setUpTests() {
+
+        scimCommonUtilsStaticMock = mockStatic(SCIMCommonUtils.class);
+    }
+
+    @BeforeMethod
+    public void setUp() {
+
+        cache = SCIMCustomAttributeSchemaCache.getInstance();
+        mockAttributeSchema = mock(AttributeSchema.class);
+    }
+
+    // --- Write-path (addSCIMCustomAttributeSchema) tests ---
+
+    @Test
+    public void testAddSCIMCustomAttributeSchema() {
+
+        cache.addSCIMCustomAttributeSchema(1, mockAttributeSchema);
+        AttributeSchema result = cache.getSCIMCustomAttributeSchemaByTenant(1);
+        assertNotNull(result);
+        assertEquals(mockAttributeSchema, result);
+    }
+
+    @Test
+    public void testGetSCIMCustomAttributeSchemaByTenant_NotFound() {
+
+        AttributeSchema result = cache.getSCIMCustomAttributeSchemaByTenant(999);
+        assertNull(result);
+    }
+
+    @Test
+    public void testClearSCIMCustomAttributeSchemaByTenant() {
+
+        scimCommonUtilsStaticMock.when(() -> SCIMCommonUtils.getOrganizationsToInvalidateCaches(1))
+                .thenReturn(v0TenantList);
+        cache.addSCIMCustomAttributeSchema(1, mockAttributeSchema);
+        cache.addSCIMCustomAttributeSchema(111, mockAttributeSchema);
+        cache.clearSCIMCustomAttributeSchemaByTenant(1);
+        AttributeSchema result = cache.getSCIMCustomAttributeSchemaByTenant(1);
+        assertNull(result);
+        AttributeSchema subOrgResult = cache.getSCIMCustomAttributeSchemaByTenant(111);
+        assertNotNull(subOrgResult);
+    }
+
+    @Test
+    public void testClearSCIMCustomAttributeSchemaByV1Tenant() {
+
+        scimCommonUtilsStaticMock.when(() -> SCIMCommonUtils.getOrganizationsToInvalidateCaches(1))
+                .thenReturn(v1TenantList);
+        cache.addSCIMCustomAttributeSchema(1, mockAttributeSchema);
+        cache.addSCIMCustomAttributeSchema(111, mockAttributeSchema);
+        cache.clearSCIMCustomAttributeSchemaByTenant(1);
+        assertNull(cache.getSCIMCustomAttributeSchemaByTenant(1));
+        assertNull(cache.getSCIMCustomAttributeSchemaByTenant(111));
+    }
+
+    @Test
+    public void testClearSCIMCustomAttributeSchemaByTenant_NonExistentTenant() {
+
+        cache.clearSCIMCustomAttributeSchemaByTenant(999);
+        // No exception should be thrown.
+    }
+
+    @Test
+    public void testSingletonInstance() {
+
+        SCIMCustomAttributeSchemaCache instance1 = SCIMCustomAttributeSchemaCache.getInstance();
+        SCIMCustomAttributeSchemaCache instance2 = SCIMCustomAttributeSchemaCache.getInstance();
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testMultipleTenants() {
+
+        AttributeSchema schema1 = mock(AttributeSchema.class);
+        AttributeSchema schema2 = mock(AttributeSchema.class);
+
+        cache.addSCIMCustomAttributeSchema(10, schema1);
+        cache.addSCIMCustomAttributeSchema(20, schema2);
+
+        assertEquals(schema1, cache.getSCIMCustomAttributeSchemaByTenant(10));
+        assertEquals(schema2, cache.getSCIMCustomAttributeSchemaByTenant(20));
+    }
+
+    @Test
+    public void testOverwriteExistingEntry() {
+
+        AttributeSchema firstSchema = mock(AttributeSchema.class);
+        AttributeSchema secondSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMCustomAttributeSchema(1, firstSchema);
+        cache.addSCIMCustomAttributeSchema(1, secondSchema);
+
+        AttributeSchema result = cache.getSCIMCustomAttributeSchemaByTenant(1);
+        assertEquals(secondSchema, result);
+        assertNotEquals(firstSchema, result);
+    }
+
+    @Test
+    public void testNullAttributeSchema() {
+
+        cache.addSCIMCustomAttributeSchema(1, null);
+        assertNull(cache.getSCIMCustomAttributeSchemaByTenant(1));
+    }
+
+    @Test
+    public void testCacheKeyEquality() {
+
+        SCIMCustomAttributeSchemaCacheKey key1 = new SCIMCustomAttributeSchemaCacheKey(1);
+        SCIMCustomAttributeSchemaCacheKey key2 = new SCIMCustomAttributeSchemaCacheKey(1);
+        SCIMCustomAttributeSchemaCacheKey key3 = new SCIMCustomAttributeSchemaCacheKey(2);
+
+        assertEquals(key1, key2);
+        assertNotEquals(key1, key3);
+    }
+
+    @Test
+    public void testCacheKeyHashCode() {
+
+        SCIMCustomAttributeSchemaCacheKey key1 = new SCIMCustomAttributeSchemaCacheKey(1);
+        SCIMCustomAttributeSchemaCacheKey key2 = new SCIMCustomAttributeSchemaCacheKey(1);
+
+        assertEquals(key1.hashCode(), key2.hashCode());
+    }
+
+    @Test
+    public void testCacheKeyEqualityWithSameObject() {
+
+        SCIMCustomAttributeSchemaCacheKey key = new SCIMCustomAttributeSchemaCacheKey(1);
+        assertEquals(key, key);
+    }
+
+    @Test
+    public void testCacheKeyEqualityWithNull() {
+
+        SCIMCustomAttributeSchemaCacheKey key = new SCIMCustomAttributeSchemaCacheKey(1);
+        assertNotEquals(key, null);
+    }
+
+    @Test
+    public void testCacheKeyEqualityWithDifferentClass() {
+
+        SCIMCustomAttributeSchemaCacheKey key = new SCIMCustomAttributeSchemaCacheKey(1);
+        assertNotEquals(key, "different");
+    }
+
+    @Test
+    public void testCacheKeyGetTenantId() {
+
+        int tenantId = 42;
+        SCIMCustomAttributeSchemaCacheKey key = new SCIMCustomAttributeSchemaCacheKey(tenantId);
+        assertEquals(tenantId, key.getTenantId());
+    }
+
+    @Test
+    public void testCacheEntryGetSchema() {
+
+        SCIMCustomAttributeSchemaCacheEntry entry = new SCIMCustomAttributeSchemaCacheEntry(mockAttributeSchema);
+        assertEquals(mockAttributeSchema, entry.getSCIMCustomAttributeSchema());
+    }
+
+    // --- Read-path (addSCIMCustomAttributeSchemaOnRead) tests ---
+    // Use dedicated tenant IDs (700+) to avoid collisions with write-path tests
+    // running in the same singleton cache instance.
+
+    @Test
+    public void testAddSCIMCustomAttributeSchemaOnRead() {
+
+        cache.addSCIMCustomAttributeSchemaOnRead(701, mockAttributeSchema);
+        AttributeSchema result = cache.getSCIMCustomAttributeSchemaByTenant(701);
+        assertNotNull(result);
+        assertEquals(mockAttributeSchema, result);
+    }
+
+    @Test
+    public void testAddSCIMCustomAttributeSchemaOnRead_NullSchema() {
+
+        cache.addSCIMCustomAttributeSchemaOnRead(702, null);
+        assertNull(cache.getSCIMCustomAttributeSchemaByTenant(702));
+    }
+
+    @Test
+    public void testAddSCIMCustomAttributeSchemaOnRead_MultipleTenants() {
+
+        AttributeSchema schema1 = mock(AttributeSchema.class);
+        AttributeSchema schema2 = mock(AttributeSchema.class);
+
+        cache.addSCIMCustomAttributeSchemaOnRead(710, schema1);
+        cache.addSCIMCustomAttributeSchemaOnRead(720, schema2);
+
+        assertEquals(schema1, cache.getSCIMCustomAttributeSchemaByTenant(710));
+        assertEquals(schema2, cache.getSCIMCustomAttributeSchemaByTenant(720));
+    }
+
+    @Test
+    public void testAddSCIMCustomAttributeSchemaOnRead_DoesNotOverwriteExistingEntry() {
+
+        AttributeSchema firstSchema = mock(AttributeSchema.class);
+        AttributeSchema secondSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMCustomAttributeSchemaOnRead(703, firstSchema);
+        cache.addSCIMCustomAttributeSchemaOnRead(703, secondSchema);
+
+        // putOnRead is a no-op if entry already exists; first value retained.
+        AttributeSchema result = cache.getSCIMCustomAttributeSchemaByTenant(703);
+        assertEquals(firstSchema, result);
+        assertNotEquals(secondSchema, result);
+    }
+
+    @Test
+    public void testAddSCIMCustomAttributeSchemaOnRead_OnReadDoesNotOverwriteWritePathEntry() {
+
+        AttributeSchema writeSchema = mock(AttributeSchema.class);
+        AttributeSchema readSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMCustomAttributeSchema(704, writeSchema);
+        cache.addSCIMCustomAttributeSchemaOnRead(704, readSchema);
+
+        // putOnRead should not overwrite; write-path value retained.
+        assertEquals(writeSchema, cache.getSCIMCustomAttributeSchemaByTenant(704));
+    }
+
+    @Test
+    public void testAddSCIMCustomAttributeSchemaOnRead_WritePathOverridesOnReadEntry() {
+
+        AttributeSchema readSchema = mock(AttributeSchema.class);
+        AttributeSchema writeSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMCustomAttributeSchemaOnRead(705, readSchema);
+        cache.addSCIMCustomAttributeSchema(705, writeSchema);
+
+        assertEquals(writeSchema, cache.getSCIMCustomAttributeSchemaByTenant(705));
+    }
+
+    @Test
+    public void testOnReadEntry_ClearedByTenantClear() {
+
+        final List<Integer> tenantList = new ArrayList<>(Collections.singletonList(706));
+        scimCommonUtilsStaticMock.when(() -> SCIMCommonUtils.getOrganizationsToInvalidateCaches(706))
+                .thenReturn(tenantList);
+        cache.addSCIMCustomAttributeSchemaOnRead(706, mockAttributeSchema);
+        cache.clearSCIMCustomAttributeSchemaByTenant(706);
+        assertNull(cache.getSCIMCustomAttributeSchemaByTenant(706));
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        scimCommonUtilsStaticMock.close();
+    }
+}

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/cache/SCIMSystemAttributeSchemaCacheTest.java
@@ -151,6 +151,90 @@ public class SCIMSystemAttributeSchemaCacheTest {
         assertEquals(key1.hashCode(), key2.hashCode());
     }
 
+    // --- Read-path (addSCIMSystemAttributeSchemaOnRead) tests ---
+    // Use dedicated tenant IDs (600+) to avoid collisions with write-path tests
+    // running in the same singleton cache instance.
+
+    @Test
+    public void testAddSCIMSystemAttributeSchemaOnRead() {
+
+        cache.addSCIMSystemAttributeSchemaOnRead(601, mockAttributeSchema);
+        AttributeSchema result = cache.getSCIMSystemAttributeSchemaByTenant(601);
+        assertNotNull(result);
+        assertEquals(mockAttributeSchema, result);
+    }
+
+    @Test
+    public void testAddSCIMSystemAttributeSchemaOnRead_NullSchema() {
+
+        cache.addSCIMSystemAttributeSchemaOnRead(602, null);
+        assertNull(cache.getSCIMSystemAttributeSchemaByTenant(602));
+    }
+
+    @Test
+    public void testAddSCIMSystemAttributeSchemaOnRead_MultipleTenants() {
+
+        AttributeSchema schema1 = mock(AttributeSchema.class);
+        AttributeSchema schema2 = mock(AttributeSchema.class);
+
+        cache.addSCIMSystemAttributeSchemaOnRead(610, schema1);
+        cache.addSCIMSystemAttributeSchemaOnRead(620, schema2);
+
+        assertEquals(schema1, cache.getSCIMSystemAttributeSchemaByTenant(610));
+        assertEquals(schema2, cache.getSCIMSystemAttributeSchemaByTenant(620));
+    }
+
+    @Test
+    public void testAddSCIMSystemAttributeSchemaOnRead_DoesNotOverwriteExistingEntry() {
+
+        AttributeSchema firstSchema = mock(AttributeSchema.class);
+        AttributeSchema secondSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMSystemAttributeSchemaOnRead(603, firstSchema);
+        cache.addSCIMSystemAttributeSchemaOnRead(603, secondSchema);
+
+        // putOnRead is a no-op if entry already exists; first value retained.
+        AttributeSchema result = cache.getSCIMSystemAttributeSchemaByTenant(603);
+        assertEquals(firstSchema, result);
+        assertNotEquals(secondSchema, result);
+    }
+
+    @Test
+    public void testAddSCIMSystemAttributeSchemaOnRead_WritePathOverridesOnReadEntry() {
+
+        AttributeSchema readSchema = mock(AttributeSchema.class);
+        AttributeSchema writeSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMSystemAttributeSchemaOnRead(604, readSchema);
+        cache.addSCIMSystemAttributeSchema(604, writeSchema);
+
+        assertEquals(writeSchema, cache.getSCIMSystemAttributeSchemaByTenant(604));
+    }
+
+    @Test
+    public void testAddSCIMSystemAttributeSchemaOnRead_OnReadDoesNotOverwriteWritePathEntry() {
+
+        AttributeSchema writeSchema = mock(AttributeSchema.class);
+        AttributeSchema readSchema = mock(AttributeSchema.class);
+
+        cache.addSCIMSystemAttributeSchema(605, writeSchema);
+        cache.addSCIMSystemAttributeSchemaOnRead(605, readSchema);
+
+        // putOnRead should not overwrite; write-path value retained.
+        assertEquals(writeSchema, cache.getSCIMSystemAttributeSchemaByTenant(605));
+    }
+
+    @Test
+    public void testOnReadEntry_ClearedByTenantClear() {
+
+        final List<Integer> tenantList = new ArrayList<>(Collections.singletonList(606));
+        scimCommonUtilsStaticMock.when(() -> SCIMCommonUtils.getOrganizationsToInvalidateCaches(606))
+                .thenReturn(tenantList);
+        cache.addSCIMSystemAttributeSchemaOnRead(606, mockAttributeSchema);
+        cache.clearSCIMSystemAttributeSchemaByTenant(606);
+        assertNull(cache.getSCIMSystemAttributeSchemaByTenant(606));
+    }
+
     @AfterClass
     public void tearDown() {
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/resources/testng.xml
@@ -40,6 +40,7 @@
             <class name="org.wso2.carbon.identity.scim2.common.listener.SCIMGroupResolverTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.internal.action.PreUpdateProfileActionExecutorTest"/>
             <class name="org.wso2.carbon.identity.scim2.common.cache.SCIMAgentAttributeSchemaCacheTest"/>
+            <class name="org.wso2.carbon.identity.scim2.common.cache.SCIMCustomAttributeSchemaCacheTest"/>
         </classes>
     </test>
 

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
         <carbon.kernel.version>4.10.106</carbon.kernel.version>
-        <identity.framework.version>7.10.73</identity.framework.version>
+        <identity.framework.version>7.10.119</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>
         <identity.governance.version>1.8.12</identity.governance.version>

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <cxf-bundle.version>3.5.11</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.10.106</carbon.kernel.version>
+        <carbon.kernel.version>4.12.22</carbon.kernel.version>
         <identity.framework.version>7.10.119</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
Related issue: https://github.com/wso2/product-is/issues/26225