### PR TITLE
Add workflow support for update users of groups

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/DefaultSCIMUserStoreErrorResolver.java
@@ -49,6 +49,11 @@ public class DefaultSCIMUserStoreErrorResolver implements SCIMUserStoreErrorReso
                 (UserCoreConstants.ErrorCode.USER_DELETION_WORKFLOW_CREATED.equals(((org.wso2.carbon.user.core.UserStoreException) e).
                         getErrorCode()))) {
             return new SCIMUserStoreException("User deletion has sent for the approval", HttpStatus.SC_ACCEPTED);
+        } else if (e instanceof org.wso2.carbon.user.core.UserStoreException &&
+                (UserCoreConstants.ErrorCode.UPDATE_GROUP_USERS_WORKFLOW_CREATED.equals(((org.wso2.carbon.user.core.UserStoreException) e).
+                        getErrorCode()))) {
+            return new SCIMUserStoreException("Update group users request has been sent for the approval",
+                    HttpStatus.SC_ACCEPTED);
         } else if (e.getMessage().contains(ERROR_CODE_EXISTING_ROLE_NAME) ||
                 (e instanceof org.wso2.carbon.user.core.UserStoreClientException &&
                         ((UserStoreClientException) e).getErrorCode() != null &&

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <cxf-bundle.version>3.5.11</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.10.106</carbon.kernel.version>
+        <carbon.kernel.version>4.12.25</carbon.kernel.version>
         <identity.framework.version>7.10.73</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <cxf-bundle.version>3.5.11</cxf-bundle.version>
         <inbound.auth.oauth.version>6.5.3</inbound.auth.oauth.version>
         <commons-collections.version>3.2.0.wso2v1</commons-collections.version>
-        <carbon.kernel.version>4.12.25</carbon.kernel.version>
+        <carbon.kernel.version>4.12.35</carbon.kernel.version>
         <identity.framework.version>7.10.119</identity.framework.version>
         <junit.version>4.13.1</junit.version>
         <commons.lang.version>20030203.000129</commons.lang.version>


### PR DESCRIPTION
resolves : https://github.com/wso2/product-is/issues/27001

This pull request introduces an enhancement to the SCIM user store error handling and updates a core dependency version. The most significant change is the addition of a new error resolution path for group user update workflows that require approval, ensuring that such requests are handled gracefully and with the correct status code. Additionally, the project is updated to use a newer version of the Carbon Kernel.

**SCIM User Store Error Handling:**
- Added a new error resolution branch in `DefaultSCIMUserStoreErrorResolver.java` to handle `UPDATE_GROUP_USERS_WORKFLOW_CREATED` errors, returning a `SCIMUserStoreException` with a message indicating that the update group users request has been sent for approval and an HTTP 202 (Accepted) status.

**Dependency Updates:**
- Updated the `carbon.kernel.version` property in `pom.xml` from `4.10.106` to `4.12.25`, ensuring compatibility with the latest features and security updates of the Carbon Kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group-user update requests that require approval now return HTTP 202 (Accepted) with a clear "awaiting approval" message.

* **Chores**
  * Bumped core platform kernel version to align with a newer stable release for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->