### PR TITLE
Enhance SCIM user claim update with pre-update profile action execution

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5935,7 +5935,7 @@ public class SCIMUserManager implements UserManager {
             populateMultiValuedClaimsToModify(oldClaimList, simpleMultiValuedClaimsToBeAdded,
                     simpleMultiValuedClaimsToBeRemoved, userClaimsToBeModifiedIncludingMultiValueClaims);
 
-            ActionExecutionStatus<?> actionExecutionStatus = preUpdateProfileActionExecutor.execute(user,
+            ActionExecutionStatus<?> actionExecutionStatus = preUpdateProfileActionExecutor.executeAndGetStatus(user,
                     userClaimsToBeModifiedIncludingMultiValueClaims, userClaimsToBeDeleted);
             if (actionExecutionStatus != null) {
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -32,6 +32,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -5896,13 +5897,44 @@ public class SCIMUserManager implements UserManager {
 
         if (isExecutableUserProfileUpdate) {
 
-            Map<String, String> multiValuedClaimsToModify =
-                    SCIMCommonUtils.getSimpleMultiValuedClaimsToModify(oldClaimList, simpleMultiValuedClaimsToBeAdded,
-                            simpleMultiValuedClaimsToBeRemoved);
-            userClaimsToBeModifiedIncludingMultiValueClaims.putAll(multiValuedClaimsToModify);
+            populateMultiValuedClaimsToModify(oldClaimList, simpleMultiValuedClaimsToBeAdded,
+                    simpleMultiValuedClaimsToBeRemoved, userClaimsToBeModifiedIncludingMultiValueClaims);
 
-            preUpdateProfileActionExecutor.execute(user, userClaimsToBeModifiedIncludingMultiValueClaims,
-                    userClaimsToBeDeleted);
+            ActionExecutionStatus<?> actionExecutionStatus = preUpdateProfileActionExecutor.execute(user,
+                    userClaimsToBeModifiedIncludingMultiValueClaims, userClaimsToBeDeleted);
+            if (actionExecutionStatus != null) {
+
+                Map<String, String> userClaimsToBeAddedFromAction = (HashMap<String, String>)
+                        actionExecutionStatus.getResponseContext().get("userClaimsToBeAdded");
+                Map<String, String> userClaimsToBeModifiedFromAction = (HashMap<String, String>)
+                        actionExecutionStatus.getResponseContext().get("userClaimsToBeModified");
+                Map<String, String> userClaimsToBeDeletedFromAction = (HashMap<String, String>)
+                        actionExecutionStatus.getResponseContext().get("userClaimsToBeRemoved");
+                Map<String, List<String>> simpleMultiValuedClaimsToBeAddedFromAction = (HashMap<String, List<String>>)
+                        actionExecutionStatus.getResponseContext().get("multiValuedClaimsToBeAdded");
+                Map<String, List<String>> simpleMultiValuedClaimsToBeRemovedFromAction = (HashMap<String, List<String>>)
+                        actionExecutionStatus.getResponseContext().get("multiValuedClaimsToBeRemoved");
+
+                if (userClaimsToBeAddedFromAction != null) {
+                    userClaimsToBeAdded.putAll(userClaimsToBeAddedFromAction);
+                    userClaimsToBeModified.putAll(userClaimsToBeAddedFromAction);
+                }
+                if (userClaimsToBeModifiedFromAction != null) {
+                    userClaimsToBeModified.putAll(userClaimsToBeModifiedFromAction);
+                }
+                if (userClaimsToBeDeletedFromAction != null) {
+                    userClaimsToBeDeleted.putAll(userClaimsToBeDeletedFromAction);
+                    userClaimsToBeModified.keySet().removeAll(userClaimsToBeDeletedFromAction.keySet());
+                }
+                if (simpleMultiValuedClaimsToBeAddedFromAction != null) {
+                    simpleMultiValuedClaimsToBeAdded.putAll(simpleMultiValuedClaimsToBeAddedFromAction);
+                }
+                if (simpleMultiValuedClaimsToBeRemovedFromAction != null) {
+                    simpleMultiValuedClaimsToBeRemoved.putAll(simpleMultiValuedClaimsToBeRemovedFromAction);
+                }
+                populateMultiValuedClaimsToModify(oldClaimList, simpleMultiValuedClaimsToBeAdded,
+                        simpleMultiValuedClaimsToBeRemoved, userClaimsToBeModifiedIncludingMultiValueClaims);
+            }
         }
 
         if (log.isDebugEnabled()) {
@@ -5946,6 +5978,27 @@ public class SCIMUserManager implements UserManager {
             publishUserProfileUpdateEvent(user, userClaimsToBeAdded, userClaimsToBeModifiedIncludingMultiValueClaims,
                     claimsDeleted, oldClaimList);
         }
+    }
+
+    /**
+     * Populate both modifiable single and multi-valued claims.
+     *
+     * @param oldClaimList User claim list for the user's existing state.
+     * @param simpleMultiValuedClaimsToBeAdded Map of simple multi-valued claims to be added.
+     * @param simpleMultiValuedClaimsToBeRemoved Map of simple multi-valued claims to be removed.
+     * @param userClaimsToBeModifiedIncludingMultiValueClaims Map of both single and multi valued claims to be modified.
+     * @return Map with the same keys and values as lists of strings, splitting multi-valued claims if necessary.
+     */
+    private void populateMultiValuedClaimsToModify(Map<String, String> oldClaimList, Map<String, List<String>>
+                                                           simpleMultiValuedClaimsToBeAdded, Map<String,
+                                                           List<String>> simpleMultiValuedClaimsToBeRemoved,
+                                                   Map<String, String> userClaimsToBeModifiedIncludingMultiValueClaims)
+    {
+
+        Map<String, String> multiValuedClaimsToModify =
+                SCIMCommonUtils.getSimpleMultiValuedClaimsToModify(oldClaimList, simpleMultiValuedClaimsToBeAdded,
+                        simpleMultiValuedClaimsToBeRemoved);
+        userClaimsToBeModifiedIncludingMultiValueClaims.putAll(multiValuedClaimsToModify);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
@@ -73,8 +73,16 @@ public class PreUpdateProfileActionExecutor {
      * @param userClaimsToBeDeleted  Collection of existing claims that deletes from the profile
      * @throws UserStoreException If an error occurs while executing the action
      */
-    public ActionExecutionStatus<?> execute(User user, Map<String, String> userClaimsToBeModified,
-                                            Map<String, String> userClaimsToBeDeleted) throws UserStoreException {
+    public void execute(User user, Map<String, String> userClaimsToBeModified,
+                        Map<String, String> userClaimsToBeDeleted) throws UserStoreException {
+
+        executeAndGetStatus(user, userClaimsToBeModified, userClaimsToBeDeleted);
+    }
+
+    // Triggers the execution of pre update profile extension at profile update with PUT and returns execution status.
+    public ActionExecutionStatus<?> executeAndGetStatus(User user, Map<String, String> userClaimsToBeModified,
+                                                        Map<String, String> userClaimsToBeDeleted)
+            throws UserStoreException {
 
         ActionExecutorService actionExecutorService = SCIMCommonComponentHolder.getActionExecutorService();
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutor.java
@@ -73,13 +73,13 @@ public class PreUpdateProfileActionExecutor {
      * @param userClaimsToBeDeleted  Collection of existing claims that deletes from the profile
      * @throws UserStoreException If an error occurs while executing the action
      */
-    public void execute(User user, Map<String, String> userClaimsToBeModified,
-                        Map<String, String> userClaimsToBeDeleted) throws UserStoreException {
+    public ActionExecutionStatus<?> execute(User user, Map<String, String> userClaimsToBeModified,
+                                            Map<String, String> userClaimsToBeDeleted) throws UserStoreException {
 
         ActionExecutorService actionExecutorService = SCIMCommonComponentHolder.getActionExecutorService();
 
         if (!actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)) {
-            return;
+            return null;
         }
 
         LOG.debug("Executing pre update profile action for user: " + user.getId());
@@ -96,7 +96,7 @@ public class PreUpdateProfileActionExecutor {
                     actionExecutorService.execute(ActionType.PRE_UPDATE_PROFILE, flowContext,
                             IdentityContext.getThreadLocalIdentityContext().getTenantDomain());
 
-            handleActionExecutionStatus(actionExecutionStatus);
+            return handleActionExecutionStatus(actionExecutionStatus);
         } catch (ActionExecutionException e) {
             throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PROFILE_ACTION_SERVER_ERROR,
                     "Error while executing pre update profile action.", e);
@@ -119,12 +119,12 @@ public class PreUpdateProfileActionExecutor {
         return userActionRequestDTOBuilder.build();
     }
 
-    private void handleActionExecutionStatus(ActionExecutionStatus<?> actionExecutionStatus)
+    private ActionExecutionStatus<?>  handleActionExecutionStatus(ActionExecutionStatus<?> actionExecutionStatus)
             throws UserStoreException {
 
         switch (actionExecutionStatus.getStatus()) {
             case SUCCESS:
-                return;
+                return actionExecutionStatus;
             case FAILED:
                 Failure failure = (Failure) actionExecutionStatus.getResponse();
                 throw new UserActionExecutionClientException(UserActionError.PRE_UPDATE_PROFILE_ACTION_EXECUTION_FAILED,

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -2614,7 +2614,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
+        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);
@@ -2662,7 +2662,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
+        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);
@@ -2718,7 +2718,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
+        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySetting
 import org.wso2.carbon.identity.compatibility.settings.core.exception.CompatibilitySettingException;
 import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySetting;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.InboundProvisioningConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -2750,6 +2751,139 @@ public class SCIMUserManagerTest {
                     eq("foo"), anyMap(), anyMap(),
                     anyMap(), anyMap(), isNull()
             );
+        }
+    }
+
+    @Test
+    public void testUpdateUserClaims_WhenActionResponseContainsAddedModifiedRemovedClaims() throws Exception {
+
+        SCIMUserManager scimUserManager = spy(new SCIMUserManager(
+                mockedUserStoreManager,
+                mockClaimMetadataManagementService,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
+        ));
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("foo");
+
+        String accountLocked = "http://wso2.org/claims/identity/accountLocked";
+        String accountState = "http://wso2.org/claims/identity/accountState";
+        String accountDisabled = "http://wso2.org/claims/identity/accountDisabled";
+
+        Map<String, String> oldClaims = new HashMap<>();
+        oldClaims.put(accountLocked, "old");
+        oldClaims.put(accountState, "deleteMe");
+
+        Map<String, String> newClaims = new HashMap<>();
+        newClaims.put(accountLocked, "new");
+
+        Map<String, String> multiValuedClaims = Collections.emptyMap();
+
+        Field preUpdateField = SCIMUserManager.class.getDeclaredField("preUpdateProfileActionExecutor");
+        preUpdateField.setAccessible(true);
+        PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
+        preUpdateField.set(scimUserManager, executorMock);
+
+        ActionExecutionStatus<?> actionExecutionStatus = mock(ActionExecutionStatus.class);
+        Map<String, Object> responseContext = new HashMap<>();
+        Map<String, String> addedFromAction = new HashMap<>();
+        addedFromAction.put(accountDisabled, "addedValue");
+        Map<String, String> modifiedFromAction = new HashMap<>();
+        modifiedFromAction.put(accountState, "modifiedValue");
+        Map<String, String> removedFromAction = new HashMap<>();
+        removedFromAction.put(accountLocked, "");
+
+        responseContext.put("userClaimsToBeAdded", addedFromAction);
+        responseContext.put("userClaimsToBeModified", modifiedFromAction);
+        responseContext.put("userClaimsToBeRemoved", removedFromAction);
+        when(actionExecutionStatus.getResponseContext()).thenReturn(responseContext);
+        scimCommonUtils.when(() -> SCIMCommonUtils.isExecutableUserProfileUpdate(anyMap(), anyMap(), anyMap(), anyMap()))
+                .thenReturn(true);
+        doReturn(actionExecutionStatus).when(executorMock)
+                .executeAndGetStatus(any(User.class), anyMap(), anyMap());
+
+        Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
+        carbonUMField.setAccessible(true);
+        carbonUMField.set(scimUserManager, mockedUserStoreManager);
+
+        doNothing().when(mockedUserStoreManager).setUserClaimValuesWithID(anyString(), anyMap(), isNull());
+        doNothing().when(mockedUserStoreManager).deleteUserClaimValueWithID(anyString(), anyString(), isNull());
+
+        Method m = SCIMUserManager.class.getDeclaredMethod(
+                "updateUserClaims", User.class, Map.class, Map.class, Map.class
+        );
+        m.setAccessible(true);
+        m.invoke(scimUserManager, user, oldClaims, newClaims, multiValuedClaims);
+
+        verify(mockedUserStoreManager).setUserClaimValuesWithID(eq("foo"),
+                argThat(map -> map.containsKey(accountDisabled)
+                        && map.containsKey(accountState)
+                        && !map.containsKey(accountLocked)),
+                isNull());
+    }
+
+    @Test
+    public void testUpdateUserClaims_WhenActionResponseContainsMultiValuedClaims() throws Exception {
+
+        SCIMUserManager scimUserManager = spy(new SCIMUserManager(
+                mockedUserStoreManager,
+                mockClaimMetadataManagementService,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
+        ));
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("foo");
+
+        Map<String, String> oldClaims = new HashMap<>();
+        oldClaims.put("emails", "a@wso2.com,b@wso2.com");
+
+        Map<String, String> newClaims = new HashMap<>();
+        newClaims.put("emails", "a@wso2.com,b@wso2.com");
+
+        Map<String, String> multiValuedClaims = new HashMap<>();
+        multiValuedClaims.put("emails", "");
+
+        Field preUpdateField = SCIMUserManager.class.getDeclaredField("preUpdateProfileActionExecutor");
+        preUpdateField.setAccessible(true);
+        PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
+        preUpdateField.set(scimUserManager, executorMock);
+
+        ActionExecutionStatus<?> actionExecutionStatus = mock(ActionExecutionStatus.class);
+        Map<String, Object> responseContext = new HashMap<>();
+        Map<String, List<String>> multiAddedFromAction = new HashMap<>();
+        multiAddedFromAction.put("emails", Collections.singletonList("c@wso2.com"));
+        Map<String, List<String>> multiRemovedFromAction = new HashMap<>();
+        multiRemovedFromAction.put("emails", Collections.singletonList("a@wso2.com"));
+
+        responseContext.put("multiValuedClaimsToBeAdded", multiAddedFromAction);
+        responseContext.put("multiValuedClaimsToBeRemoved", multiRemovedFromAction);
+        when(actionExecutionStatus.getResponseContext()).thenReturn(responseContext);
+        scimCommonUtils.when(() -> SCIMCommonUtils.isExecutableUserProfileUpdate(anyMap(), anyMap(), anyMap(), anyMap()))
+                .thenReturn(true);
+        doReturn(actionExecutionStatus).when(executorMock)
+                .executeAndGetStatus(any(User.class), anyMap(), anyMap());
+
+        Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
+        carbonUMField.setAccessible(true);
+        carbonUMField.set(scimUserManager, mockedUserStoreManager);
+
+        try (MockedStatic<FrameworkUtils> fw = mockStatic(FrameworkUtils.class)) {
+            fw.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
+
+            doNothing().when(mockedUserStoreManager).setUserClaimValuesWithID(anyString(), anyMap(), anyMap(),
+                    anyMap(), anyMap(), isNull());
+
+            Method m = SCIMUserManager.class.getDeclaredMethod(
+                    "updateUserClaims", User.class, Map.class, Map.class, Map.class
+            );
+            m.setAccessible(true);
+            m.invoke(scimUserManager, user, oldClaims, newClaims, multiValuedClaims);
+
+            verify(mockedUserStoreManager, times(1)).setUserClaimValuesWithID(
+                    eq("foo"),
+                    anyMap(),
+                    argThat(map -> map.containsKey("emails") && map.get("emails").contains("c@wso2.com")),
+                    argThat(map -> map.containsKey("emails") && map.get("emails").contains("a@wso2.com")),
+                    anyMap(),
+                    isNull());
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -2620,7 +2620,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
+        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);
@@ -2668,7 +2668,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
+        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);
@@ -2724,7 +2724,7 @@ public class SCIMUserManagerTest {
         PreUpdateProfileActionExecutor executorMock = mock(PreUpdateProfileActionExecutor.class);
         preUpdateField.set(scimUserManager, executorMock);
 
-        when(executorMock.execute(any(User.class), anyMap(), anyMap())).thenReturn(null);
+        doNothing().when(executorMock).execute(any(User.class), anyMap(), anyMap());
 
         Field carbonUMField = SCIMUserManager.class.getDeclaredField("carbonUM");
         carbonUMField.setAccessible(true);

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/internal/action/PreUpdateProfileActionExecutorTest.java
@@ -164,6 +164,51 @@ public class PreUpdateProfileActionExecutorTest {
     }
 
     @Test
+    public void testExecuteAndGetStatusReturnsNullWhenActionExecutionIsDisabled() throws Exception {
+
+        when(actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)).thenReturn(false);
+
+        User user = getSCIMUser();
+        ActionExecutionStatus<?> status =
+                preUpdateProfileActionExecutor.executeAndGetStatus(user, Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        assertEquals(status, null);
+        verify(actionExecutorService, Mockito.never()).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testExecuteAndGetStatusReturnsSuccessStatusWhenActionSucceeds() throws Exception {
+
+        setOrganizationToIdentityContext();
+        when(actionExecutorService.isExecutionEnabled(ActionType.PRE_UPDATE_PROFILE)).thenReturn(true);
+
+        ActionExecutionStatus<?> successStatus = mock(ActionExecutionStatus.class);
+        when(successStatus.getStatus()).thenReturn(ActionExecutionStatus.Status.SUCCESS);
+        when(actionExecutorService.execute(eq(ActionType.PRE_UPDATE_PROFILE), any(), any())).thenReturn(successStatus);
+
+        LocalClaim newClaim = getMockedLocalClaim(NEW_SINGLEVALUE_CLAIM1);
+        LocalClaim deletingClaim = getMockedLocalClaim(DELETING_SINGLEVALUE_CLAIM4);
+        when(claimMetadataManagementService.getLocalClaim(eq(NEW_SINGLEVALUE_CLAIM1.getClaimURI()), any(String.class)))
+                .thenReturn(Optional.of(newClaim));
+        when(claimMetadataManagementService.getLocalClaim(eq(DELETING_SINGLEVALUE_CLAIM4.getClaimURI()),
+                any(String.class))).thenReturn(Optional.of(deletingClaim));
+
+        User user = getSCIMUser();
+        Map<String, String> claimsToModify = new HashMap<>();
+        claimsToModify.put(NEW_SINGLEVALUE_CLAIM1.getClaimURI(), NEW_SINGLEVALUE_CLAIM1.getInputValueAsString());
+        Map<String, String> claimsToDelete = new HashMap<>();
+        claimsToDelete.put(DELETING_SINGLEVALUE_CLAIM4.getClaimURI(),
+                DELETING_SINGLEVALUE_CLAIM4.getInputValueAsString());
+
+        ActionExecutionStatus<?> status =
+                preUpdateProfileActionExecutor.executeAndGetStatus(user, claimsToModify, claimsToDelete);
+
+        assertNotNull(status);
+        assertEquals(status, successStatus);
+    }
+
+    @Test
     public void testSuccessExecutionForClaimUpdateExecutionAtPutOperation() throws Exception {
 
         setOrganizationToIdentityContext();


### PR DESCRIPTION
This pull request enhances the user claim update process in the SCIM user manager by introducing support for handling additional claim modifications via pre-update profile actions. It refactors the `PreUpdateProfileActionExecutor` to return detailed execution results, updates the claim modification logic to incorporate these results, and adjusts related tests accordingly.

Key changes include:

**User claim update logic improvements:**

* The `updateUserClaims` method in `SCIMUserManager` now uses a new helper method, `populateMultiValuedClaimsToModify`, to handle multi-valued claims, and processes additional claim modifications returned from the pre-update profile action executor. This allows dynamic modification of claims based on action execution results. 
* The new `populateMultiValuedClaimsToModify` method consolidates logic for updating both single and multi-valued claims to be modified.

**Pre-update profile action executor refactor:**

* The `PreUpdateProfileActionExecutor.execute` method now returns an `ActionExecutionStatus<?>` object instead of void, allowing the caller to process results from action execution. The internal `handleActionExecutionStatus` method also returns this status object.

**Related PR**
- https://github.com/wso2/carbon-identity-framework/pull/8124