### PR TITLE
Block the selected identity claim update from scim2/me endpoint.

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -283,6 +283,7 @@ public class SCIMUserManager implements UserManager {
             IDENTITY_CLAIM_URI + "/accountState",
             IDENTITY_CLAIM_URI + "/lockedReason",
             IDENTITY_CLAIM_URI + "/unlockTime",
+            IDENTITY_CLAIM_URI + "/accountDisabled",
             // System managed timestamps.
             IDENTITY_CLAIM_URI + "/lastLoginTime",
             IDENTITY_CLAIM_URI + "/lastLogonTime",

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -262,6 +262,34 @@ public class SCIMUserManager implements UserManager {
     private static final List<String> VERIFICATION_TRIGGERING_CLAIMS =
             Arrays.asList(VERIFIED_EMAIL_ADDRESSES_CLAIM_URI, VERIFIED_MOBILE_NUMBERS_CLAIM_URI);
 
+    /*
+     * Local claims in this set are system-managed security and audit attributes that must not be modified by the
+     * authenticated user via the /Me endpoint. These include failed-attempt counters, account lock/state
+     * attributes, system-managed timestamps, and password-expiry information.
+     */
+    private static final Set<String> ME_ENDPOINT_NOT_UPDATABLE_LOCAL_CLAIMS = new HashSet<>(Arrays.asList(
+            // Failed Attempts related claims
+            IDENTITY_CLAIM_URI + "/failedLoginAttempts",
+            IDENTITY_CLAIM_URI + "/failedLoginAttemptsBeforeSuccess",
+            IDENTITY_CLAIM_URI + "/failedLoginLockoutCount",
+            IDENTITY_CLAIM_URI + "/failedPasswordRecoveryAttempts",
+            IDENTITY_CLAIM_URI + "/failedSMSOTPAttempts",
+            IDENTITY_CLAIM_URI + "/failedTOTPAttempts",
+            IDENTITY_CLAIM_URI + "/failedEmailOTPAttempts",
+            IDENTITY_CLAIM_URI + "/failedBackupCodeAttempts",
+            IDENTITY_CLAIM_URI + "/failedPushAuthAttempts",
+            // Account related claims.
+            IDENTITY_CLAIM_URI + "/accountLocked",
+            IDENTITY_CLAIM_URI + "/accountState",
+            IDENTITY_CLAIM_URI + "/lockedReason",
+            IDENTITY_CLAIM_URI + "/unlockTime",
+            // System managed timestamps.
+            IDENTITY_CLAIM_URI + "/lastLoginTime",
+            IDENTITY_CLAIM_URI + "/lastLogonTime",
+            IDENTITY_CLAIM_URI + "/lastPasswordUpdateTime",
+            IDENTITY_CLAIM_URI + "/passwordExpiryTime"
+    ));
+
     @Deprecated
     public SCIMUserManager(UserStoreManager carbonUserStoreManager, ClaimManager claimManager) {
 
@@ -3114,6 +3142,9 @@ public class SCIMUserManager implements UserManager {
         if (user.getPassword() != null) {
             blockScim2MePasswordUpdateIfRequired();
         }
+
+        // Validate that the user is not attempting to update system-managed security claims.
+        validateRestrictedClaimsForMeUpdate(user);
 
         return updateUser(user, requiredAttributes);
     }
@@ -7901,6 +7932,47 @@ public class SCIMUserManager implements UserManager {
                     + userTenantDomain, e);
         }
         return false;
+    }
+
+    /**
+     * Validates that the user update request via the /Me endpoint does not attempt to modify
+     * system-managed security claims (e.g., failed-attempt counters, account lock attributes,
+     * or system-managed timestamps). These claims must only be managed by the system or by an
+     * administrator via the /Users endpoint.
+     *
+     * @param user The {@link User} object from the Me update request.
+     * @throws BadRequestException If the request contains one or more restricted claims.
+     * @throws CharonException     If an error occurs while extracting claims from the user object.
+     */
+    private void validateRestrictedClaimsForMeUpdate(User user) throws BadRequestException, CharonException {
+
+        Map<String, String> scimToLocalMappings;
+        try {
+            scimToLocalMappings = SCIMCommonUtils.getSCIMtoLocalMappings();
+        } catch (UserStoreException e) {
+            throw new CharonException("Error while retrieving SCIM to local claim mappings.", e);
+        }
+
+        Map<String, String> claims = AttributeMapper.getClaimsMap(user);
+
+        // Map each SCIM claim URI to its local claim URI and check if it matches any restricted local claim.
+        // Collect all restricted SCIM claim URIs found in the request.
+        List<String> restrictedClaimsFound = claims.keySet().stream()
+                .filter(scimClaimUri -> {
+                    String localClaimUri = scimToLocalMappings.get(scimClaimUri);
+                    return localClaimUri != null && ME_ENDPOINT_NOT_UPDATABLE_LOCAL_CLAIMS.stream()
+                            .anyMatch(restricted -> restricted.equalsIgnoreCase(localClaimUri));
+                })
+                .collect(Collectors.toList());
+
+        if (!restrictedClaimsFound.isEmpty()) {
+            String errorMessage = "The following claims are not allowed to be updated via the scim2/Me "
+                    + "endpoint: " + String.join(", ", restrictedClaimsFound);
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage);
+            }
+            throw new BadRequestException(errorMessage, ResponseCodeConstants.MUTABILITY);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -268,7 +268,7 @@ public class SCIMUserManager implements UserManager {
      * attributes, system-managed timestamps, and password-expiry information.
      */
     private static final Set<String> ME_ENDPOINT_NOT_UPDATABLE_LOCAL_CLAIMS = new HashSet<>(Arrays.asList(
-            // Failed Attempts related claims
+            // Failed Attempts related claims.
             IDENTITY_CLAIM_URI + "/failedLoginAttempts",
             IDENTITY_CLAIM_URI + "/failedLoginAttemptsBeforeSuccess",
             IDENTITY_CLAIM_URI + "/failedLoginLockoutCount",

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -203,6 +203,18 @@ public class SCIMUserManagerTest {
     private static final String COMPATIBILITY_SETTING_DISABLE_PASSWORD_UPDATE_IN_ME_ENDPOINT =
             "disablePasswordUpdateInMeEndpoint";
 
+    private static final String IDENTITY_CLAIM_URI = "http://wso2.org/claims/identity";
+
+    // A few representative SCIM claim URIs that map to restricted local claims.
+    private static final String SCIM_FAILED_TOTP_ATTEMPTS =
+            "urn:scim:wso2:schema:failedTOTPAttempts";
+    private static final String SCIM_ACCOUNT_LOCKED =
+            "urn:scim:wso2:schema:accountLocked";
+    private static final String SCIM_ENTERPRISE_ACCOUNT_LOCKED =
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountLocked";
+    private static final String SCIM_DISPLAY_NAME =
+            "urn:ietf:params:scim:schemas:core:2.0:User:displayName";
+
     @Mock
     private AbstractUserStoreManager mockedUserStoreManager;
     @Mock
@@ -2996,5 +3008,122 @@ public class SCIMUserManagerTest {
         return new UserStoreClientException(
                 DUPLICATE_CLAIM_ERROR_MESSAGE, duplicateClaimErrorCode,
                 new PolicyViolationException("testCode", DUPLICATE_CLAIM_ERROR_MESSAGE));
+    }
+
+    @DataProvider(name = "restrictedClaimsForMeUpdateData")
+    public Object[][] restrictedClaimsForMeUpdateData() {
+
+        // scimClaimsInRequest : SCIM claim URIs present in the user payload
+        // scimToLocalMap      : the mapping getSCIMtoLocalMappings() will return
+        // expectException     : whether a BadRequestException is expected
+        Map<String, String> allowedOnlyMap = new HashMap<>();
+        allowedOnlyMap.put(SCIM_DISPLAY_NAME, "http://wso2.org/claims/displayName");
+
+        // Single restricted claim via urn:scim:wso2:schema dialect.
+        Map<String, String> restrictedWso2Map = new HashMap<>();
+        restrictedWso2Map.put(SCIM_FAILED_TOTP_ATTEMPTS, IDENTITY_CLAIM_URI + "/failedTOTPAttempts");
+        restrictedWso2Map.put(SCIM_DISPLAY_NAME, "http://wso2.org/claims/displayName");
+
+        // Single restricted claim via enterprise dialect.
+        Map<String, String> restrictedEnterpriseMap = new HashMap<>();
+        restrictedEnterpriseMap.put(SCIM_ENTERPRISE_ACCOUNT_LOCKED, IDENTITY_CLAIM_URI + "/accountLocked");
+
+        // Mix of restricted and allowed claims.
+        Map<String, String> mixedMap = new HashMap<>();
+        mixedMap.put(SCIM_FAILED_TOTP_ATTEMPTS, IDENTITY_CLAIM_URI + "/failedTOTPAttempts");
+        mixedMap.put(SCIM_ACCOUNT_LOCKED, IDENTITY_CLAIM_URI + "/accountLocked");
+        mixedMap.put(SCIM_DISPLAY_NAME, "http://wso2.org/claims/displayName");
+
+        // Case-insensitive: local claim URI returned with different casing.
+        Map<String, String> caseInsensitiveMap = new HashMap<>();
+        caseInsensitiveMap.put(SCIM_ACCOUNT_LOCKED, IDENTITY_CLAIM_URI.toUpperCase() + "/ACCOUNTLOCKED");
+
+        // SCIM claim present but has no local mapping entry (unknown claim) — should be allowed.
+        Map<String, String> noMappingMap = new HashMap<>();
+        // empty: SCIM_DISPLAY_NAME has no mapping
+
+        return new Object[][] {
+                // description, claimsInPayload, scimToLocalMap, expectBadRequest
+                { "no_restricted_claims", allowedOnlyMap.keySet().stream().collect(java.util.stream.Collectors.toMap(k -> k, k -> "value")), allowedOnlyMap, false },
+                { "restricted_wso2_dialect", restrictedWso2Map.keySet().stream().collect(java.util.stream.Collectors.toMap(k -> k, k -> "value")), restrictedWso2Map, true },
+                { "restricted_enterprise_dialect", restrictedEnterpriseMap.keySet().stream().collect(java.util.stream.Collectors.toMap(k -> k, k -> "value")), restrictedEnterpriseMap, true },
+                { "multiple_restricted_claims", mixedMap.keySet().stream().collect(java.util.stream.Collectors.toMap(k -> k, k -> "value")), mixedMap, true },
+                { "case_insensitive_local_claim", caseInsensitiveMap.keySet().stream().collect(java.util.stream.Collectors.toMap(k -> k, k -> "value")), caseInsensitiveMap, true },
+                { "scim_claim_without_local_mapping", Collections.singletonMap(SCIM_DISPLAY_NAME, "value"), noMappingMap, false },
+        };
+    }
+
+    @Test(dataProvider = "restrictedClaimsForMeUpdateData")
+    public void testValidateRestrictedClaimsForMeUpdate(String description,
+                                                        Map<String, String> claimsInPayload,
+                                                        Map<String, String> scimToLocalMap,
+                                                        boolean expectBadRequest) throws Exception {
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        User user = mock(User.class);
+
+        try (MockedStatic<AttributeMapper> mockedAttributeMapper = mockStatic(AttributeMapper.class)) {
+            mockedAttributeMapper.when(() -> AttributeMapper.getClaimsMap(user)).thenReturn(claimsInPayload);
+            scimCommonUtils.when(SCIMCommonUtils::getSCIMtoLocalMappings).thenReturn(scimToLocalMap);
+
+            Method method = SCIMUserManager.class.getDeclaredMethod("validateRestrictedClaimsForMeUpdate", User.class);
+            method.setAccessible(true);
+
+            try {
+                method.invoke(scimUserManager, user);
+                if (expectBadRequest) {
+                    Assert.fail("Expected BadRequestException for case: " + description);
+                }
+            } catch (InvocationTargetException e) {
+                if (!expectBadRequest) {
+                    Assert.fail("Unexpected exception for case: " + description + " — " + e.getCause());
+                }
+                Throwable cause = e.getCause();
+                assertTrue(cause instanceof BadRequestException,
+                        "Expected BadRequestException but got: " + cause.getClass().getSimpleName());
+                BadRequestException badRequestEx = (BadRequestException) cause;
+                assertEquals(badRequestEx.getScimType(), ResponseCodeConstants.MUTABILITY,
+                        "SCIM type should be MUTABILITY for case: " + description);
+                // The error detail should contain at least one of the SCIM claim URIs that was restricted.
+                String detail = badRequestEx.getDetail();
+                boolean containsRestrictedScimUri = claimsInPayload.keySet().stream()
+                        .filter(scimUri -> (IDENTITY_CLAIM_URI + "/failedTOTPAttempts")
+                                        .equalsIgnoreCase(scimToLocalMap.get(scimUri))
+                                || (IDENTITY_CLAIM_URI + "/accountLocked")
+                                        .equalsIgnoreCase(scimToLocalMap.get(scimUri)))
+                        .anyMatch(scimUri -> detail != null && detail.contains(scimUri));
+                assertTrue(containsRestrictedScimUri,
+                        "Error detail should contain the SCIM claim URI for case: " + description);
+            }
+        }
+    }
+
+    @Test
+    public void testValidateRestrictedClaimsForMeUpdate_UserStoreExceptionThrowsCharonException() throws Exception {
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        User user = mock(User.class);
+
+        try (MockedStatic<AttributeMapper> mockedAttributeMapper = mockStatic(AttributeMapper.class)) {
+            mockedAttributeMapper.when(() -> AttributeMapper.getClaimsMap(user))
+                    .thenReturn(Collections.singletonMap(SCIM_ACCOUNT_LOCKED, "true"));
+            scimCommonUtils.when(SCIMCommonUtils::getSCIMtoLocalMappings)
+                    .thenThrow(new org.wso2.carbon.user.core.UserStoreException("DB error"));
+
+            Method method = SCIMUserManager.class.getDeclaredMethod("validateRestrictedClaimsForMeUpdate", User.class);
+            method.setAccessible(true);
+
+            try {
+                method.invoke(scimUserManager, user);
+                Assert.fail("Expected CharonException to be thrown");
+            } catch (InvocationTargetException e) {
+                assertTrue(e.getCause() instanceof CharonException,
+                        "Expected CharonException but got: " + e.getCause().getClass().getSimpleName());
+            }
+        }
     }
 }


### PR DESCRIPTION
### Purpose
- $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented validation to prevent modifications to system-managed security and audit attributes (such as account lock status, failed login attempts, and password expiry information) during user profile updates through the API.

* **Tests**
  * Added comprehensive test coverage for restricted claims validation, including scenarios for single/multiple restricted claims and case-insensitive matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->