### PR TITLE
Reject non-existing and future dates for the Date of Birth claim

### DIFF
--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListener.java
@@ -51,6 +51,8 @@ import org.wso2.charon3.core.schema.SCIMConstants;
 import org.wso2.charon3.core.utils.AttributeUtil;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
@@ -77,6 +79,8 @@ import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.NO
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MAX_LENGTH;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.MIN_LENGTH;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.REQUIRED;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.DOB_FUTURE_DATE_VALIDATION_ERROR;
+import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_INVALID_DATE_OF_BIRTH;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_LENGTH_VIOLATION;
 import static org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants.ErrorMessages.ERROR_CODE_REGEX_VIOLATION;
 
@@ -225,6 +229,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
             case DATE_OF_BIRTH_LOCAL_CLAIM:
                 validateClaimValueForRegex(claimURI, claimValue, tenantDomain, DATE_OF_BIRTH_REGEX,
                         DOB_REG_EX_VALIDATION_DEFAULT_ERROR, userStoreDomain);
+                validateDateOfBirthValue(claimValue);
                 break;
             case MOBILE_LOCAL_CLAIM:
                 validateClaimValueForRegex(claimURI, claimValue, tenantDomain, MOBILE_REGEX,
@@ -288,6 +293,32 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                     throw new UserStoreClientException(regexError, ERROR_CODE_REGEX_VIOLATION.getCode());
                 }
             }
+        }
+    }
+
+    /**
+     * Validate the date of birth claim value semantically. The value should be an existing
+     * calendar date and should not be a future date.
+     *
+     * @param claimValue Date of birth claim value in YYYY-MM-DD format.
+     * @throws UserStoreClientException When the value is not an existing date or is a future date.
+     */
+    private void validateDateOfBirthValue(String claimValue) throws UserStoreClientException {
+
+        if (StringUtils.isBlank(claimValue)) {
+            return;
+        }
+        LocalDate dateOfBirth;
+        try {
+            dateOfBirth = LocalDate.parse(claimValue);
+        } catch (DateTimeParseException e) {
+            // Value matches the YYYY-MM-DD pattern but is not an existing calendar date. Ex: 2025-02-30.
+            throw new UserStoreClientException(DOB_REG_EX_VALIDATION_DEFAULT_ERROR,
+                    ERROR_CODE_INVALID_DATE_OF_BIRTH.getCode());
+        }
+        if (dateOfBirth.isAfter(LocalDate.now())) {
+            throw new UserStoreClientException(DOB_FUTURE_DATE_VALIDATION_ERROR,
+                    ERROR_CODE_INVALID_DATE_OF_BIRTH.getCode());
         }
     }
 
@@ -564,6 +595,7 @@ public class SCIMUserOperationListener extends AbstractIdentityUserOperationEven
                 case DATE_OF_BIRTH_LOCAL_CLAIM:
                     validateClaimValueForRegex(DATE_OF_BIRTH_LOCAL_CLAIM, claims.get(DATE_OF_BIRTH_LOCAL_CLAIM),
                             tenantDomain, DATE_OF_BIRTH_REGEX, DOB_REG_EX_VALIDATION_DEFAULT_ERROR, userStoreDomain);
+                    validateDateOfBirthValue(claims.get(DATE_OF_BIRTH_LOCAL_CLAIM));
                     break;
                 case MOBILE_LOCAL_CLAIM:
                     validateClaimValueForRegex(MOBILE_LOCAL_CLAIM, claims.get(MOBILE_LOCAL_CLAIM), tenantDomain,

--- a/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/main/java/org/wso2/carbon/identity/scim2/common/utils/SCIMCommonConstants.java
@@ -165,6 +165,7 @@ public class SCIMCommonConstants {
     public static final String PROP_DISPLAYNAME = "DisplayName";
     public static final String DOB_REG_EX_VALIDATION_DEFAULT_ERROR =
             "Date of Birth is not in the correct format of YYYY-MM-DD";
+    public static final String DOB_FUTURE_DATE_VALIDATION_ERROR = "Date of Birth cannot be a future date";
     public static final String MOBILE_REGEX_VALIDATION_DEFAULT_ERROR =
             "Mobile number is not in the correct format. Valid format is [+][country code][area code][local phone number]";
     public static final String COMMON_REGEX_VALIDATION_ERROR = "%s is not in the correct format.";
@@ -238,7 +239,9 @@ public class SCIMCommonConstants {
         ERROR_CODE_REGEX_VIOLATION("SUO-10001", "Regex validation error",
                 "%s attribute value doesn't match with %s regex pattern"),
         ERROR_CODE_LENGTH_VIOLATION("SUO-10002", "Length validation error",
-                "%s attribute should be between %s and %s characters");
+                "%s attribute should be between %s and %s characters"),
+        ERROR_CODE_INVALID_DATE_OF_BIRTH("SUO-10003", "Date of Birth validation error",
+                "Date of Birth attribute value is invalid");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 import org.wso2.carbon.identity.scim2.common.internal.component.SCIMCommonComponentHolder;
+import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonConstants;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.carbon.user.api.Permission;
 import org.wso2.carbon.user.api.RealmConfiguration;
@@ -578,6 +579,51 @@ public class SCIMUserOperationListenerTest {
                 method.invoke(scimUserOperationListener, claimURI, claimValue, tenantDomain, defaultRegex,
                         defaultRegexValidationError, userStoreDomain);
             }
+        }
+    }
+
+    @DataProvider(name = "validateDateOfBirthValueData")
+    public Object[][] validateDateOfBirthValueData() {
+
+        return new Object[][]{
+                // Valid past date.
+                {"1990-05-10", null},
+                // Blank values are skipped.
+                {"", null},
+                {null, null},
+                // Today is not a future date.
+                {java.time.LocalDate.now().toString(), null},
+                // Valid leap day.
+                {"2024-02-29", null},
+                // Future date.
+                {java.time.LocalDate.now().plusDays(1).toString(),
+                        SCIMCommonConstants.DOB_FUTURE_DATE_VALIDATION_ERROR},
+                {java.time.LocalDate.now().plusYears(2).toString(),
+                        SCIMCommonConstants.DOB_FUTURE_DATE_VALIDATION_ERROR},
+                // Non existing calendar dates.
+                {"2025-02-30", SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR},
+                {"2023-02-29", SCIMCommonConstants.DOB_REG_EX_VALIDATION_DEFAULT_ERROR}
+        };
+    }
+
+    @Test(dataProvider = "validateDateOfBirthValueData")
+    public void testValidateDateOfBirthValue(String claimValue, String expectedError) throws Exception {
+
+        java.lang.reflect.Method method = SCIMUserOperationListener.class.getDeclaredMethod(
+                "validateDateOfBirthValue", String.class);
+        method.setAccessible(true);
+
+        if (expectedError != null) {
+            try {
+                method.invoke(scimUserOperationListener, claimValue);
+                org.testng.Assert.fail("Expected UserStoreClientException to be thrown");
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                assertTrue(cause instanceof org.wso2.carbon.user.core.UserStoreClientException);
+                assertEquals(cause.getMessage(), expectedError);
+            }
+        } else {
+            method.invoke(scimUserOperationListener, claimValue);
         }
     }
 

--- a/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
+++ b/components/org.wso2.carbon.identity.scim2.common/src/test/java/org/wso2/carbon/identity/scim2/common/listener/SCIMUserOperationListenerTest.java
@@ -595,9 +595,10 @@ public class SCIMUserOperationListenerTest {
                 {java.time.LocalDate.now().toString(), null},
                 // Valid leap day.
                 {"2024-02-29", null},
-                // Future date.
-                {java.time.LocalDate.now().plusDays(1).toString(),
-                        SCIMCommonConstants.DOB_FUTURE_DATE_VALIDATION_ERROR},
+                // Future date. A fixed far-future date is used instead of LocalDate.now().plusDays(1) so the
+                // fixture cannot flip to "today" if a midnight boundary is crossed between data provider
+                // evaluation and test execution.
+                {"9999-12-31", SCIMCommonConstants.DOB_FUTURE_DATE_VALIDATION_ERROR},
                 {java.time.LocalDate.now().plusYears(2).toString(),
                         SCIMCommonConstants.DOB_FUTURE_DATE_VALIDATION_ERROR},
                 // Non existing calendar dates.


### PR DESCRIPTION
## Purpose

The Date of Birth (`http://wso2.org/claims/dob`) claim is only validated against a format regex (`^\d{4}-\d{2}-\d{2}$`). A future date such as `2027-04-20` matches the pattern and is accepted, on both the create path (self-registration, SCIM2 `POST /Users`) and the update path (SCIM2 `PATCH /Me`, admin console). This lets invalid DOB values be persisted server-side.

This PR adds semantic validation for the Date of Birth claim so that:
1. Values matching the format but not representing a real calendar date (for example `2025-02-30`) are rejected.
2. Future dates are rejected.

Because the check is added inside `SCIMUserOperationListener`, which fires on both add and update operations, it applies uniformly to self-registration, SCIM create, SCIM update, and admin-driven user operations.

## Changes

1. `SCIMUserOperationListener`
   - New `validateDateOfBirthValue(String claimValue)` method: skips blank values, parses with `LocalDate.parse` (a `DateTimeParseException` means the format matched but the date does not exist), and rejects dates after `LocalDate.now()`.
   - Called from both DOB branches of `validateClaimValue` (the single-claim and claim-map overloads), immediately after the existing regex check. It stays within the existing `isRegexValidationForUserClaimEnabled()` gate.

2. `SCIMCommonConstants`
   - Added the error message constant `DOB_FUTURE_DATE_VALIDATION_ERROR`.
   - Added the error code `ERROR_CODE_INVALID_DATE_OF_BIRTH` (`SUO-10003`), following the existing `SUO-1000x` series.

## Testing

- Added a data-driven unit test `testValidateDateOfBirthValue` in `SCIMUserOperationListenerTest` covering: past date, today, empty, null, and valid leap day (all pass); tomorrow, a future year, and impossible dates `2025-02-30` / `2023-02-29` (all rejected with the expected message). Future-date cases are computed relative to the current date so the test does not go stale.
- Full module test suite passes: 603 tests, 0 failures (JDK 21).

## Related PRs

- Frontend (self-registration page, dynamic registration flow date field, Console user forms): wso2/identity-apps#10558
- Dynamic-flow server-side rule authoring (the client can't show an inline error without this): wso2/carbon-identity-framework#8212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date-of-birth validation to check for real, valid calendar dates rather than relying on format matching.
  * Added explicit rejection of future date-of-birth values with a clearer validation message.
  * Ensured the same date-of-birth validation behavior applies to both single and bulk updates.
* **Tests**
  * Added TestNG coverage for past/today/leap dates, blank/null inputs, invalid/nonexistent dates, and future dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
