### PR TITLE
Fix ignoring publishing profile update event for deleting user claims

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -5835,8 +5835,10 @@ public class SCIMUserManager implements UserManager {
             }
         }
 
-        if (isExecutableUserProfileUpdate &&
-                containsNonAccountStateOrNonVerificationClaim(claimsAddedOrUpdatedByUser.keySet())) {
+        boolean isNonAccountStateOrNonVerificationClaimChanged =
+                containsNonAccountStateOrNonVerificationClaim(claimsAddedOrUpdatedByUser.keySet()) ||
+                containsNonAccountStateOrNonVerificationClaim(claimsDeleted.keySet());
+        if (isExecutableUserProfileUpdate && isNonAccountStateOrNonVerificationClaimChanged) {
             publishUserProfileUpdateEvent(user, userClaimsToBeAdded, claimsAddedOrUpdatedByUser, claimsDeleted,
                     oldClaimList);
         }
@@ -5976,8 +5978,10 @@ public class SCIMUserManager implements UserManager {
         }
 
         // userClaimsToBeModified already includes the userClaimsToBeAdded as well.
-        if (isExecutableUserProfileUpdate &&
-                containsNonAccountStateOrNonVerificationClaim(userClaimsToBeModifiedIncludingMultiValueClaims.keySet())) {
+        boolean isNonAccountStateOrNonVerificationClaimChanged =
+                containsNonAccountStateOrNonVerificationClaim(userClaimsToBeModifiedIncludingMultiValueClaims.keySet())
+                        || containsNonAccountStateOrNonVerificationClaim(claimsDeleted.keySet());
+        if (isExecutableUserProfileUpdate && isNonAccountStateOrNonVerificationClaimChanged) {
             publishUserProfileUpdateEvent(user, userClaimsToBeAdded, userClaimsToBeModifiedIncludingMultiValueClaims,
                     claimsDeleted, oldClaimList);
         }


### PR DESCRIPTION
## Purpose
- Previously when the user profile updates only with deleting claims(without modifying claims), the profile update event was not fired. 
- So this PR will fix that issue.

## Related issue
- https://github.com/wso2/product-is/issues/28071