### PR TITLE
Resolve shared user ID for shared user SCIM2 Me calls

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -55,6 +55,11 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -3066,6 +3071,7 @@ public class SCIMUserManager implements UserManager {
                 requiredClaimsInLocalDialect = new ArrayList<>();
             }
 
+            userId = resolveSharedUserId(userId);
             org.wso2.carbon.user.core.common.User coreUser = carbonUM.getUser(userId, null);
 
             // We assume (since id is unique per user) only one user exists for a given id.
@@ -3088,7 +3094,36 @@ public class SCIMUserManager implements UserManager {
             throw resolveError(e, "Error from getting the authenticated user");
         } catch (BadRequestException | NotImplementedException e) {
             throw new CharonException("Error from getting the authenticated user");
+        } catch (OrganizationManagementException e) {
+            throw new CharonException("Error while resolving the shared user association.", e);
         }
+    }
+
+    /**
+     * Resolve the shared user ID if the user is shared to the accessing organization.
+     *
+     * @param userId ID of the user.
+     * @return Shared user ID.
+     * @throws OrganizationManagementException If an error occurs while resolving user association.
+     */
+    private String resolveSharedUserId(String userId) throws OrganizationManagementException {
+
+        if (!OrganizationManagementUtil.isOrganization(
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())) {
+            return userId;
+        }
+
+        OrganizationUserSharingService organizationUserSharingService =
+                SCIMCommonComponentHolder.getOrganizationUserSharingService();
+        OrganizationManager organizationManager = SCIMCommonComponentHolder.getOrganizationManager();
+        String accessingOrgId = organizationManager.resolveOrganizationId(
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        UserAssociation userAssociation = organizationUserSharingService.getUserAssociationOfAssociatedUserByOrgId(
+                userId, accessingOrgId);
+        if (userAssociation != null) {
+            return userAssociation.getUserId();
+        }
+        return userId;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.UserBasicInfo;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
@@ -273,6 +274,7 @@ public class SCIMUserManagerTest {
     private MockedStatic<SCIMCommonComponentHolder> scimCommonComponentHolder;
     private MockedStatic<ResourceManagerUtil> resourceManagerUtil;
     private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<OrganizationManagementUtil> organizationManagementUtil;
 
     @BeforeMethod
     public void setUpMethod() {
@@ -289,6 +291,9 @@ public class SCIMUserManagerTest {
         scimSystemSchemaExtensionBuilder = mockStatic(SCIMSystemSchemaExtensionBuilder.class);
         claimMetadataHandler = mockStatic(ClaimMetadataHandler.class);
         resourceManagerUtil = mockStatic(ResourceManagerUtil.class);
+        organizationManagementUtil = mockStatic(OrganizationManagementUtil.class);
+        organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                .thenReturn(false);
         SCIMUserSchemaExtensionBuilder mockSCIMUserSchemaExtensionBuilder = mock(SCIMUserSchemaExtensionBuilder.class);
         SCIMSystemSchemaExtensionBuilder mockSCIMSystemSchemaExtensionBuilder = mock(SCIMSystemSchemaExtensionBuilder.class);
         scimUserSchemaExtensionBuilder.when(SCIMUserSchemaExtensionBuilder::getInstance).thenReturn(mockSCIMUserSchemaExtensionBuilder);
@@ -316,6 +321,7 @@ public class SCIMUserManagerTest {
         scimSystemSchemaExtensionBuilder.close();
         claimMetadataHandler.close();
         resourceManagerUtil.close();
+        organizationManagementUtil.close();
     }
 
     @DataProvider(name = "ClaimData")


### PR DESCRIPTION
### Purpose
If the scim2/Me endpoint is invoked with a shared user access token a 404 response is returned since the resolved user ID the ID of the resident user profile.

### Related issue
- https://github.com/wso2/product-is/issues/27371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced SCIM user identity resolution to correctly map users in organization-sharing contexts.
  * Improved error handling for organization management operations to surface failures more reliably.

* **Tests**
  * Updated unit tests to cover organization-context behavior and static utilities related to organization checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-inbound-provisioning-scim2/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->