### PR TITLE
Return 409 Conflict when concurrent user creation results in duplicate username

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -209,6 +209,8 @@ public class SCIMUserManager implements UserManager {
     private static final String ERROR_CODE_INVALID_USERNAME = "31301";
     private static final String ERROR_CODE_INVALID_CREDENTIAL = "30003";
     private static final String ERROR_CODE_USER_ALREADY_EXISTS = "30004";
+    private static final String ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER = "31309";
+    private static final String ERROR_MSG_USER_ALREADY_EXISTS = "Username: %s already exists in the system.";
     private static final String ERROR_CODE_INVALID_CREDENTIAL_DURING_UPDATE = "36001";
     private static final String ERROR_CODE_PASSWORD_HISTORY_VIOLATION = "22001";
     private static final String ERROR_CODE_PASSWORD_POLICY_VIOLATION = "20035";
@@ -477,21 +479,24 @@ public class SCIMUserManager implements UserManager {
                     handleResourceLimitReached();
                 }
 
-                if (ex instanceof UserStoreClientException &&
-                        ERROR_CODE_USER_ALREADY_EXISTS.equals(((UserStoreClientException) ex).getErrorCode())) {
-                    String duplicateUserErrorMessage = "Username: " + user.getUserName() +
-                            " already exists in the system.";
-
-                    if (log.isDebugEnabled()) {
-                        log.debug(duplicateUserErrorMessage);
-                    }
-
-                    throw new ConflictException(duplicateUserErrorMessage);
-                }
-
                 publishEventOnUserRegistrationFailure(user, ResponseCodeConstants.INVALID_VALUE, ex.getMessage(),
                         claimsInLocalDialect);
                 throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_VALUE);
+            }
+
+            // Handle UserStoreException thrown with a duplicate-user error code from the user store
+            // (e.g. NameAlreadyBoundException from LDAP caught and rethrown with the error code).
+            String errorCode = (e instanceof org.wso2.carbon.user.core.UserStoreException)
+                    ? ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode() : null;
+            if ((e.getMessage() != null && e.getMessage().contains(ERROR_CODE_USER_ALREADY_EXISTS))
+                    || ERROR_CODE_USER_ALREADY_EXISTS.equals(errorCode)
+                    || ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER.equals(errorCode)) {
+                String duplicateUserErrorMessage = String.format(ERROR_MSG_USER_ALREADY_EXISTS,
+                        maskIfRequired(user.getUserName()));
+                if (log.isDebugEnabled()) {
+                    log.debug(duplicateUserErrorMessage);
+                }
+                throw new ConflictException(duplicateUserErrorMessage);
             }
 
             try {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -493,9 +493,7 @@ public class SCIMUserManager implements UserManager {
                     || ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER.equals(errorCode)) {
                 String duplicateUserErrorMessage = String.format(ERROR_MSG_USER_ALREADY_EXISTS,
                         maskIfRequired(user.getUserName()));
-                if (log.isDebugEnabled()) {
-                    log.debug(duplicateUserErrorMessage);
-                }
+                log.debug(duplicateUserErrorMessage);
                 throw new ConflictException(duplicateUserErrorMessage);
             }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -3068,4 +3068,64 @@ public class SCIMUserManagerTest {
                 DUPLICATE_CLAIM_ERROR_MESSAGE, duplicateClaimErrorCode,
                 new PolicyViolationException("testCode", DUPLICATE_CLAIM_ERROR_MESSAGE));
     }
+
+    @DataProvider(name = "duplicateUserUserStoreExceptionDataProvider")
+    public Object[][] duplicateUserUserStoreExceptionDataProvider() {
+
+        // {exceptionMessage, errorCode}
+        // Case 1: UserStoreException with errorCode "30004" (kernel rethrows NameAlreadyBoundException).
+        // Case 2: UserStoreException with errorCode "31309" (JDBC duplicate-key violation).
+        // Case 3: UserStoreException with message containing "30004" but no errorCode set
+        //         (legacy path where only the message carries the code).
+        return new Object[][]{
+                {"30004 - Username already exists in the system.", "30004"},
+                {"31309 - Error occurred while adding the user to the user store.", "31309"},
+                {"30004 - Username already exists in the system.", null}
+        };
+    }
+
+    /**
+     * Verifies that when the underlying user store throws a UserStoreException carrying a duplicate-user
+     * error code (either via getErrorCode() or embedded in the exception message), createUser surfaces it
+     * as a 409 ConflictException rather than a 500 / generic error. This is the regression test for the
+     * race condition where two concurrent SCIM POST /Users requests pass the pre-existing-user check and
+     * both attempt to add the same user.
+     */
+    @Test(dataProvider = "duplicateUserUserStoreExceptionDataProvider",
+            expectedExceptions = ConflictException.class)
+    public void testCreateUser_DuplicateUserUserStoreExceptionReturnsConflict(String exceptionMessage,
+                                                                              String errorCode) throws Exception {
+
+        User user = new User();
+        user.setUserName("DomainName/testUser1");
+
+        when(IdentityUtil.getProperty(SCIMCommonConstants.ENABLE_LOGIN_IDENTIFIERS))
+                .thenReturn("false");
+        when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        // The pre-existing-user check passes (returns false), simulating the race condition where
+        // the duplicate is not detected until the user store layer attempts to persist the user.
+        when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(false);
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString()))
+                .thenReturn(mockedUserStoreManager);
+        when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
+
+        UserStoreException duplicateUserException = (errorCode != null)
+                ? new UserStoreException(exceptionMessage, errorCode)
+                : new UserStoreException(exceptionMessage);
+        when(mockedUserStoreManager.addUserWithID(anyString(), any(), any(), any(), any()))
+                .thenThrow(duplicateUserException);
+
+        IdentityEventService mockService = mock(IdentityEventService.class);
+        scimCommonComponentHolder.when(SCIMCommonComponentHolder::getIdentityEventService).thenReturn(mockService);
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        scimUserManager.createUser(user, null);
+        // The expectedExceptions attribute asserts that ConflictException is thrown.
+    }
 }


### PR DESCRIPTION
### Purpose

- Fixes HTTP 500 errors returned when concurrent SCIM2 user creation requests are made with the same username.

- Three paths are addressed that resulted in 500 error response:

  - Path 1 - Kernel pre-check:

      - `AbstractUserStoreManager` pre-check [1] throws `UserStoreException` with message `30004 - UserAlreadyExisting:...` but no error code set. Previously this was not caught and resulted in a 500 response.

  - Path 2 - Store-level constraint detection:

      - LDAP/AD throws `NameAlreadyBoundException` (now propagated as `UserStoreException` with error code `30004` via carbon-kernel PR https://github.com/wso2/carbon-kernel/pull/4604), or JDBC throws `UserStoreException` with error code `31309`[2] when a username unique constraint is configured in the database. Both are now caught and returned as `409` Conflict.

  - Path 3 - Workflow : 

     - `AddUserWFRequestHandler.isValidOperation` threw `WorkflowException` even when no workflow was engaged, due to a missing `eventEngaged` guard on the `isExistingUser` call. Fixed by adding the guard (PR https://github.com/wso2-extensions/identity-user-workflow/pull/85).

#### Background : 

- SCIM2 PR [764](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/764)) previously handled the duplicate user case only for LDAP (not AD) by catching `UserStoreClientException`. Kernel PR [4523](https://github.com/wso2/carbon-kernel/pull/4523) introduced `UserStoreClientException` for duplicate detection, but there could be any customizations that havent explicitly handled the `UserStoreClientException`.

- The new kernel fix (carbon-kernel PR [#4604](https://github.com/wso2/carbon-kernel/pull/4604) deliberately uses `UserStoreException` (not `UserStoreClientException`) to maintain consistency with the existing `isExistingUser` error format, avoiding any change for customers with their own customizations.

#### Changes introduced with this PR:

  - Updated `SCIMUserManager.createUser` catch block to handle:
    - `UserStoreException` with message containing `30004` (Path 1 — pre-check)
    - `UserStoreException` with error code `30004` (Path 2 — LDAP/AD store-level, carbon-kernel PR [#3204](https://github.com/wso2-support/carbon-kernel/pull/3204))
    - `UserStoreException` with error code `31309` (Path 2 — JDBC unique constraint where configured)

### Related Issue 
- https://github.com/wso2/product-is/issues/26148

### Related PRs : 
- https://github.com/wso2/carbon-kernel/pull/4604
- https://github.com/wso2-extensions/identity-user-workflow/pull/85

[1] https://github.com/wso2/carbon-kernel/blob/53f4838ce4b18e94ec61cd790258b2b932300bff/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L5290
[2] https://github.com/wso2/carbon-kernel/blob/53f4838ce4b18e94ec61cd790258b2b932300bff/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java#L1404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-user detection during user creation by recognizing additional duplicate scenarios and returning a consistent **409 Conflict** response.
  * Standardized the conflict message for existing usernames and ensured the username is appropriately masked when included.
* **Tests**
  * Added regression coverage for duplicate-user cases from the underlying user store, including scenarios where the duplicate error code may be missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->