### PR TITLE
Skip redundant group name update when the group name is unchanged in group PATCH

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -4012,8 +4012,10 @@ public class SCIMUserManager implements UserManager {
                         addedMemberIdsFromUserstore.toArray(new String[0]));
             }
 
-            // Update the group name in UM_HYBRID_GROUP_ROLE table.
-            carbonUM.updateGroupName(currentGroupName, newGroupName);
+            // Update the group name in UM_HYBRID_GROUP_ROLE table only when the group name actually changed.
+            if (!StringUtils.equals(currentGroupName, newGroupName)) {
+                carbonUM.updateGroupName(currentGroupName, newGroupName);
+            }
         } catch (UserStoreException e) {
             if (e instanceof org.wso2.carbon.user.core.UserStoreException && (StringUtils
                     .equals(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -116,6 +116,7 @@ import org.wso2.charon3.core.schema.SCIMResourceSchemaManager;
 import org.wso2.charon3.core.schema.SCIMResourceTypeSchema;
 import org.wso2.charon3.core.utils.ResourceManagerUtil;
 import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
+import org.wso2.charon3.core.utils.codeutils.PatchOperation;
 import org.wso2.charon3.core.utils.codeutils.FilterTreeManager;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
@@ -451,6 +452,70 @@ public class SCIMUserManagerTest {
                 {"123456", null, "userStoreDomain", null},
                 {"567890", "roleName", null, "roleName"}
         };
+    }
+
+    @Test
+    public void testPatchGroupMembershipOnlyDoesNotUpdateGroupName() throws Exception {
+
+        // A membership-only PATCH (no displayName change) must not trigger a redundant group rename.
+        String groupId = "group-id-1";
+        String groupName = "Internal/engineering";
+        String memberName = "Internal/john";
+        String memberId = "member-id-1";
+
+        identityUtil.when(() -> IdentityUtil.extractDomainFromName(anyString())).thenReturn("Internal");
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(mockedUserStoreManager);
+        when(mockedUserStoreManager.getUserIDFromProperties(anyString(), anyString(), anyString()))
+                .thenReturn(memberId);
+
+        Map<String, String> memberObject = new HashMap<>();
+        memberObject.put(SCIMConstants.GroupSchemaConstants.DISPLAY, memberName);
+        memberObject.put(SCIMConstants.GroupSchemaConstants.VALUE, memberId);
+        PatchOperation memberOperation = new PatchOperation();
+        memberOperation.setOperation(SCIMConstants.OperationalConstants.ADD);
+        memberOperation.setAttributeName(SCIMConstants.GroupSchemaConstants.MEMBERS);
+        memberOperation.setValues(memberObject);
+
+        Map<String, List<PatchOperation>> patchOperations = new HashMap<>();
+        patchOperations.put(SCIMConstants.GroupSchemaConstants.MEMBERS,
+                Collections.singletonList(memberOperation));
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
+        scimUserManager.patchGroup(groupId, groupName, patchOperations);
+
+        verify(mockedUserStoreManager).updateUserListOfRoleWithID(eq(groupName), any(), any());
+        verify(mockedUserStoreManager, never()).updateGroupName(any(), any());
+    }
+
+    @Test
+    public void testPatchGroupRenameUpdatesGroupName() throws Exception {
+
+        // A genuine rename PATCH (displayName changes) must still trigger the group rename exactly once.
+        String groupId = "group-id-2";
+        String currentGroupName = "Internal/engineering";
+        String newGroupName = "Internal/platform";
+
+        identityUtil.when(() -> IdentityUtil.extractDomainFromName(anyString())).thenReturn("Internal");
+        scimCommonUtils.when(() -> SCIMCommonUtils.getGroupNameWithDomain(currentGroupName))
+                .thenReturn(currentGroupName);
+        scimCommonUtils.when(() -> SCIMCommonUtils.getGroupNameWithDomain(newGroupName))
+                .thenReturn(newGroupName);
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        PatchOperation displayNameOperation = new PatchOperation();
+        displayNameOperation.setOperation(SCIMConstants.OperationalConstants.REPLACE);
+        displayNameOperation.setAttributeName(SCIMConstants.GroupSchemaConstants.DISPLAY_NAME);
+        displayNameOperation.setValues(newGroupName);
+
+        Map<String, List<PatchOperation>> patchOperations = new HashMap<>();
+        patchOperations.put(SCIMConstants.GroupSchemaConstants.DISPLAY_NAME,
+                Collections.singletonList(displayNameOperation));
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager, mockedClaimManager);
+        scimUserManager.patchGroup(groupId, currentGroupName, patchOperations);
+
+        verify(mockedUserStoreManager, times(1)).updateGroupName(currentGroupName, newGroupName);
     }
 
     @Test(dataProvider = "getGroupException")


### PR DESCRIPTION
## Purpose
A SCIM2 `PATCH /Groups/{id}` membership operation (add/remove members) unconditionally called
`carbonUM.updateGroupName(currentGroupName, newGroupName)` even when the group name was unchanged.
For every membership change this fired a redundant no-op group "rename" against the group's rows
in `UM_HYBRID_GROUP_ROLE`, taking a write lock. Under bulk concurrent assignment to the same group
this serialised in-flight transactions and, at migration scale, escalated to DB lock contention and
a CPU spike.

This guards the call so it runs only when the group name actually changed. Behaviour-preserving for
genuine renames; eliminates the redundant write for membership-only patches.

## Related Issue
- wso2/product-is#28055

## Tests
- Membership-only `PATCH` (add members), group name unchanged: the redundant `updateGroupName` write
  on `UM_HYBRID_GROUP_ROLE` no longer occurs.
- Genuine rename `PATCH` (`displayName` replace): still performs the rename and members remain intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group PATCH handling to avoid redundant group name persistence when only membership is being changed or when the group display name does not actually differ.  
  * Added unit test coverage to verify membership-only PATCH requests do not trigger group rename updates, and rename PATCH requests update the group name exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->