### PR TITLE
Return 403 with scimType when agent creation hits the application limit

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -463,7 +463,7 @@ public class SCIMUserManager implements UserManager {
                 handleResourceLimitReached();
             }
             if (isAgentResourceLimitError(e, user.getUserName())) {
-                handleAgentResourceLimitReached(e);
+                handleAgentResourceLimitReached();
             }
             handleAndThrowClientExceptionForDuplicateClaim(e, errorMessage);
             publishEventOnUserRegistrationFailure(user, e.getErrorCode(), e.getMessage(), claimsInLocalDialect);
@@ -483,7 +483,7 @@ public class SCIMUserManager implements UserManager {
                 }
                 if (ex instanceof UserStoreClientException &&
                         isAgentResourceLimitError((UserStoreClientException) ex, user.getUserName())) {
-                    handleAgentResourceLimitReached((UserStoreClientException) ex);
+                    handleAgentResourceLimitReached();
                 }
 
                 publishEventOnUserRegistrationFailure(user, ResponseCodeConstants.INVALID_VALUE, ex.getMessage(),
@@ -7174,9 +7174,10 @@ public class SCIMUserManager implements UserManager {
                         UserCoreUtil.extractDomainFromName(username));
     }
 
-    private void handleAgentResourceLimitReached(UserStoreClientException e) throws ForbiddenException {
+    private void handleAgentResourceLimitReached() throws ForbiddenException {
 
-        throw new ForbiddenException(e.getMessage(), "applicationLimitReached");
+        throw new ForbiddenException("Maximum number of allowed applications have been reached.",
+                "applicationLimitReached");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -7176,8 +7176,8 @@ public class SCIMUserManager implements UserManager {
 
     private void handleAgentResourceLimitReached() throws ForbiddenException {
 
-        throw new ForbiddenException("Maximum number of allowed applications have been reached.",
-                "applicationLimitReached");
+        throw new ForbiddenException("Agent application creation failed. Maximum number of allowed applications "
+                + "have been reached.", "applicationLimitReached");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -7170,8 +7170,8 @@ public class SCIMUserManager implements UserManager {
     private boolean isAgentResourceLimitError(UserStoreClientException e, String username) {
 
         return SCIMCommonConstants.ERROR_CODE_TIER_RESOURCE_LIMIT_REACHED.equals(e.getErrorCode())
-                && IdentityUtil.getAgentIdentityUserstoreName()
-                        .equalsIgnoreCase(UserCoreUtil.extractDomainFromName(username));
+                && StringUtils.equalsIgnoreCase(IdentityUtil.getAgentIdentityUserstoreName(),
+                        UserCoreUtil.extractDomainFromName(username));
     }
 
     private void handleAgentResourceLimitReached(UserStoreClientException e) throws ForbiddenException {

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManager.java
@@ -462,6 +462,9 @@ public class SCIMUserManager implements UserManager {
             if (isResourceLimitReachedError(e)) {
                 handleResourceLimitReached();
             }
+            if (isAgentResourceLimitError(e, user.getUserName())) {
+                handleAgentResourceLimitReached(e);
+            }
             handleAndThrowClientExceptionForDuplicateClaim(e, errorMessage);
             publishEventOnUserRegistrationFailure(user, e.getErrorCode(), e.getMessage(), claimsInLocalDialect);
             throw new BadRequestException(errorMessage, ResponseCodeConstants.INVALID_VALUE);
@@ -477,6 +480,10 @@ public class SCIMUserManager implements UserManager {
                 }
                 if (ex instanceof UserStoreClientException && isResourceLimitReachedError((UserStoreClientException) ex)) {
                     handleResourceLimitReached();
+                }
+                if (ex instanceof UserStoreClientException &&
+                        isAgentResourceLimitError((UserStoreClientException) ex, user.getUserName())) {
+                    handleAgentResourceLimitReached((UserStoreClientException) ex);
                 }
 
                 publishEventOnUserRegistrationFailure(user, ResponseCodeConstants.INVALID_VALUE, ex.getMessage(),
@@ -7149,6 +7156,27 @@ public class SCIMUserManager implements UserManager {
     private void handleResourceLimitReached() throws ForbiddenException {
 
         throw new ForbiddenException("Maximum number of allowed users have been reached.", "userLimitReached");
+    }
+
+    /**
+     * Check whether the given client exception was caused by a tier resource limit (RLS-10001) while creating an
+     * agent. Agents live in the agent identity userstore, so the check is scoped to that userstore domain to avoid
+     * altering the error responses of regular user creation flows.
+     *
+     * @param e        Client exception thrown by the user core.
+     * @param username Username (with domain) of the user being created.
+     * @return true if this is an agent creation blocked by a resource limit.
+     */
+    private boolean isAgentResourceLimitError(UserStoreClientException e, String username) {
+
+        return SCIMCommonConstants.ERROR_CODE_TIER_RESOURCE_LIMIT_REACHED.equals(e.getErrorCode())
+                && IdentityUtil.getAgentIdentityUserstoreName()
+                        .equalsIgnoreCase(UserCoreUtil.extractDomainFromName(username));
+    }
+
+    private void handleAgentResourceLimitReached(UserStoreClientException e) throws ForbiddenException {
+
+        throw new ForbiddenException(e.getMessage(), "applicationLimitReached");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -174,6 +174,7 @@ public class SCIMCommonConstants {
     public static final String MOBILE_REGEX =
             "^\\s*(?:\\+?(\\d{1,3}))?[-. (]*(\\d{3})?[-. )]*(\\d{3})?[-. ]*(\\d{4,6})(?: *x(\\d+))?\\s*$";
     public static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "ATS-10001";
+    public static final String ERROR_CODE_TIER_RESOURCE_LIMIT_REACHED = "RLS-10001";
     public static final String DEFAULT_REGEX = "[^<>`\"]+";
     public static final String MIN_LENGTH = "minLength";
     public static final String MAX_LENGTH = "maxLength";

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/impl/SCIMUserManagerTest.java
@@ -2950,6 +2950,93 @@ public class SCIMUserManagerTest {
         }
     }
 
+    @DataProvider(name = "agentResourceLimitErrorDataProvider")
+    public Object[][] agentResourceLimitErrorDataProvider() {
+
+        UserStoreClientException resourceLimitException = new UserStoreClientException(
+                "Agent application creation failed: Maximum number of allowed applications have been reached.",
+                SCIMCommonConstants.ERROR_CODE_TIER_RESOURCE_LIMIT_REACHED);
+        return new Object[][]{
+                // Client exception thrown directly.
+                { resourceLimitException },
+                // Client exception wrapped in a UserStoreException, as thrown by the user core.
+                { new org.wso2.carbon.user.core.UserStoreException("Error while persisting the user.",
+                        resourceLimitException) }
+        };
+    }
+
+    @Test(dataProvider = "agentResourceLimitErrorDataProvider")
+    public void testCreateUser_AgentResourceLimitReachedReturnsForbidden(UserStoreException thrownException)
+            throws Exception {
+
+        User user = new User();
+        user.setUserName("AGENT/9a276ed3-4b5a-4a55-89f4-9d09879e5a31");
+
+        when(IdentityUtil.getProperty(SCIMCommonConstants.ENABLE_LOGIN_IDENTIFIERS)).thenReturn("false");
+        when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+        when(IdentityUtil.getAgentIdentityUserstoreName()).thenReturn("AGENT");
+
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(false);
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(mockedUserStoreManager);
+        when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
+        when(mockedUserStoreManager.addUserWithID(anyString(), any(), any(), any(), any()))
+                .thenThrow(thrownException);
+
+        IdentityEventService mockService = mock(IdentityEventService.class);
+        scimCommonComponentHolder.when(SCIMCommonComponentHolder::getIdentityEventService).thenReturn(mockService);
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        try {
+            scimUserManager.createUser(user, null);
+            Assert.fail("Expected ForbiddenException");
+        } catch (ForbiddenException e) {
+            // The agent application limit must surface as a 403 with a machine-readable scimType,
+            // mirroring the userLimitReached handling for regular users.
+            assertEquals(e.getScimType(), "applicationLimitReached");
+        }
+    }
+
+    @Test
+    public void testCreateUser_NonAgentResourceLimitErrorKeepsExistingBehavior() throws Exception {
+
+        User user = new User();
+        user.setUserName("DomainName/testUser1");
+
+        when(IdentityUtil.getProperty(SCIMCommonConstants.ENABLE_LOGIN_IDENTIFIERS)).thenReturn("false");
+        when(IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+        when(IdentityUtil.getAgentIdentityUserstoreName()).thenReturn("AGENT");
+
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getServiceProvider(anyString(), anyString())).thenReturn(null);
+
+        when(mockedUserStoreManager.isExistingUser(anyString())).thenReturn(false);
+        when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(mockedUserStoreManager);
+        when(mockedUserStoreManager.isSCIMEnabled()).thenReturn(true);
+        when(mockedUserStoreManager.addUserWithID(anyString(), any(), any(), any(), any()))
+                .thenThrow(new UserStoreClientException("Resource limit reached.",
+                        SCIMCommonConstants.ERROR_CODE_TIER_RESOURCE_LIMIT_REACHED));
+
+        IdentityEventService mockService = mock(IdentityEventService.class);
+        scimCommonComponentHolder.when(SCIMCommonComponentHolder::getIdentityEventService).thenReturn(mockService);
+
+        SCIMUserManager scimUserManager = new SCIMUserManager(mockedUserStoreManager,
+                mockClaimMetadataManagementService, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        try {
+            scimUserManager.createUser(user, null);
+            Assert.fail("Expected BadRequestException");
+        } catch (BadRequestException e) {
+            // Users outside the agent userstore must keep the existing error response even when the
+            // exception carries the tier resource limit error code.
+            assertEquals(e.getScimType(), ResponseCodeConstants.INVALID_VALUE);
+        }
+    }
+
     @Test(dataProvider = "duplicateClaimErrorDataProvider")
     public void testUpdateUser_DuplicateClaimErrorReturnsExpectedResponse(
             boolean isConflictOnClaimUniquenessViolationEnabled,


### PR DESCRIPTION
### Proposed changes in this pull request

Creating a user-serving agent via `POST /scim2/Agents` auto-creates an OAuth application (handled by `UserApplicationCreationListener` in identity-inbound-auth-oauth). When that application creation fails because the tenant's application limit is reached, the user core throws a `UserStoreClientException` with error code `RLS-10001`. `SCIMUserManager.createUser` currently surfaces that as a generic 400 (`scimType: invalidValue`) where the only signal is the human-readable `detail` text — clients (e.g. the Console) cannot detect the limit condition reliably.

**Change:** when the client exception carries error code `RLS-10001` **and** the user being created belongs to the agent identity userstore, throw a `ForbiddenException` with a fixed detail message and `scimType: applicationLimitReached` instead. This mirrors the existing user-limit handling (`ATS-10001` → 403 `scimType: userLimitReached`). The agent-userstore scoping keeps all regular user creation responses unchanged.

Response before:

```
HTTP 400
{"scimType":"invalidValue","detail":"Error in adding the user: A***... Agent application creation failed: Maximum number of allowed applications have been reached.","status":"400"}
```

Response after:

```
HTTP 403
{"scimType":"applicationLimitReached","detail":"Agent application creation failed. Maximum number of allowed applications have been reached.","status":"403"}
```

Related PR: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3277 (surfaces the client error code from the agent application creation listener; without it the failure is a plain `UserStoreException` and reaches SCIM as a 500).

### When should this PR be merged

After https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3277 — without it this code path is not reached.

### Follow up actions

Console-side handling of the new `scimType`: https://github.com/wso2/identity-apps/pull/10538

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SCIM user creation when tier resource limits are reached for agent application users.
  * Returns a clear forbidden response with an `applicationLimitReached` indication for agent-scoped limit errors.
  * Keeps existing behavior for non-agent user limit errors.
* **New Features**
  * Added the `RLS-10001` tier resource-limit reached error code constant for consistent detection.
* **Tests**
  * Added coverage for both direct and wrapped tier resource-limit failure scenarios during user creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Behavioral changes (explicit)

This PR changes the API response of `POST /scim2/Agents` **only** when the creation fails with a `UserStoreClientException` carrying error code `RLS-10001` (resource limit reached) **and** the user being created belongs to the agent identity userstore:

| | Before (with the oauth PR) | After |
|---|---|---|
| HTTP status | `400` | `403` |
| `scimType` | `invalidValue` | `applicationLimitReached` |
| `detail` | `Error in adding the user: A***... Agent application creation failed: Maximum number of allowed applications have been reached.` | `Agent application creation failed. Maximum number of allowed applications have been reached.` |

No behavioral change for:

- Regular (non-agent) user creation — the check is scoped to the agent userstore domain, so the existing `ATS-10001` → `userLimitReached` handling and all other error paths are untouched.
- Any other agent creation failure (validation errors, conflicts, server errors).

Verified end-to-end on a local Asgardeo setup with the tier controller enforcing an application quota: at the limit the endpoint returns the 403 above; with a free slot agent creation returns 201; rollback of the agent user on failure is unchanged.





