### PR TITLE
Fix incorrect userstore domain in SCIM2 group creation response when group ID is disabled

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMGroupResolver.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMGroupResolver.java
@@ -104,6 +104,7 @@ public class SCIMGroupResolver extends AbstractIdentityGroupResolver {
             throw new UserStoreException(
                     String.format("Group id cannot be empty the group: %s in tenant: %s. ", groupWithDomain, tenantId));
         }
+        group.setGroupName(groupWithDomain);
         group.setDisplayName(groupWithDomain);
         group.setUserStoreDomain(domain);
         processTimestampAttributesOnGroupAdd(groupName, tenantId, claims, group);


### PR DESCRIPTION
### Problem                                                                                                                                                                                                        
   
  When creating a group in a secondary userstore (e.g., `OKTA`) via the SCIM2 `/Groups` endpoint, the                                                                                                                
  creation response always returns `PRIMARY/` as the domain prefix regardless of the actual userstore.
  This happens only for userstores where group ID support is disabled (`GroupIDEnabled=false`), which                                                                                                                
  are handled by `SCIMGroupResolver`.

  The root cause is that `SCIMGroupResolver.addGroup()` sets the domain-qualified name only on                                                                                                                       
  `displayName` but leaves the group's `name` field as the bare name. `SCIMUserManager.buildGroup()`
  reads from `name`, and `SCIMCommonUtils.prependDomain()` then unconditionally prepends `PRIMARY/`                                                                                                                  
  when no domain separator is found.                                                                                                                                                                                 
   
  Subsequent GET/filter calls return the correct domain — only the creation response is affected.                                                                                                                    
                  
  ### Fix

  `SCIMGroupResolver.addGroup()` also sets the group's `name` to the domain-qualified value,                                                                                                                
  making the creation response consistent with the GET response.                                                                                                                                                      
   
  ### Related issues                                                                                                                                                                                                 
                  
  - https://github.com/wso2/product-is/issues/27625